### PR TITLE
Tweak gocql client params for perf

### DIFF
--- a/common/configure/commonmetadataconfig.go
+++ b/common/configure/commonmetadataconfig.go
@@ -26,6 +26,7 @@ type MetadataConfig struct {
 	Keyspace       string            `yaml:"Keyspace"`
 	Consistency    string            `yaml:"Consistency"`
 	ClusterName    string            `yaml:"ClusterName"`
+	NumConns       int               `yaml:"NumConns"`
 	DcFilter       map[string]string `yaml:"DcFilter"`
 }
 
@@ -64,4 +65,11 @@ func (r *MetadataConfig) SetCassandraHosts(cHosts string) {
 // GetClusterName gets the cassandra cluster name
 func (r *MetadataConfig) GetClusterName() string {
 	return r.ClusterName
+}
+
+// GetNumConns returns the desired number of
+// conns from the client to every cassandra
+// server
+func (r *MetadataConfig) GetNumConns() int {
+	return r.NumConns
 }

--- a/common/configure/interfaces.go
+++ b/common/configure/interfaces.go
@@ -153,6 +153,10 @@ type (
 		SetCassandraHosts(hosts string)
 		// GetClusterName gets the cassandra cluster name
 		GetClusterName() string
+		// GetNumConns returns the desired number of
+		// conns from the client to every cassandra
+		// server
+		GetNumConns() int
 	}
 
 	// CommonControllerConfig holds the controller related config

--- a/common/metadataMgr.go
+++ b/common/metadataMgr.go
@@ -30,7 +30,13 @@ import (
 	"github.com/uber/cherami-thrift/.generated/go/shared"
 )
 
-const defaultPageSize = 4000
+// Some of our records like ExtentStats are
+// huge. Larger records along with large
+// pageSize will result in bigger response
+// payloads. This can impact latency for all
+// queries multiplexed on a tcp conn. So,
+// keep the pageSize small.
+const defaultPageSize = 512
 
 type (
 	// MetadataMgr manages extents. It exposes easy

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -79,6 +79,7 @@ MetadataConfig:
   Keyspace: "cherami"
   Consistency: "one"
   ClusterName: "base"
+  NumConns: 1
 
 # ReplicatorConfig specifies 
 ReplicatorConfig:


### PR DESCRIPTION
This patch tweaks some of the client gocql parameters to reduce latency and query response time. 
* Exposed gocql.NumConns as a metadataConfig param 
* Changed metadata API page size from 4k to 512
* Changed extentDeleteTTL from 30 days to 24 hours
* Changed userOperationsTableTTL from 365 days to 30 days