### PR TITLE
Smart retry auto disable

### DIFF
--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -63,7 +63,6 @@ func NewLRUWithInitialCapacity(initialCapacity, maxSize int) Cache {
 	return New(maxSize, &Options{
 		InitialCapacity: initialCapacity,
 	})
-
 }
 
 // Get retrieves the value stored under the given key

--- a/common/metrics/simplereporter.go
+++ b/common/metrics/simplereporter.go
@@ -20,11 +20,7 @@
 
 package metrics
 
-import (
-	"fmt"
-	"sync"
-	"time"
-)
+import "time"
 
 type (
 	// SimpleReporter is the reporter used to dump metric to console for stress runs
@@ -39,11 +35,6 @@ type (
 		elasped    time.Duration
 	}
 )
-
-type HandlerFn func(metricName string, baseTags, tags map[string]string, value int64)
-
-var handlers = make(map[string]map[string]HandlerFn) // Key1 - metricName; Key2 - "filterTag:filterVal"
-var handlerMutex sync.RWMutex
 
 // NewSimpleReporter create an instance of Reporter which can be used for driver to emit metric to console
 func NewSimpleReporter(tags map[string]string) Reporter {
@@ -87,78 +78,12 @@ func (r *SimpleReporter) GetTags() map[string]string {
 
 // IncCounter reports Counter metric to M3
 func (r *SimpleReporter) IncCounter(name string, tags map[string]string, delta int64) {
-	r.executeHandler(name, tags, delta)
+	// not implemented
 }
 
 // UpdateGauge reports Gauge type metric
 func (r *SimpleReporter) UpdateGauge(name string, tags map[string]string, value int64) {
-	r.executeHandler(name, tags, value)
-}
-
-func (r *SimpleReporter) executeHandler(name string, tags map[string]string, value int64) {
-	handlerMutex.RLock()
-	 _, ok0 := handlers[``]
-	 _, ok1 := handlers[name]
-	if ok0 || ok1 {
-		if allHandler2, ok2 := handlers[``][``]; ok2 { // Global handler
-			allHandler2(name, r.tags, tags, value)
-		}
-		if allHandler3, ok3 := handlers[name][``]; ok3 { // Handler for all metrics named 'name'
-			allHandler3(name, r.tags, tags, value)
-		}
-
-		// TODO: technically, this is wrong, as we don't have the local tags overriding the struct tags, but this
-		// has no practical effect in our current use of metrics, since we never override
-		for _, q := range []map[string]string{r.tags, tags} {
-			for filterTag, filterTagVal := range q {
-				key2 := filterTag + `:` + filterTagVal
-				if handler4, ok4 := handlers[``][key2]; ok4 { // Handler for this tag, any name
-					handler4(name, r.tags, tags, value)
-				}
-				if handler5, ok5 := handlers[name][key2]; ok5 { // Handler for specifically this name and tag
-					handler5(name, r.tags, tags, value)
-				}
-			}
-		}
-	}
-	handlerMutex.RUnlock()
-}
-
-// Register a handler (closure) that receives updates for a particular guage or counter based on the metric name and
-// the name/value of one of the metric's tags. If the filterTag/Val are both empty, all updates to that metric will
-// trigger the handler. If metricName is empty, all metrics matching the tag filter will pass through your function.
-// A nil handler unregisters the handler for the given filter parameters
-//
-// Dev notes:
-// * It is advisible to defer a call to unregister your handler when your test ends
-// * Your handler can be called concurrently. Capture your own sync.Mutex if you must serialize
-// * Counters report the delta; you must maintain the cumulative value of your counter if it is important
-// * Your handler executes synchronously with the metrics code; DO NOT BLOCK
-func RegisterHandler(metricName, filterTag, filterTagVal string, handler HandlerFn) {
-	defer handlerMutex.Unlock()
-	handlerMutex.Lock()
-	if _, ok := handlers[metricName]; !ok {
-		handlers[metricName] = make(map[string]HandlerFn)
-	}
-
-	key2 := filterTag + `:` + filterTagVal
-	if key2 == `:` {
-		key2 = ``
-	}
-
-	if handler == nil {
-		delete(handlers[metricName], key2)
-		if len(handlers[metricName]) == 0 {
-			delete(handlers, metricName)
-		}
-		return
-	}
-
-	if hf, ok2 := handlers[metricName][key2]; ok2 {
-		panic(fmt.Sprintf("Metrics handler %v (for '%s'/'%s') should have been unregistered", hf, metricName, key2))
-	}
-
-	handlers[metricName][key2] = handler
+	// Not implemented
 }
 
 func newSimpleStopWatch(metricName string, reporter *SimpleReporter) *simpleStopWatch {

--- a/services/outputhost/cgcache.go
+++ b/services/outputhost/cgcache.go
@@ -549,7 +549,7 @@ func (cgCache *consumerGroupCache) checkSingleCGVisible(ctx thrift.Context, cge 
 			ExtentUUID:      common.StringPtr(cge.GetExtentUUID()),
 		}
 		ext, err := cgCache.metaClient.ReadExtentStats(ctx, req)
-		if err != nil {
+		if err == nil {
 			if ext != nil && ext.GetExtentStats() != nil {
 				val = ext.GetExtentStats().GetConsumerGroupVisibility() != ``
 				if val {

--- a/services/outputhost/messagecache.go
+++ b/services/outputhost/messagecache.go
@@ -1073,9 +1073,11 @@ func (msgCache *cgMsgCache) isStalled() bool {
 	var m3St m3HealthState
 	var smartRetryDisabled bool
 
-	if strings.Contains(msgCache.GetOwnerEmail(), SmartRetryDisableString) {
+	msgCache.cgCache.extMutex.RLock()
+	if msgCache.cgCache.dlqMerging || strings.Contains(msgCache.GetOwnerEmail(), SmartRetryDisableString) {
 		smartRetryDisabled = true
 	}
+	msgCache.cgCache.extMutex.RUnlock()
 
 	now := common.Now()
 
@@ -1164,8 +1166,8 @@ func (msgCache *cgMsgCache) isStalled() bool {
 		msgCache.logMessageCacheHealth()
 	}
 
-	// Assign M3 state, preferring progressing over idle. It is possible for both progressing and idle to be true if there are
-	// no redeliveries are happening
+	// Assign M3 state, preferring progressing over idle. It is possible for both
+	// progressing and idle to be true if there are no redeliveries happening
 	switch {
 	case stalled:
 		m3St = stateStalled

--- a/services/outputhost/messagecache.go
+++ b/services/outputhost/messagecache.go
@@ -21,6 +21,7 @@
 package outputhost
 
 import (
+	"sync/atomic"
 	"fmt"
 	"strings"
 	"sync"
@@ -1074,12 +1075,10 @@ func (msgCache *cgMsgCache) isStalled() bool {
 	var m3St m3HealthState
 	var smartRetryDisabled bool
 
-	msgCache.cgCache.extMutex.RLock()
-	if msgCache.cgCache.dlqMerging || strings.Contains(msgCache.GetOwnerEmail(), SmartRetryDisableString) {
+	if atomic.LoadInt32(&msgCache.cgCache.dlqMerging) > 0 || strings.Contains(msgCache.GetOwnerEmail(), SmartRetryDisableString) {
 		smartRetryDisabled = true
 	}
-	msgCache.cgCache.extMutex.RUnlock()
-
+	
 	now := common.Now()
 
 	// Determines that no progress has been made in the recent past; this is half the lock timeout to be

--- a/services/outputhost/outputhost_test.go
+++ b/services/outputhost/outputhost_test.go
@@ -177,6 +177,7 @@ func (s *OutputHostSuite) TestOutputHostReadMessage() {
 	destDesc.DestinationUUID = common.StringPtr(destUUID)
 	destDesc.Status = common.InternalDestinationStatusPtr(shared.DestinationStatus_ENABLED)
 	s.mockMeta.On("ReadDestination", mock.Anything, mock.Anything).Return(destDesc, nil).Once()
+	s.mockMeta.On("ReadExtentStats", mock.Anything, mock.Anything).Return(nil, fmt.Errorf(`foo`))
 
 	cgDesc := shared.NewConsumerGroupDescription()
 	cgDesc.ConsumerGroupUUID = common.StringPtr(uuid.New())
@@ -239,6 +240,7 @@ func (s *OutputHostSuite) TestOutputHostAckMessage() {
 	destDesc.DestinationUUID = common.StringPtr(destUUID)
 	destDesc.Status = common.InternalDestinationStatusPtr(shared.DestinationStatus_ENABLED)
 	s.mockMeta.On("ReadDestination", mock.Anything, mock.Anything).Return(destDesc, nil).Once()
+	s.mockMeta.On("ReadExtentStats", mock.Anything, mock.Anything).Return(nil, fmt.Errorf(`foo`))
 
 	cgUUID := uuid.New()
 	extUUID := uuid.New()
@@ -355,6 +357,7 @@ func (s *OutputHostSuite) TestOutputHostReconfigure() {
 	destDesc.DestinationUUID = common.StringPtr(destUUID)
 	destDesc.Status = common.InternalDestinationStatusPtr(shared.DestinationStatus_ENABLED)
 	s.mockMeta.On("ReadDestination", mock.Anything, mock.Anything).Return(destDesc, nil).Twice()
+	s.mockMeta.On("ReadExtentStats", mock.Anything, mock.Anything).Return(nil, fmt.Errorf(`foo`))
 
 	// 1. Make sure we setup the ReadConsumerGroup metadata
 	cgDesc := shared.NewConsumerGroupDescription()
@@ -478,6 +481,7 @@ func (s *OutputHostSuite) TestOutputHostReceiveMessageBatch() {
 	destDesc.DestinationUUID = common.StringPtr(destUUID)
 	destDesc.Status = common.InternalDestinationStatusPtr(shared.DestinationStatus_ENABLED)
 	s.mockMeta.On("ReadDestination", mock.Anything, mock.Anything).Return(destDesc, nil).Once()
+	s.mockMeta.On("ReadExtentStats", mock.Anything, mock.Anything).Return(nil, fmt.Errorf(`foo`))
 
 	cgDesc := shared.NewConsumerGroupDescription()
 	cgDesc.ConsumerGroupUUID = common.StringPtr(uuid.New())
@@ -546,6 +550,7 @@ func (s *OutputHostSuite) TestOutputHostReceiveMessageBatch_NoMsg() {
 	destDesc.DestinationUUID = common.StringPtr(destUUID)
 	destDesc.Status = common.InternalDestinationStatusPtr(shared.DestinationStatus_ENABLED)
 	s.mockMeta.On("ReadDestination", mock.Anything, mock.Anything).Return(destDesc, nil)
+	s.mockMeta.On("ReadExtentStats", mock.Anything, mock.Anything).Return(nil, fmt.Errorf(`foo`))
 
 	cgDesc := shared.NewConsumerGroupDescription()
 	cgDesc.ConsumerGroupUUID = common.StringPtr(uuid.New())
@@ -595,6 +600,7 @@ func (s *OutputHostSuite) TestOutputHostReceiveMessageBatch_SomeMsgAvailable() {
 	destDesc.DestinationUUID = common.StringPtr(destUUID)
 	destDesc.Status = common.InternalDestinationStatusPtr(shared.DestinationStatus_ENABLED)
 	s.mockMeta.On("ReadDestination", mock.Anything, mock.Anything).Return(destDesc, nil)
+	s.mockMeta.On("ReadExtentStats", mock.Anything, mock.Anything).Return(nil, fmt.Errorf(`foo`))
 
 	cgDesc := shared.NewConsumerGroupDescription()
 	cgDesc.ConsumerGroupUUID = common.StringPtr(uuid.New())
@@ -667,6 +673,7 @@ func (s *OutputHostSuite) TestOutputCgUnload() {
 	destDesc.DestinationUUID = common.StringPtr(destUUID)
 	destDesc.Status = common.InternalDestinationStatusPtr(shared.DestinationStatus_ENABLED)
 	s.mockMeta.On("ReadDestination", mock.Anything, mock.Anything).Return(destDesc, nil).Twice()
+	s.mockMeta.On("ReadExtentStats", mock.Anything, mock.Anything).Return(nil, fmt.Errorf(`foo`))
 
 	// 1. Make sure we setup the ReadConsumerGroup metadata
 	cgDesc := shared.NewConsumerGroupDescription()
@@ -759,6 +766,7 @@ func (s *OutputHostSuite) TestOutputAckMgrReset() {
 	destDesc.DestinationUUID = common.StringPtr(destUUID)
 	destDesc.Status = common.InternalDestinationStatusPtr(shared.DestinationStatus_ENABLED)
 	s.mockMeta.On("ReadDestination", mock.Anything, mock.Anything).Return(destDesc, nil).Twice()
+	s.mockMeta.On("ReadExtentStats", mock.Anything, mock.Anything).Return(nil, fmt.Errorf(`foo`))
 
 	// 1. Make sure we setup the ReadConsumerGroup metadata
 	cgDesc := shared.NewConsumerGroupDescription()

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/uber-common/bark"
@@ -34,6 +35,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	client "github.com/uber/cherami-client-go/client/cherami"
 	"github.com/uber/cherami-server/common"
+	"github.com/uber/cherami-server/common/metrics"
 	"github.com/uber/cherami-server/services/controllerhost"
 	"github.com/uber/cherami-server/services/storehost"
 	"github.com/uber/cherami-thrift/.generated/go/cherami"
@@ -50,6 +52,9 @@ type NetIntegrationSuiteParallelA struct {
 	testBase
 }
 type NetIntegrationSuiteParallelC struct {
+	testBase
+}
+type NetIntegrationSuiteParallelD struct {
 	testBase
 }
 type NetIntegrationSuiteSerial struct {
@@ -70,6 +75,12 @@ func TestNetIntegrationSuiteParallelB(t *testing.T) {
 }
 func TestNetIntegrationSuiteParallelC(t *testing.T) {
 	s := new(NetIntegrationSuiteParallelC)
+	s.testBase.SetupSuite(t)
+	t.Parallel()
+	suite.Run(t, s)
+}
+func TestNetIntegrationSuiteParallelD(t *testing.T) {
+	s := new(NetIntegrationSuiteParallelD)
 	s.testBase.SetupSuite(t)
 	t.Parallel()
 	suite.Run(t, s)
@@ -1242,6 +1253,320 @@ operationsLoop:
 		log.WithField(common.TagAckID, dlqAckIDMap[id]).Errorf("DLQ Message %v wasn't merged [%v]", id, v)
 	}
 
+}
+
+func (s *NetIntegrationSuiteParallelD) TestSmartRetryDisableDuringDLQMerge() {
+	const (
+		destPath                   = `/test.runner.SmartRetry/SRDDDM` // This path ensures that throttling is limited for this test
+		cgPath                     = `/test.runner.SmartRetry/SRDDDMCG`
+		metricsName                = `_test.runner.SmartRetry_SRDDDM`
+		cgMaxDeliveryCount         = 1
+		cgLockTimeout              = 1
+		cnsmrPrefetch              = 10
+		publisherPubInterval       = time.Second / 5
+		publisherPubSlowInterval   = publisherPubInterval * 10 // This is 10x slower
+		DLQPublishClearTime        = cgLockTimeout * time.Second * 2
+		DLQMergeMessageTargetCount = 2
+		DLQMessageStart            = 10
+		DLQMessageSpacing          = 6
+		mergeAssumedCompleteTime   = cgLockTimeout * (cgMaxDeliveryCount + 1) * 2 * time.Second * 2 // +1 for initial delivery, *2 for dlqInhibit, *2 for fudge
+		testTimeout                = time.Second * 180
+	)
+
+	const (
+		// Operation/Phase IDS
+		produceDLQ = iota
+		smartRetryProvoke1
+		mergeOp
+		smartRetryProvoke3
+		smartRetryProvoke4
+		done
+		PhaseCount
+	)
+
+	const (
+		stateStalled = iota
+		stateIdle
+		stateProgressing
+	)
+
+	var dlqMutex sync.RWMutex
+	phase := produceDLQ
+	var currentHealth = stateIdle
+	var dlqDeliveryCount int
+	var dlqDeliveryTime time.Time
+	phaseOnce := make([]sync.Once, PhaseCount)
+
+	// ll - local log
+	ll := func(fmtS string, rest ...interface{}) {
+		common.GetDefaultLogger().WithFields(bark.Fields{`phase`: phase}).Infof(fmtS, rest...)
+		//fmt.Printf(`p`+strconv.Itoa(phase)+` `+fmtS+"\n", rest...)
+	}
+
+	// lll - local log with lock (for race on access to phase)
+	lll := func(fmtS string, rest ...interface{}) {
+		dlqMutex.Lock()
+		ll(fmtS, rest...)
+		dlqMutex.Unlock()
+	}
+
+	// == Metrics ===
+
+	getCurrentHealth := func() int {
+		dlqMutex.RLock()
+		r := currentHealth
+		dlqMutex.RUnlock()
+		return r
+	}
+
+	getDLQDeliveryCount := func() int {
+		dlqMutex.RLock()
+		r := dlqDeliveryCount
+		dlqMutex.RUnlock()
+		return r
+	}
+
+	getDLQDeliveryTime := func() time.Time {
+		dlqMutex.RLock()
+		r := dlqDeliveryTime
+		dlqMutex.RUnlock()
+		return r
+	}
+
+	defer metrics.RegisterHandler(`outputhost.healthstate.cg`, `destination`, metricsName, nil)
+	metrics.RegisterHandler(`outputhost.healthstate.cg`, `destination`, metricsName,
+		func(metricName string, baseTags, tags map[string]string, value int64) {
+			dlqMutex.Lock()
+			last := currentHealth
+			currentHealth = int(value)
+			if last != currentHealth {
+				ll("Metric %s: %d", metricName, value)
+			}
+			dlqMutex.Unlock()
+		})
+
+	defer metrics.RegisterHandler(`outputhost.message.sent-dlq.cg`, `destination`, metricsName, nil)
+	metrics.RegisterHandler(`outputhost.message.sent-dlq.cg`, `destination`, metricsName,
+		func(metricName string, baseTags, tags map[string]string, value int64) {
+			dlqMutex.Lock()
+			dlqDeliveryCount += int(value)
+			ll("Metric %s: %d (+%d)", metricName, dlqDeliveryCount, value)
+			if value > 0 {
+				dlqDeliveryTime = time.Now()
+			}
+			dlqMutex.Unlock()
+		})
+
+	// == Merge ==
+
+	merge := func() {
+		fe := s.GetFrontend()
+		s.NotNil(fe)
+		mergeReq := cherami.NewMergeDLQForConsumerGroupRequest()
+		mergeReq.DestinationPath = common.StringPtr(destPath)
+		mergeReq.ConsumerGroupName = common.StringPtr(cgPath)
+
+		time.Sleep(DLQPublishClearTime)
+		// Merge DLQ
+		err := fe.MergeDLQForConsumerGroup(nil, mergeReq)
+		s.NoError(err)
+	}
+
+	// == Setup ==
+
+	// Create the client
+	ipaddr, port, _ := net.SplitHostPort(s.GetFrontend().GetTChannel().PeerInfo().HostPort)
+	portNum, _ := strconv.Atoi(port)
+	cheramiClient, _ := client.NewClient("cherami-test", ipaddr, portNum, nil)
+
+	// Create the destination to publish message
+	crReq := cherami.NewCreateDestinationRequest()
+	crReq.Path = common.StringPtr(destPath)
+	crReq.Type = cherami.DestinationTypePtr(cherami.DestinationType_PLAIN)
+	crReq.ConsumedMessagesRetention = common.Int32Ptr(60)
+	crReq.UnconsumedMessagesRetention = common.Int32Ptr(120)
+	crReq.OwnerEmail = common.StringPtr("lhcIntegration@uber.com")
+
+	desDesc, _ := cheramiClient.CreateDestination(crReq)
+	s.NotNil(desDesc)
+
+	// we should see the destination now in cassandra
+	rReq := cherami.NewReadDestinationRequest()
+	rReq.Path = common.StringPtr(destPath)
+	readDesc, _ := cheramiClient.ReadDestination(rReq)
+	s.NotNil(readDesc)
+
+	// ==WRITE==
+
+	// Create the publisher
+	cPublisherReq := &client.CreatePublisherRequest{
+		Path: destPath,
+	}
+
+	publisherTest := cheramiClient.CreatePublisher(cPublisherReq)
+	s.NotNil(publisherTest)
+
+	err := publisherTest.Open()
+	s.NoError(err)
+
+	// Publish messages continuously in a goroutine to ensures a steady supply of 'good' messages so
+	// that smart retry will not affect us.
+	var curPubInterval = int64(publisherPubInterval)
+	closeCh := make(chan struct{})
+	defer close(closeCh)
+	go func() {
+		i := 0
+		defer lll("DONE PUBLISHING %v MESSAGES", i)
+		defer publisherTest.Close()
+		myIntrvl := atomic.LoadInt64(&curPubInterval)
+		ticker := time.NewTicker(time.Duration(myIntrvl))
+		for {
+			select {
+			case <-ticker.C:
+				data := []byte(fmt.Sprintf("msg_%d", i+1))
+				receipt := publisherTest.Publish(&client.PublisherMessage{Data: data})
+				s.NoError(receipt.Error)
+				i++
+
+				if atomic.LoadInt64(&curPubInterval) != myIntrvl { // Adjust publish speed as requested
+					ticker.Stop()
+					myIntrvl = atomic.LoadInt64(&curPubInterval)
+					ticker = time.NewTicker(time.Duration(myIntrvl))
+					lll("publisher changed interval to %v seconds", common.UnixNanoTime(myIntrvl).ToSeconds())
+				}
+			case <-closeCh:
+				return
+			}
+		}
+	}()
+
+	// ==READ==
+
+	// Create the consumer group
+	cgReq := cherami.NewCreateConsumerGroupRequest()
+	cgReq.ConsumerGroupName = common.StringPtr(cgPath)
+	cgReq.DestinationPath = common.StringPtr(destPath)
+	cgReq.LockTimeoutInSeconds = common.Int32Ptr(cgLockTimeout) // this is the message redelivery timeout
+	cgReq.MaxDeliveryCount = common.Int32Ptr(cgMaxDeliveryCount)
+	cgReq.OwnerEmail = common.StringPtr("consumer_integration_test@uber.com")
+
+	cgDesc, err := cheramiClient.CreateConsumerGroup(cgReq)
+	s.NoError(err)
+	s.NotNil(cgDesc)
+
+	cConsumerReq := &client.CreateConsumerRequest{
+		Path:              destPath,
+		ConsumerGroupName: cgPath,
+		ConsumerName:      "consumerName",
+		PrefetchCount:     cnsmrPrefetch,
+		Options:           &client.ClientOptions{Timeout: time.Second * 30}, // this is the thrift context timeout
+	}
+
+	consumerTest := cheramiClient.CreateConsumer(cConsumerReq)
+	s.NotNil(consumerTest)
+
+	// Open the consumer channel
+	delivery := make(chan client.Delivery, 1)
+	delivery, err = consumerTest.Open(delivery)
+	s.NoError(err)
+
+	beforeMergeDLQDeliveryCount := -1
+	testStartTime := time.Now()
+
+	// Read the messages in a loop.
+readLoop:
+	for msgCount := 0; ; {
+		select {
+		case msg := <-delivery:
+			msgCount++
+			msgID, _ := strconv.Atoi(string(msg.GetMessage().GetPayload().GetData()[4:]))
+			var ack, poison, merged bool
+
+			msgDecorator := `  `
+			if msgID > DLQMessageStart && msgID%DLQMessageSpacing == 0 {
+				msgDecorator = `* ` // DLQ Message
+				poison = true
+				if msgID < DLQMessageStart+beforeMergeDLQDeliveryCount*DLQMessageSpacing {
+					merged = true
+					msgDecorator = `*M` // DLQ Message, and was likely merged
+				}
+			}
+
+			lll("msgId %3d %s dlqDvlry=%3d (merged %2d, last %-12s), health = %d",
+				msgID,
+				msgDecorator,
+				getDLQDeliveryCount(),
+				beforeMergeDLQDeliveryCount,
+				common.UnixNanoTime(time.Since(getDLQDeliveryTime())).ToSecondsFmt(),
+				getCurrentHealth())
+
+			if time.Since(testStartTime) > testTimeout {
+				s.Fail("This test should complete quickly")
+				break
+			}
+
+			switch phase {
+			case produceDLQ: // Normal consumption with some selected 'poison' message. This is dilute poison going to DLQ
+				if !poison {
+					ack = true
+				}
+				s.NotEqual(getCurrentHealth(), stateStalled)
+				if getDLQDeliveryCount() >= DLQMergeMessageTargetCount { // Produced enough DLQ, move on
+					phase++
+				}
+			case smartRetryProvoke1: // Provoke smart retry by NACKing everything
+				if getCurrentHealth() == stateStalled {
+					phase++
+				}
+			case mergeOp: // Now in smart retry, perform the merge, wait for it to come into effect; transition to healthy state by acking
+				beforeMergeDLQDeliveryCount = getDLQDeliveryCount()
+				phaseOnce[phase].Do(func() { go merge() }) // Perform the merge once, asychronously
+
+				if merged {
+					s.True(poison) // This is just an assertion/sanity check
+					if getCurrentHealth() == stateProgressing {
+						phase++
+					}
+				} else {
+					// ACK all messages until we see something get merged; this halts DLQ production
+					ack = true
+				}
+			case smartRetryProvoke3:
+				phaseOnce[phase].Do(func() { lll("smartRetryProvoke3") })
+
+				// We will transition from healthy to stalled by NACKing in this phase
+				s.False(getCurrentHealth() == stateIdle)
+				if getCurrentHealth() == stateStalled {
+					phase++
+				}
+			case smartRetryProvoke4:
+				phaseOnce[phase].Do(func() {
+					lll("smartRetryProvoke4")
+					atomic.StoreInt64(&curPubInterval, int64(publisherPubSlowInterval)) // Slow down the publisher so that we can finish faster
+				})
+
+				// Since we are merging, the indicated state is stalled, but smart retry is disabled until the merge completes
+				s.Equal(getCurrentHealth(), stateStalled, `While NACKING, indicated state should be stalled`)
+
+				if getDLQDeliveryCount() > beforeMergeDLQDeliveryCount*2 && // Verify that we've published enough to DLQ since the merge
+					time.Since(getDLQDeliveryTime()) > mergeAssumedCompleteTime { // Verify that we are done DLQ publishing (i.e. transitioned to normal smart retry behavior)
+					phase++
+				}
+			case done:
+				phaseOnce[phase].Do(func() { lll("done") })
+				ack = true
+				if getCurrentHealth() == stateProgressing { // Verify that we can get back to fully normal health
+					break readLoop
+				}
+			}
+
+			if ack {
+				msg.Ack()
+			} else {
+				msg.Nack()
+			}
+		}
+	}
 }
 
 func (s *NetIntegrationSuiteParallelA) _TestSmartRetry() {


### PR DESCRIPTION

This change adds product code and tests to automatically disable smart retry when a DLQ merge is in progress.

Key pieces:
- Change to cgCache to lookup single CG visibility, and calculate whether DLQ is merging
- Change to isStalled to disable smart retry when the dlqMerging flag is set
- Test that verifies a complete dlq merge cycle, runtime 70s (100s w/ race)
- Small fix on consConnection to fix metrics spamming that I noticed during testing
- Fix for a race in logPumpHealth