### PR TITLE
Allow to use embedded rocskdb (locked to 4.11.2).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,13 +14,12 @@ test.log
 .tmp
 .generated
 vendor/
-rocksdb/
+librocksdb*
 
 # Executables produced by Cherami repo
-cmd/standalone/standalone
-cmd/replicator/replicator
-cmd/tools/admin/cherami-admin
-cmd/tools/cli/cherami-cli
-cmd/tools/replicator/cherami-replicator-tool
-cmd/tools/store/cherami-store-tool
-cmd/tools/cassandra/cherami-cassandra-tool
+cherami-admin
+cherami-cassandra-tool
+cherami-cli
+cherami-replicator-tool
+cherami-server
+cherami-replicator-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,17 @@ addons:
 before_install:
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update -qq
-  - sudo apt-get install g++-4.8 libsnappy-dev zlib1g-dev libbz2-dev -qq
-  - export CXX="g++-4.8" CC="gcc-4.8"
+  - sudo apt-get remove gcc g++ libc6-dev -y
+  - sudo apt-get install gcc-4.9 g++-4.9 libsnappy-dev zlib1g-dev libbz2-dev -qq
+  - wget http://launchpadlibrarian.net/198723917/libc6_2.19-0ubuntu6.6_amd64.deb
+  - wget http://launchpadlibrarian.net/198723918/libc6-dev_2.19-0ubuntu6.6_amd64.deb
+  - wget http://launchpadlibrarian.net/198723921/libc-dev-bin_2.19-0ubuntu6.6_amd64.deb
+  - wget http://launchpadlibrarian.net/296841256/linux-libc-dev_3.13.0-106.153_amd64.deb
+  - sudo dpkg -i libc6_2.19-0ubuntu6.6_amd64.deb libc6-dev_2.19-0ubuntu6.6_amd64.deb libc-dev-bin_2.19-0ubuntu6.6_amd64.deb linux-libc-dev_3.13.0-106.153_amd64.deb
+  - export CXX="g++-4.9" CC="gcc-4.9"
   - wget https://launchpad.net/ubuntu/+archive/primary/+files/libgflags2_2.0-1.1ubuntu1_amd64.deb
-  - sudo dpkg -i libgflags2_2.0-1.1ubuntu1_amd64.deb
   - wget https://launchpad.net/ubuntu/+archive/primary/+files/libgflags-dev_2.0-1.1ubuntu1_amd64.deb
-  - sudo dpkg -i libgflags-dev_2.0-1.1ubuntu1_amd64.deb
+  - sudo dpkg -i libgflags-dev_2.0-1.1ubuntu1_amd64.deb libgflags2_2.0-1.1ubuntu1_amd64.deb
 
 install:
   - go get -u github.com/Masterminds/glide
@@ -24,10 +29,12 @@ install:
   - go get golang.org/x/tools/cmd/cover
   - pip install --user ccm
   - pip install --user cqlsh==5.0.3
-  - ./scripts/travis/get-rocksdb.sh
   - ccm create test -v 2.2.8 -n 1 -s
   - sudo ln -sf /home/travis/.local/bin/cqlsh /usr/local/bin/cqlsh
-  - make bins
+  - travis_wait 20 ./scripts/travis/get-rocksdb.sh
+  - export CGO_CFLAGS="$CGO_FLAGS -I`pwd`/vendor/github.com/cockroachdb/c-rocksdb/internal/include"
+  - export CGO_LDFLAGS="$CGO_LDFLAGS -L`pwd`/vendor/github.com/cockroachdb/c-rocksdb/internal -lrocksdb"
+  - export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:`pwd`"
 
 script:
- - make cover_ci
+  - EMBEDROCKSDB=0 make cover_ci

--- a/Makefile
+++ b/Makefile
@@ -8,18 +8,21 @@ NOVENDOR = $(shell GO15VENDOREXPERIMENT=1 glide novendor)
 TEST_ARG ?= -race -v -timeout 5m
 TEST_NO_RACE_ARG ?= -timeout 5m
 BUILD := ./build
+PWD = $(shell pwd)
 
 export PATH := $(GOPATH)/bin:$(PATH)
