### PR TITLE
Controller: Make isCGStalled() use 5MinSum(bytesOut) instead of 5MinA…

### DIFF
--- a/services/controllerhost/load/types.go
+++ b/services/controllerhost/load/types.go
@@ -70,6 +70,10 @@ const (
 	// that does average of all data points
 	// across the past five minutes
 	FiveMinAvg
+	// FiveMinSum gives the sum of
+	// all data points over the
+	// past five minutes
+	FiveMinSum
 )
 
 const (

--- a/services/controllerhost/queueDepth.go
+++ b/services/controllerhost/queueDepth.go
@@ -645,7 +645,7 @@ func (qdc *queueDepthCalculator) isCGExtentStalled(cge *metadata.ConsumerGroupEx
 		return false
 	}
 
-	msgsOut, err := context.loadMetrics.Get(hostID, extID, load.MsgsOutPerSec, load.FiveMinAvg)
+	msgsOut, err := context.loadMetrics.Get(hostID, extID, load.MsgsOutPerSec, load.FiveMinSum)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
The queueDepth module within Controller has a stallness check to detect consumer-groups that are potentially stalled. This check works for the most part, except when the bytesOut is really small - the average gets rounded to zero and as a result, we have a false alarm. This patch makes the change to look at fiveMinSum instead of fiveMinAvg. 