### PR TITLE
Output leak fixes

### DIFF
--- a/services/outputhost/cgcache.go
+++ b/services/outputhost/cgcache.go
@@ -408,7 +408,6 @@ func (cgCache *consumerGroupCache) manageConsumerGroupCache() {
 			}
 			cgCache.extMutex.Unlock()
 		case <-cgCache.closeChannel:
-			cgCache.logger.Info("stopped")
 			// stop the delivery cache as well
 			cgCache.msgDeliveryCache.stop()
 			// wait for the manage routine to go away
@@ -416,6 +415,7 @@ func (cgCache *consumerGroupCache) manageConsumerGroupCache() {
 			// at this point, the cg is completely unloaded, close all message channels
 			// to cleanup
 			cgCache.cleanupChannels()
+			cgCache.logger.Info("cg is stopped and all channels are cleanedup")
 			quit = true
 		}
 	}

--- a/services/outputhost/cgcache.go
+++ b/services/outputhost/cgcache.go
@@ -170,6 +170,15 @@ type (
 		hostMetrics *load.HostMetrics
 		// cgMetrics represents consgroup level load metrics reported to controller
 		cgMetrics *load.CGMetrics
+
+		// unloadInProgress is used to indicate if an unload of this CG is in progress to prevent racing loads from happening
+		unloadInProgress bool
+
+		// connsWG is used to wait for all the connections (including ext) to go away before stopping the manage routine.
+		connsWG sync.WaitGroup
+
+		// manageMsgCacheWG is used to wait for the manage delivery cache routine to go away. This is needed to make sure we cleanup all the buffered channels appropriately.
+		manageMsgCacheWG sync.WaitGroup
 	}
 )
 
@@ -269,28 +278,25 @@ func (cgCache *consumerGroupCache) getConsumerGroupTags() map[string]string {
 }
 
 // loadExtentCache loads the extent cache, if it doesn't already exist for this consumer group
