### PR TITLE
Fix storehost shutdown

### DIFF
--- a/services/storehost/replicationJobRunner.go
+++ b/services/storehost/replicationJobRunner.go
@@ -29,10 +29,10 @@ import (
 
 	"github.com/uber-common/bark"
 
+	"github.com/uber/cherami-server/common"
 	"github.com/uber/cherami-thrift/.generated/go/metadata"
 	"github.com/uber/cherami-thrift/.generated/go/shared"
 	"github.com/uber/cherami-thrift/.generated/go/store"
-	"github.com/uber/cherami-server/common"
 )
 
 type (
@@ -53,8 +53,7 @@ type (
 		mClient metadata.TChanMetadataService
 		logger  bark.Logger
 
-		closeChannel    chan struct{}
-		rpmBootstrapped chan struct{}
+		closeChannel chan struct{}
 
 		ticker  *time.Ticker
 		running int64
@@ -104,7 +103,6 @@ func (runner *replicationJobRunner) Start() {
 
 func (runner *replicationJobRunner) Stop() {
 	close(runner.closeChannel)
-	close(runner.rpmBootstrapped)
 
 	runner.logger.Info("ReplicationJobRunner: stopped")
 }


### PR DESCRIPTION
Looks like we are closing a nil channel here, which
will cause panics. This patch simply removes the unnecessary close, since it is now within RPM.