### PR TITLE
Make message cache size configurable per CG

### DIFF
--- a/common/dconfig/configmgr.go
+++ b/common/dconfig/configmgr.go
@@ -47,6 +47,12 @@ type (
 		// input parameters refer to the 4 levels in the
 		// config hierarchy
 		Get(svc string, version string, sku string, host string) (interface{}, error)
+
+		//Start starts the config manager
+		Start()
+
+		//Stop stops the running config manager
+		Stop()
 	}
 
 	// CassandraConfigManager is an implementation of
@@ -173,7 +179,7 @@ var cfgRefreshInterval = time.Minute
 //
 // Future Work:
 //   Notifications to observers on config changes
-func NewCassandraConfigManager(mClient m.TChanMetadataService, configTypes map[string]interface{}, logger bark.Logger) *CassandraConfigManager {
+func NewCassandraConfigManager(mClient m.TChanMetadataService, configTypes map[string]interface{}, logger bark.Logger) ConfigManager {
 	cfgMgr := new(CassandraConfigManager)
 	cfgMgr.mClient = mClient
 	cfgMgr.configTypes = configTypes

--- a/common/dconfig/configmgr.go
+++ b/common/dconfig/configmgr.go
@@ -99,10 +99,11 @@ type (
 )
 
 const (
-	wildcardToken      = "*"
-	sliceSplitToken    = ","
-	cfgRefreshInterval = time.Minute
+	wildcardToken   = "*"
+	sliceSplitToken = ","
 )
+
+var cfgRefreshInterval = time.Minute
 
 // NewCassandraConfigManager constructs and returns an
 // implementation of config managed backed by a store
@@ -536,4 +537,9 @@ func setStringField(field reflect.Value, fieldName string, keyValues map[string]
 		return
 	}
 	field.SetString(defaultStr)
+}
+
+// SetRefreshInterval is used to set the refresh interval
+func SetRefreshInterval(interval time.Duration) {
+	cfgRefreshInterval = interval
 }

--- a/common/dconfig/configmgr_test.go
+++ b/common/dconfig/configmgr_test.go
@@ -184,7 +184,8 @@ func (s *ConfigManagerTestSuite) TestConfigOverrides() {
 	configTypes["input"] = testInputConfig1{}
 	configTypes["store"] = testStoreConfig1{}
 
-	cfgMgr := NewCassandraConfigManager(s.cdb.GetClient(), configTypes, s.logger)
+	cfgMgrIface := NewCassandraConfigManager(s.cdb.GetClient(), configTypes, s.logger)
+	cfgMgr := cfgMgrIface.(*CassandraConfigManager)
 	cfgMgr.refresh() // force refresh from cassandra
 
 	for i, tc := range inputTestCases {

--- a/services/controllerhost/config.go
+++ b/services/controllerhost/config.go
@@ -59,7 +59,7 @@ type (
 
 // newConfigManager creates and returns a new instance
 // of CassandraConfigManager.
-func newConfigManager(mClient m.TChanMetadataService, logger bark.Logger) *dconfig.CassandraConfigManager {
+func newConfigManager(mClient m.TChanMetadataService, logger bark.Logger) dconfig.ConfigManager {
 	cfgTypes := map[string]interface{}{
 		common.InputServiceName:      InputPlacementConfig{},
 		common.OutputServiceName:     OutputPlacementConfig{},

--- a/services/controllerhost/controllerhost.go
+++ b/services/controllerhost/controllerhost.go
@@ -115,7 +115,7 @@ type (
 		retMgr          *retMgrRunner
 		appConfig       configure.CommonAppConfig
 		m3Client        metrics.Client
-		cfgMgr          *dconfig.CassandraConfigManager
+		cfgMgr          dconfig.ConfigManager
 		loadMetrics     load.MetricsAggregator
 		placement       Placement
 		extentSeals     struct {

--- a/services/outputhost/cgcache.go
+++ b/services/outputhost/cgcache.go
@@ -183,7 +183,7 @@ type (
 		manageMsgCacheWG sync.WaitGroup
 
 		// cfgMgr is the reference to the cassandra backed cfgMgr
-		cfgMgr *dconfig.CassandraConfigManager
+		cfgMgr dconfig.ConfigManager
 	}
 )
 

--- a/services/outputhost/config.go
+++ b/services/outputhost/config.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package outputhost
+
+import (
+	"github.com/uber-common/bark"
+	"github.com/uber/cherami-server/common"
+	"github.com/uber/cherami-server/common/dconfig"
+	m "github.com/uber/cherami-thrift/.generated/go/metadata"
+)
+
+type (
+	// OutputCgConfig is the per cg config used by the
+	// cassandra config manager
+	OutputCgConfig struct {
+		MessageCacheSize []string `name:"messagecachesize" default:"/=10000"`
+	}
+)
+
+// newConfigManager creates and returns a new instance
+// of CassandraConfigManager.
+func newConfigManager(mClient m.TChanMetadataService, logger bark.Logger) *dconfig.CassandraConfigManager {
+	cfgTypes := map[string]interface{}{
+		common.OutputServiceName: OutputCgConfig{},
+	}
+	return dconfig.NewCassandraConfigManager(mClient, cfgTypes, logger)
+}

--- a/services/outputhost/config.go
+++ b/services/outputhost/config.go
@@ -37,7 +37,7 @@ type (
 
 // newConfigManager creates and returns a new instance
 // of CassandraConfigManager.
-func newConfigManager(mClient m.TChanMetadataService, logger bark.Logger) *dconfig.CassandraConfigManager {
+func newConfigManager(mClient m.TChanMetadataService, logger bark.Logger) dconfig.ConfigManager {
 	cfgTypes := map[string]interface{}{
 		common.OutputServiceName: OutputCgConfig{},
 	}

--- a/services/outputhost/config.go
+++ b/services/outputhost/config.go
@@ -31,6 +31,12 @@ type (
 	// OutputCgConfig is the per cg config used by the
 	// cassandra config manager
 	OutputCgConfig struct {
+		// MessageCacheSize is used to configure the per CG cache size.
+		// This is a string slice, where each entry is a tuple with the
+		// destination/CG_name=value.
+		// For example, we can ideally have two CGs for the same destination
+		// with different size config as follows:
+		// "/test/destination//test/cg_1=50,/test/destination//test/cg_2=100"
 		MessageCacheSize []string `name:"messagecachesize" default:"/=10000"`
 	}
 )

--- a/services/outputhost/outputhost.go
+++ b/services/outputhost/outputhost.go
@@ -88,7 +88,7 @@ type (
 		ackMgrLoadCh      chan ackMgrLoadMsg
 		ackMgrUnloadCh    chan uint32
 		hostMetrics       *load.HostMetrics
-		cfgMgr            *cassDconfig.CassandraConfigManager
+		cfgMgr            cassDconfig.ConfigManager
 		common.SCommon
 	}
 

--- a/test/integration/base.go
+++ b/test/integration/base.go
@@ -32,6 +32,7 @@ import (
 	"github.com/uber/cherami-server/clients/metadata"
 	"github.com/uber/cherami-server/common"
 	"github.com/uber/cherami-server/common/configure"
+	cassConfig "github.com/uber/cherami-server/common/dconfig"
 	dconfig "github.com/uber/cherami-server/common/dconfigclient"
 	"github.com/uber/cherami-server/services/controllerhost"
 	"github.com/uber/cherami-server/services/frontendhost"
@@ -161,6 +162,9 @@ func (tb *testBase) setupSuiteImpl(t *testing.T) {
 	controllerhost.IntervalBtwnScans = time.Second
 	storehost.ReportInterval = time.Second
 	storehost.ReportPause = common.Int32Ptr(0) // unpaused
+
+	// Make sure the cassandra config refresh interval is small
+	cassConfig.SetRefreshInterval(10 * time.Millisecond)
 }
 
 func (tb *testBase) TearDownSuite() {

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -92,7 +92,7 @@ func (s *NetIntegrationSuiteParallelC) TestMsgCacheLimit() {
 	log := common.GetDefaultLogger()
 
 	value := fmt.Sprintf("%v/%v=%v", destPath, cgPath, testMsgCacheLimit)
-	log.Infof("VALUE IS: %v", value)
+
 	// set the message cache limit for this cg on the outputhost to be a smaller number
 	cItem := &metadata.ServiceConfigItem{
 		ServiceName:    common.StringPtr("cherami-outputhost"),


### PR DESCRIPTION
This patch makes sure we can configure the message cache size per
CG and has the following pieces:
(1) Move the cassandra based config manager behind the interface so that we can easily write tests
(2) Update existing code which got the hard type to get the interface
(3) Modify outputhost to get the new message cache size value from configMgr. Update tests to use this value.