-func (cgCache *consumerGroupCache) loadExtentCache(tClients common.ClientFactory,
-	metaClient metadata.TChanMetadataService, wsConnector common.WSConnector,
-	outputHostUUID string, destUUID string, destType shared.DestinationType,
-	cgUUID string, cge *metadata.ConsumerGroupExtent, startFrom int64) (err error) {
+func (cgCache *consumerGroupCache) loadExtentCache(destType shared.DestinationType, cge *metadata.ConsumerGroupExtent) (err error) {
 	extUUID := cge.GetExtentUUID()
 	extLogger := cgCache.logger.WithField(common.TagExt, extUUID)
 	if extCache, exists := cgCache.extentCache[extUUID]; !exists {
 		extCache = &extentCache{
-			cgUUID:               cgUUID,
+			cgUUID:               cgCache.cachedCGDesc.GetConsumerGroupUUID(),
 			extUUID:              extUUID,
-			destUUID:             destUUID,
+			destUUID:             cgCache.cachedCGDesc.GetDestinationUUID(),
 			destType:             destType,
 			storeUUIDs:           cge.StoreUUIDs,
-			startFrom:            startFrom,
+			startFrom:            cgCache.cachedCGDesc.GetStartFrom(),
 			notifyReplicaCloseCh: make(chan error, 5),
 			closeChannel:         make(chan struct{}),
 			waitConsumedCh:       make(chan bool, 1),
 			msgsCh:               cgCache.msgsCh,
 			connectionsClosedCh:  cgCache.notifyReplicaCloseCh,
-			shutdownWG:           cgCache.shutdownWG,
-			tClients:             tClients,
-			wsConnector:          wsConnector,
+			shutdownWG:           &cgCache.connsWG,
+			tClients:             cgCache.tClients,
+			wsConnector:          cgCache.wsConnector,
 			logger:               extLogger.WithField(common.TagModule, `extCache`),
 			creditNotifyCh:       cgCache.creditNotifyCh,
 			creditRequestCh:      cgCache.creditRequestCh,
@@ -303,14 +309,14 @@ func (cgCache *consumerGroupCache) loadExtentCache(tClients common.ClientFactory
 		cgCache.hostMetrics.Increment(load.HostMetricNumOpenExtents)
 
 		// TODO: create a newAckManagerRequestArgs struct here
-		extCache.ackMgr = newAckManager(cgCache, cgCache.ackIDGen.GetNextAckID(), outputHostUUID, cgUUID, extCache.extUUID, &extCache.connectedStoreUUID, extCache.waitConsumedCh, cge, metaClient, extCache.logger)
+		extCache.ackMgr = newAckManager(cgCache, cgCache.ackIDGen.GetNextAckID(), cgCache.outputHostUUID, cgCache.cachedCGDesc.GetConsumerGroupUUID(), extCache.extUUID, &extCache.connectedStoreUUID, extCache.waitConsumedCh, cge, cgCache.metaClient, extCache.logger)
 		extCache.loadReporter = cgCache.loadReporterFactory.CreateReporter(extentLoadReportingInterval, extCache, extCache.logger)
 
 		// make sure we prevent shutdown from racing
 		extCache.shutdownWG.Add(1)
 
 		// if load fails we will unload it the usual way
-		go extCache.load(outputHostUUID, cgUUID, metaClient, cge)
+		go extCache.load(cgCache.outputHostUUID, cgCache.cachedCGDesc.GetConsumerGroupUUID(), cgCache.metaClient, cge)
 
 		// now notify the outputhost
 		cgCache.ackMgrLoadCh <- ackMgrLoadMsg{uint32(extCache.ackMgr.ackMgrID), extCache.ackMgr}
@@ -405,6 +411,11 @@ func (cgCache *consumerGroupCache) manageConsumerGroupCache() {
 			cgCache.logger.Info("stopped")
 			// stop the delivery cache as well
 			cgCache.msgDeliveryCache.stop()
+			// wait for the manage routine to go away
+			cgCache.manageMsgCacheWG.Wait()
+			// at this point, the cg is completely unloaded, close all message channels
+			// to cleanup
+			cgCache.cleanupChannels()
 			quit = true
 		}
 	}
@@ -476,9 +487,7 @@ func (cgCache *consumerGroupCache) refreshCgCache(ctx thrift.Context) error {
 		// Now we have the cgCache. check and load extent for all extents
 		for _, cge := range cgRes.GetExtents() {
 			nExtents++
-			errR := cgCache.loadExtentCache(cgCache.tClients, cgCache.metaClient, cgCache.wsConnector,
-				cgCache.outputHostUUID, cgCache.cachedCGDesc.GetDestinationUUID(), dstDesc.GetType(),
-				cgCache.cachedCGDesc.GetConsumerGroupUUID(), cge, cgCache.cachedCGDesc.GetStartFrom())
+			errR := cgCache.loadExtentCache(dstDesc.GetType(), cge)
 			if errR != nil {
 				return errR
 			}
@@ -500,7 +509,7 @@ func (cgCache *consumerGroupCache) loadConsumerGroupCache(ctx thrift.Context, ex
 	defer cgCache.extMutex.Unlock()
 
 	// Make sure we don't race with an unload
-	if cgCache.isClosed() {
+	if cgCache.isClosed() || cgCache.unloadInProgress {
 		return ErrCgUnloaded
 	}
 
@@ -520,6 +529,7 @@ func (cgCache *consumerGroupCache) loadConsumerGroupCache(ctx thrift.Context, ex
 			cgCache.nackMsgCh, cgCache.cachedCGDesc, dlq, cgCache.logger, cgCache.m3Client, cgCache.consumerM3Client, cgCache.notifier, cgCache.creditNotifyCh, cgCache.creditRequestCh, defaultNumOutstandingMsgs, cgCache)
 		cgCache.shutdownWG.Add(1)
 		go cgCache.manageConsumerGroupCache() // Has cgCache.shutdownWG.Done()
+		cgCache.manageMsgCacheWG.Add(1)       // wait group for msgCache
 		go cgCache.msgDeliveryCache.start()   // Uses the dlq, so must be after it
 	}
 
@@ -621,12 +631,12 @@ func (cgCache *consumerGroupCache) updateLastDisconnectTime() {
 func (cgCache *consumerGroupCache) unloadConsumerGroupCache() {
 	cgCache.extMutex.Lock()
 
-	if cgCache.isClosed() {
+	if cgCache.isClosed() || cgCache.unloadInProgress {
 		cgCache.extMutex.Unlock()
 		return
 	}
 
-	close(cgCache.closeChannel)
+	cgCache.unloadInProgress = true
 	for _, conn := range cgCache.connections {
 		go conn.close()
 	}
@@ -637,6 +647,13 @@ func (cgCache *consumerGroupCache) unloadConsumerGroupCache() {
 
 	cgCache.extMutex.Unlock()
 
+	// wait for all the above to go away
+	cgCache.connsWG.Wait()
+
+	// now close the closeChannel which will stop the manage routine
+	close(cgCache.closeChannel)
+
+	cgCache.loadReporter.Stop()
 	// notify the outputhost to remove this from the map
 	// We do this in a blocking way to make sure the cgCache is deleted from the
 	// map so that new connections can be opened on a new CG cache instance.
@@ -644,12 +661,31 @@ func (cgCache *consumerGroupCache) unloadConsumerGroupCache() {
 	// before stopping the manageCgCache routine.
 	cgCache.notifyUnloadCh <- cgCache.cachedCGDesc.GetConsumerGroupUUID()
 
-	cgCache.loadReporter.Stop()
-
 	// since the load reporter is stopped above make sure to mark the number of connections
 	// as 0 explicitly, since we close the connections in an asynchronous fashion
 	cgCache.consumerM3Client.UpdateGauge(metrics.ConsConnectionScope, metrics.OutputhostCGConsConnection, 0)
 	cgCache.consumerM3Client.UpdateGauge(metrics.ConsConnectionScope, metrics.OutputhostCGNumExtents, 0)
+}
+
+// this is a utility routine which closes all message channels
+// to make sure we free up memory
+// this can be done outside of a mutex since this will happen only after we
+// closed everything.
+func (cgCache *consumerGroupCache) cleanupChannels() {
+	// close msgsCh
+	close(cgCache.msgsCh)
+	// close cacheCh
+	close(cgCache.msgCacheCh)
+	// redelivery channel
+	close(cgCache.msgsRedeliveryCh)
+	// priority redelivery channel
+	close(cgCache.priorityMsgsRedeliveryCh)
+	// redeliverd channel
+	close(cgCache.msgCacheRedeliveredCh)
+	// ackMsgsCh
+	close(cgCache.ackMsgCh)
+	// nackMsgsCh
+	close(cgCache.nackMsgCh)
 }
 
 // this can be used to set the max outstanding messages for testing

--- a/services/outputhost/extcache.go
+++ b/services/outputhost/extcache.go
@@ -305,10 +305,7 @@ func (extCache *extentCache) stop(notify bool) {
 	extCache.ackMgr.stop()
 	if notify {
 		// notify cgCache and stop
-		select {
-		case extCache.connectionsClosedCh <- extCache.extUUID:
-		default:
-		}
+		extCache.connectionsClosedCh <- extCache.extUUID
 	}
 	// stop the load reporter pump as well
 	extCache.loadReporter.Stop()

--- a/services/outputhost/messagecache.go
+++ b/services/outputhost/messagecache.go
@@ -774,6 +774,7 @@ func (msgCache *cgMsgCache) manageMessageDeliveryCache() {
 				}
 			}
 		case <-msgCache.closeChannel:
+			msgCache.cgCache.manageMsgCacheWG.Done()
 			return
 		} // select
 		msgCache.checkTimer()

--- a/services/outputhost/messagecache.go
+++ b/services/outputhost/messagecache.go
@@ -792,8 +792,8 @@ func (msgCache *cgMsgCache) shutdownCleanupEntries() {
 	for id := range msgCache.msgMap {
 		delete(msgCache.msgMap, id)
 	}
-
 }
+
 func (msgCache *cgMsgCache) reinjectlastAckMsg() bool {
 	if msgCache.consumerHealth.lastAckMsg == nil {
 		msgCache.lclLg.Warn(`Couldn't inject good message: no message to inject`)

--- a/services/outputhost/outputhost.go
+++ b/services/outputhost/outputhost.go
@@ -32,19 +32,19 @@ import (
 	"github.com/uber-common/bark"
 	"github.com/uber/tchannel-go/thrift"
 
-	ccherami "github.com/uber/cherami-thrift/.generated/go/cherami"
 	ccommon "github.com/uber/cherami-client-go/common"
-	"github.com/uber/cherami-thrift/.generated/go/admin"
-	"github.com/uber/cherami-thrift/.generated/go/cherami"
-	"github.com/uber/cherami-thrift/.generated/go/controller"
-	"github.com/uber/cherami-thrift/.generated/go/metadata"
-	"github.com/uber/cherami-thrift/.generated/go/shared"
 	"github.com/uber/cherami-server/common"
 	dconfig "github.com/uber/cherami-server/common/dconfigclient"
 	mm "github.com/uber/cherami-server/common/metadata"
 	"github.com/uber/cherami-server/common/metrics"
 	"github.com/uber/cherami-server/services/outputhost/load"
 	"github.com/uber/cherami-server/stream"
+	"github.com/uber/cherami-thrift/.generated/go/admin"
+	"github.com/uber/cherami-thrift/.generated/go/cherami"
+	ccherami "github.com/uber/cherami-thrift/.generated/go/cherami"
+	"github.com/uber/cherami-thrift/.generated/go/controller"
+	"github.com/uber/cherami-thrift/.generated/go/metadata"
+	"github.com/uber/cherami-thrift/.generated/go/shared"
 )
 
 const (
@@ -489,9 +489,17 @@ func (h *OutputHost) ReceiveMessageBatch(ctx thrift.Context, request *cherami.Re
 	firstResultTimer := common.NewTimer(timeoutTime.Sub(time.Now()))
 	defer firstResultTimer.Stop()
 	select {
-	case msg := <-cgCache.msgsRedeliveryCh:
+	case msg, ok := <-cgCache.msgsRedeliveryCh:
+		if !ok {
+			h.m3Client.IncCounter(metrics.ReceiveMessageBatchOutputHostScope, metrics.OutputhostFailures)
+			return nil, ErrCgUnloaded
+		}
 		deliver(msg, cgCache.msgCacheRedeliveredCh)
-	case msg := <-cgCache.msgsCh:
+	case msg, ok := <-cgCache.msgsCh:
+		if !ok {
+			h.m3Client.IncCounter(metrics.ReceiveMessageBatchOutputHostScope, metrics.OutputhostFailures)
+			return nil, ErrCgUnloaded
+		}
 		deliver(msg, cgCache.msgCacheCh)
 	case <-firstResultTimer.C:
 		exception := cherami.NewTimeoutError()
@@ -510,9 +518,17 @@ MORERESULTLOOP:
 			break MORERESULTLOOP
 		default:
 			select {
-			case msg := <-cgCache.msgsRedeliveryCh:
+			case msg, ok := <-cgCache.msgsRedeliveryCh:
+				if !ok {
+					// the cg is already unloaded
+					break MORERESULTLOOP
+				}
 				deliver(msg, cgCache.msgCacheRedeliveredCh)
-			case msg := <-cgCache.msgsCh:
+			case msg, ok := <-cgCache.msgsCh:
+				if !ok {
+					// the cg is already unloaded
+					break MORERESULTLOOP
+				}
 				deliver(msg, cgCache.msgCacheCh)
 			case <-moreResultTimer.C:
 				break MORERESULTLOOP

--- a/services/outputhost/outputhost.go
+++ b/services/outputhost/outputhost.go
@@ -458,6 +458,11 @@ func (h *OutputHost) ReceiveMessageBatch(ctx thrift.Context, request *cherami.Re
 	}
 
 	cgCache.updateLastDisconnectTime()
+
+	// make sure we don't close all the channels here
+	cgCache.connsWG.Add(1) // this WG is for the cgCache
+	defer cgCache.connsWG.Done()
+
 	res := cherami.NewReceiveMessageBatchResult_()
 	msgCacheWriteTicker := common.NewTimer(msgCacheWriteTimeout)
 	defer msgCacheWriteTicker.Stop()

--- a/services/outputhost/outputhost.go
+++ b/services/outputhost/outputhost.go
@@ -312,8 +312,6 @@ func (h *OutputHost) OpenConsumerStream(ctx thrift.Context, call stream.BOutOpen
 	}
 	conn := newConsConnection(cgCache.currID, cgCache, call, h.cacheTimeout, cgLogger)
 	cgCache.connections[cgCache.currID] = conn
-	// wait for shutdown here as well. this makes sure the pubconnection is done
-	h.shutdownWG.Add(1)
 	connWG := conn.open()
 	cgCache.currID++
 	// increment the active connection count
@@ -328,7 +326,6 @@ func (h *OutputHost) OpenConsumerStream(ctx thrift.Context, call stream.BOutOpen
 	// wait till the conn is closed. we cannot return immediately.
 	// If we do so, we will get data races reading/writing from/to the stream
 	connWG.Wait()
-	h.shutdownWG.Done()
 	h.hostMetrics.Decrement(load.HostMetricNumOpenConns)
 	return nil
 }


### PR DESCRIPTION
This is the corresponding equivalent of the input leak fixes. Stress tests over the weekend looks good. 

This makes sure:
(1) we cleanup all connections/extents properly by making sure we wait appropriately before breaking the manageRoutine
(2) make sure all the buffered channels are closed
(3) make sure the message cache entries are cleaned up during shutdown so that we don't keep any existing references.

The only remaining leak is this known leak with maps in go which will be fixed in 1.8:
https://github.com/golang/go/issues/16070