-
-export CGO_CFLAGS=$(env CGO_FLAGS) -I$(CURDIR)/rocksdb/include
-export CGO_LDFLAGS=$(env CGO_LDFLAGS) -L$(CURDIR)/rocksdb/lib -lrocksdb
 
 export CHERAMI_STORE=$(shell dirname `mktemp -u store.test.XXX`)/cherami_store
 export CHERAMI_CONFIG_DIR=$(CURDIR)/config
 
-ifeq ($(shell uname -s),Linux)
-        export CGO_LDFLAGS=$(env CGO_LDFLAGS) -L$(CURDIR)/rocksdb/lib -lrocksdb -lsnappy -lgflags -lbz2 -lstdc++
-        export LD_LIBRARY_PATH=$(CURDIR)/rocksdb/lib:$(env LD_LIBRARY_PATH)
+# Determine whether to use embedded rocksdb. This is recommended
+# for building the executable for deployment because the binary
+# will link statically with rocksdb. Testing with embedded
+# rocksdb will be slow to build. If EMBEDROCKSDB=0, user need to
+# supply proper CGO_CFLAGS, CGO_LDFLAGS, LD_LIBRARY_PATH value
+# in environment variable.
+ifneq ($(EMBEDROCKSDB), 0)
+	EMBED = -tags=embed
 endif
 
 # Automatically gather all srcs
@@ -33,21 +36,13 @@ TEST_DIRS := $(sort $(dir $(filter %_test.go,$(ALL_SRC))))
 
 test: bins
 	@for dir in $(TEST_DIRS); do \
-		go test "$$dir" $(TEST_NO_RACE_ARG) $(shell glide nv); \
+		go test $(EMBED) "$$dir" $(TEST_NO_RACE_ARG) $(shell glide nv); \
 	done;
 
-test-race:
+test-race: $(ALL_SRC)
 	@for dir in $(TEST_DIRS); do \
-		go test "$$dir" $(TEST_ARG) | tee -a "$$dir"_test.log; \
+		go test $(EMBED) "$$dir" $(TEST_ARG) | tee -a "$$dir"_test.log; \
 	done;	       
-
-checkrocksdb:
-	@if [ ! -d $(CURDIR)/rocksdb ]; then \
-		echo "please install rocksdb and copy the static libraries and include files within $(CURDIR)/rocksdb directory" >&2; \
-		echo "one can follow instructions here to build rocksdb: https://github.com/facebook/rocksdb/blob/master/INSTALL.md" >&2; \
-		echo "once the repo is cloned and libraries are built, please copy the liborcksdb* to $(CURDIR)/rocksdb/lib and rocksdb/include to $(CURDIR)/rocksdb/include" >&2; \
-		exit 1; \
-	fi
 
 checkcassandra:
 	@if ! which cqlsh | grep -q /; then \
@@ -55,22 +50,37 @@ checkcassandra:
 		exit 1; \
 	fi
 
-server_dep:
+vendor/glide.updated: glide.lock glide.yaml
 	glide install
+	touch vendor/glide.updated
 
-bins: server_dep checkrocksdb checkcassandra
-	go build -i -o cmd/standalone/standalone cmd/standalone/main.go
-	go build -i -o cmd/replicator/replicator cmd/replicator/main.go
-	go build -i -o cmd/tools/cli/cherami-cli cmd/tools/cli/main.go
-	go build -i -o cmd/tools/admin/cherami-admin cmd/tools/admin/main.go
-	go build -i -o cmd/tools/replicator/cherami-replicator-tool cmd/tools/replicator/main.go
-	go build -i -o cmd/tools/cassandra/cherami-cassandra-tool cmd/tools/cassandra/main.go
+DEPS = vendor/glide.updated $(ALL_SRC)
 
-cover_profile: clean bins
+cherami-server: $(DEPS)
+	go build -i $(EMBED) -o cherami-server cmd/standalone/main.go
+
+cherami-replicator-server: $(DEPS)
+	go build -i $(EMBED) -o cherami-replicator-server cmd/replicator/main.go
+
+cherami-cli: $(DEPS)
+	go build -i -o cherami-cli cmd/tools/cli/main.go
+
+cherami-admin: $(DEPS)
+	go build -i -o cherami-admin cmd/tools/admin/main.go
+
+cherami-replicator-tool: $(DEPS)
+	go build -i -o cherami-replicator-tool cmd/tools/replicator/main.go
+
+cherami-cassandra-tool: $(DEPS)
+	go build -i -o cherami-cassandra-tool cmd/tools/cassandra/main.go
+
+bins: cherami-server cherami-replicator-server cherami-cli cherami-admin cherami-replicator-tool cherami-cassandra-tool
+
+cover_profile: bins
 	@echo Testing packages:
 	@for dir in $(TEST_DIRS); do \
 		mkdir -p $(BUILD)/"$$dir"; \
