### PR TITLE
Dockerfile for standalone cherami-server

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,0 +1,35 @@
+# Copyright (c) 2016 Uber Technologies, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+FROM golang:1.7.4
+
+# get and compile cherami-server
+ENV CHERAMI_HOME $GOPATH/src/github.com/uber/cherami-server
+
+RUN go get -u github.com/Masterminds/glide
+RUN git clone --depth=50 https://github.com/uber/cherami-server.git $CHERAMI_HOME
+RUN cd $CHERAMI_HOME; make bins
+
+EXPOSE 4922 4253 4240 4254 5425 6280 6189 6190 6191 6310
+
+WORKDIR $CHERAMI_HOME
+
+# Remember to mount host directories (config and data), and have CHERAMI_CONFIG_DIR properly point to config.
+CMD ["./cherami-server", "start", "all"]

--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -1,0 +1,63 @@
+# Copyright (c) 2016 Uber Technologies, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+FROM cassandra:3.9
+
+# get golang 1.7.4 (https://github.com/docker-library/golang/blob/18ee81a2ec649dd7b3d5126b24eef86bc9c86d80/1.7/Dockerfile)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		g++ \
+		gcc \
+		libc6-dev \
+		make \
+		pkg-config \
+		curl \
+		git libsnappy-dev zlib1g-dev libbz2-dev libgflags-dev gettext \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV GOLANG_VERSION 1.7.4
+ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
+ENV GOLANG_DOWNLOAD_SHA256 47fda42e46b4c3ec93fa5d4d4cc6a748aa3f9411a2a2b7e08e3a6d80d753ec8b
+
+RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
+	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
+	&& tar -C /usr/local -xzf golang.tar.gz \
+	&& rm golang.tar.gz
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+
+# get and compile cherami-server
+ENV CHERAMI_HOME $GOPATH/src/github.com/uber/cherami-server
+
+RUN go get -u github.com/Masterminds/glide
+RUN git clone --depth=50 https://github.com/uber/cherami-server.git $CHERAMI_HOME
+RUN cd $CHERAMI_HOME; make bins
+
+VOLUME /var/lib/cherami-store
+EXPOSE 4922 4253 4240 4254 5425 6280 6189 6190 6191 6310
+
+COPY ./start.sh $CHERAMI_HOME/start.sh
+COPY ./docker_template.yaml $CHERAMI_HOME/config/docker_template.yaml
+RUN chmod a+x $CHERAMI_HOME/start.sh
+
+WORKDIR $CHERAMI_HOME
+CMD ./start.sh

--- a/docker/standalone/docker_template.yaml
+++ b/docker/standalone/docker_template.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) 2016 Uber Technologies, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+DefaultServiceConfig:
+  ListenAddress: "${HOST_IP}"
+
+DefaultDestinationConfig:
+  Replicas: 1
+
+MetadataConfig:
+  CassandraHosts: "${HOST_IP}"
+
+StorageConfig:
+  BaseDir: /var/lib/cherami-store
+  HostUUID: "11111111-1111-1111-1111-111111111111"
+
+logging:
+  level: debug
+  stdout: true

--- a/docker/standalone/start.sh
+++ b/docker/standalone/start.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -x
+
+# Copyright (c) 2016 Uber Technologies, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+# start up cassandra
+pushd /
+./docker-entrypoint.sh cassandra
+popd
+sleep 20
+
+export HOST_IP=`hostname --ip-address`
+
+# setup schema
+CQLSH_HOST=$HOST_IP RF=1 ./scripts/cherami-setup-schema
+
+# fix up config
+envsubst < config/docker_template.yaml > config/docker.yaml
+
+export CHERAMI_ENVIRONMENT=docker
+./cherami-server start all


### PR DESCRIPTION
This PR contains files to build and run a docker container to run Cherami in single-server, standalone mode. The container includes Cassandra and all the Cherami binaries. The image is currently public at Docker registry as `thuningxu/cherami-server:latest`.

To start the container with name "cherami":
`$ docker run -d --name cherami thuningxu/cherami-server-standalone:latest`

Please wait about 30 seconds for the Cassandra and Cherami to start up. Then, you can connect to it using the container IP address:

`$ docker exec cherami hostname --ip-address`
`172.17.0.2`

You can use the tools inside the container to interact with Cherami, for example, create a destination:
`$ docker exec cherami ./cherami-cli --env=prod --hostport=172.17.0.2:4922 c d "/test/cherami"`

Create a consumer group:
`$ docker exec cherami ./cherami-cli --env=prod --hostport=172.17.0.2:4922 c c "/test/cherami" "/test/cherami_reader"`

Publish from terminal (need `-it` flag for docker):
`$ docker exec -it cherami ./cherami-cli --env=prod --hostport=172.17.0.2:4922 p "/test/cherami"`

Consume:
`$ docker exec cherami ./cherami-cli --env=prod --hostport=172.17.0.2:4922 r "/test/cherami" "/test/cherami_reader"`