-		go test "$$dir" $(TEST_ARG) -coverprofile=$(BUILD)/"$$dir"/coverage.out || exit 1; \
+		go test $(EMBED) "$$dir" $(TEST_ARG) -coverprofile=$(BUILD)/"$$dir"/coverage.out || exit 1; \
 	done
 
 cover: cover_profile
@@ -84,9 +94,5 @@ cover_ci: cover_profile
 	done
 
 clean:
-	rm -f cmd/standalone/standalone
-	rm -f cmd/replicator/replicator
-	rm -f cmd/tools/cli/cherami-cli
-	rm -f cmd/tools/admin/cherami-admin
-	rm -f cmd/tools/replicator/cherami-replicator-tool
-	rm -f cmd/tools/cassandra/cherami-cassandra-tool
+	rm -f cherami-server cherami-replicator-server cherami-cli cherami-admin cherami-replicator-tool cherami-cassandra-tool
+	rm -Rf vendor/*

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 cherami-server
 ==============
+[Cherami](https://eng.uber.com/cherami) is a distributed, scalable, durable, and highly available message queue system we developed at Uber Engineering to transport asynchronous tasks. 
 
-Cherami is a distributed, scalable, durable, and highly available message queue system we developed at Uber Engineering to transport asynchronous tasks. 
-
-cherami-server is the actual implementation of the cherami architecture.
+This repo contains the source code of Cherami server, cross-zone replicator server, and several tools.
 
 Getting started
 ---------------
@@ -11,48 +10,44 @@ Getting started
 To get cherami-server:
 
 ```
-git clone git@github.com:uber/cherami-server.git
+git clone git@github.com:uber/cherami-server.git $GOPATH/src/github.com/uber/cherami-server
 ```
 
-Developing
-----------
+Build
+-----
+We use [`glide`](https://glide.sh) to manage Go dependencies. Additionally, we need a Cassandra running locally in order to run the integration tests. Please make sure `glide` and `cqlsh` are in your PATH, and `cqlsh` can connect to the local Cassandra server.
 
-The cherami-server repository holds the implementation of cherami architecture. Before getting started, cherami-server has a bunch of dependencies as follows:
-
-* Make certain that `thrift` (OSX: `brew install thrift`) and `glide` are
-in your path (above).
-* `thrift-gen` is needed to autogenerate thrift APIs (`go get github.com/uber/tchannel-go/thrift/thrift-gen`)
-* `cassandra` which is our metadata store is required to be up and running
-* `rocksdb` is our data store and needs to be installed with the libraries being placed along with the cherami code in a folder called `rocksdb`:
-	* In OSX, we need rocksdb3.13 (which can be installed using brew)
-	* In Linux, download https://github.com/facebook/rocksdb and compile to get all the rocksdb libraries manually.
-
-After installing all the requisite dependencies, one can do the following to start cherami:
-
-* Setup the cherami keyspace for metadata (cassandra):
-```
-./scripts/cherami-setup-schema
-```
-
-* Build the cherami `standalone` and other binaries:
+* Build the `cherami-server` and other binaries:
 ```
 make bins
 ```
 
-Once built, the service can be started as follows:
+Run Cherami locally
+-------------------
+
+* Setup the cherami keyspace for metadata:
 ```
-CHERAMI_ENVIRONMENT=laptop CHERAMI_CONFIG_DIR=`pwd`/config CHERAMI_STORE=/tmp/store ./cmd/standalone/standalone start all
+./scripts/cherami-setup-schema
 ```
 
-One can use the CLI to verify if cherami is running properly:
+* The service can be started as follows:
 ```
-./cmd/tools/cli/cherami-cli --hostport=<localIP>:4922 create destination /test/cherami
+CHERAMI_ENVIRONMENT=laptop CHERAMI_CONFIG_DIR=`pwd`/config CHERAMI_STORE=/tmp/store ./cherami-server start all
 ```
+
+One can use the CLI to verify if Cherami is running properly:
+```
+./cherami-cli --hostport=<localIP>:4922 create destination /test/cherami
+```
+
+Deploy Cherami as a cluster
+---------------------------
+Documentation coming soon....
 
 Contributing
 ------------
 
-We'd love your help in making Cherami great. If you find a bug or need a new feature, Open an issue and we will respond as fast as we can. If you want to implement new feature(s) and/or fix bug(s) yourself, open a pull request with the appropriate unit tests and we will merge it after review.
+We'd love your help in making Cherami great. If you find a bug or need a new feature, open an issue and we will respond as fast as we can. If you want to implement new feature(s) and/or fix bug(s) yourself, open a pull request with the appropriate unit tests and we will merge it after review.
 
 **Note:** All contributors also need to fill out the [Uber Contributor License Agreement](http://t.uber.com/cla) before we can merge in any of your changes.
 
@@ -60,7 +55,7 @@ Documentation
 --------------
 
 Interested in learning more about Cherami? Read the blog post:
-[eng.uber.com.cherami](https://eng.uber.com/cherami/)
+[eng.uber.com/cherami](https://eng.uber.com/cherami/)
 
 License
 -------

--- a/glide.lock
+++ b/glide.lock
@@ -42,7 +42,7 @@ imports:
   subpackages:
   - statsd
 - name: github.com/cockroachdb/c-jemalloc
-  version: 42e6a32cd7a4dff9c70d80323681d46d046181ef
+  version: d726b40f0bc9c90ced1e00c044cf172ae094c083
 - name: github.com/cockroachdb/c-lz4
   version: 834d3303c9e84b1045bc57c3eb3723ee8cb4d33b
 - name: github.com/cockroachdb/c-rocksdb
@@ -98,7 +98,7 @@ imports:
   - require
   - suite
 - name: github.com/tecbot/gorocksdb
-  version: 762103f8ef378b89332183a9ca2fe9cebc8d88db
+  version: f2a0b10f7228cff360e2d9efa081a15a8cbd68b7
 - name: github.com/uber-common/bark
   version: 8841a0f8e7ca869284ccb29c08a14cf3f4310f46
 - name: github.com/uber-go/atomic

--- a/scripts/travis/get-rocksdb.sh
+++ b/scripts/travis/get-rocksdb.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
-sudo mkdir -p rocksdb/lib
-sudo mkdir -p rocksdb/include
-git clone https://github.com/facebook/rocksdb.git /tmp/rocksdb
-pushd /tmp/rocksdb
-git checkout -b tmp b78c8e07de599f8152edf4a30b994aaa217c870b
+# retrieve rocksdb via github.com/cockroachdb/c-rocksdb
+make vendor/glide.updated
+DIR=vendor/github.com/cockroachdb/c-rocksdb/internal
+
+pushd $DIR
 make shared_lib
 popd
-sudo cp --preserve=links /tmp/rocksdb/librocksdb.* rocksdb/lib/
-sudo cp -r /tmp/rocksdb/include/rocksdb/ rocksdb/include/ 
+
+if [ -f $DIR/librocksdb.4.11.2.dylib ]; then
+	ln -sf $DIR/librocksdb.4.11.2.dylib librocksdb.4.11.dylib 
+fi
+
+if [ -f $DIR/librocksdb.so.4.11.2 ]; then
+	ln -sf $DIR/librocksdb.so.4.11.2 librocksdb.so.4.11
+fi


### PR DESCRIPTION
Our dependencies already have rocksdb source (from github.com/cockroachdb/c-rocksdb). This commit defaults to build rocksdb from this source, and statically link to the binary. User does not need to worry about rocksdb dependency. Downside is that build time is significantly longer because cgo does not appear to parallelize compilation when possible.

User can also set environment variable "EMBEDROCKSDB=0" to disable embedding. When desired to do so, user need to supply proper include and lib directory in CGO_CFLAGS and CGO_LDFLAGS. For testing, shared rocksdb is used, because otherwise, each test involving gorocksdb will make Go recompile rocksdb, wasting a lot of time.

Changed get-rocksdb.sh to use locally vendored rocksdb from github.com/cockroachdb/c-rocksdb.