### PR TITLE
RetMgr: handle empty extents correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,10 @@ cherami-replicator-tool: $(DEPS)
 cherami-cassandra-tool: $(DEPS)
 	go build -i -o cherami-cassandra-tool cmd/tools/cassandra/main.go
 
-bins: cherami-server cherami-replicator-server cherami-cli cherami-admin cherami-replicator-tool cherami-cassandra-tool
+cherami-store-tool: $(DEPS)
+	go build -i $(EMBED) -o cherami-store-tool cmd/tools/store/main.go
+
+bins: cherami-server cherami-replicator-server cherami-cli cherami-admin cherami-replicator-tool cherami-cassandra-tool cherami-store-tool
 
 cover_profile: bins
 	@echo Testing packages:

--- a/clients/metadata/metadata_cassandra.go
+++ b/clients/metadata/metadata_cassandra.go
@@ -687,19 +687,19 @@ func (s *CassandraMetadataService) UpdateDestination(ctx thrift.Context, updateR
 	}
 
 	// Note: if we add a new updatable property here, we also need to update the metadataReconciler in replicator to do reconcilation
-	if updateRequest.Status == nil {
+	if !updateRequest.IsSetStatus() {
 		updateRequest.Status = common.InternalDestinationStatusPtr(existing.GetStatus())
 	}
-	if updateRequest.ConsumedMessagesRetention == nil {
+	if !updateRequest.IsSetConsumedMessagesRetention() {
 		updateRequest.ConsumedMessagesRetention = common.Int32Ptr(existing.GetConsumedMessagesRetention())
 	}
-	if updateRequest.UnconsumedMessagesRetention == nil {
+	if !updateRequest.IsSetUnconsumedMessagesRetention() {
 		updateRequest.UnconsumedMessagesRetention = common.Int32Ptr(existing.GetUnconsumedMessagesRetention())
 	}
-	if updateRequest.OwnerEmail == nil {
+	if !updateRequest.IsSetOwnerEmail() {
 		updateRequest.OwnerEmail = common.StringPtr(existing.GetOwnerEmail())
 	}
-	if updateRequest.ChecksumOption == nil {
+	if !updateRequest.IsSetChecksumOption() {
 		updateRequest.ChecksumOption = common.InternalChecksumOptionPtr(existing.GetChecksumOption())
 	}
 	batch := s.session.NewBatch(gocql.LoggedBatch) // Consider switching to unlogged
@@ -755,11 +755,21 @@ func (s *CassandraMetadataService) UpdateDestination(ctx thrift.Context, updateR
 		time.Now(),
 		marshalRequest(updateRequest))
 
-	existing.Status = common.InternalDestinationStatusPtr(updateRequest.GetStatus())
-	existing.ConsumedMessagesRetention = common.Int32Ptr(updateRequest.GetConsumedMessagesRetention())
-	existing.UnconsumedMessagesRetention = common.Int32Ptr(updateRequest.GetUnconsumedMessagesRetention())
-	existing.OwnerEmail = common.StringPtr(updateRequest.GetOwnerEmail())
-	existing.ChecksumOption = common.InternalChecksumOptionPtr(updateRequest.GetChecksumOption())
+	if updateRequest.IsSetStatus() {
+		existing.Status = common.InternalDestinationStatusPtr(updateRequest.GetStatus())
+	}
+	if updateRequest.IsSetConsumedMessagesRetention() {
+		existing.ConsumedMessagesRetention = common.Int32Ptr(updateRequest.GetConsumedMessagesRetention())
+	}
+	if updateRequest.IsSetUnconsumedMessagesRetention() {
+		existing.UnconsumedMessagesRetention = common.Int32Ptr(updateRequest.GetUnconsumedMessagesRetention())
+	}
+	if updateRequest.IsSetOwnerEmail() {
+		existing.OwnerEmail = common.StringPtr(updateRequest.GetOwnerEmail())
+	}
+	if updateRequest.IsSetChecksumOption() {
+		existing.ChecksumOption = common.InternalChecksumOptionPtr(updateRequest.GetChecksumOption())
+	}
 	return existing, nil
 }
 

--- a/cmd/tools/admin/main.go
+++ b/cmd/tools/admin/main.go
@@ -43,7 +43,7 @@ func main() {
 	})
 	app.Name = "cherami"
 	app.Usage = "A command-line tool for cherami developer, including debugging tool"
-	app.Version = "1.1"
+	app.Version = "1.1.1"
 	app.Flags = []cli.Flag{
 		cli.BoolTFlag{
 			Name:  "hyperbahn",
@@ -56,8 +56,8 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "env",
-			Value: "",
-			Usage: "env to connect. By default connects to prod, use \"staging\" to connect to staging",
+			Value: "staging",
+			Usage: "env to connect. By default connects to staging, use \"prod\" to connect to production",
 		},
 		cli.StringFlag{
 			Name:   "hyperbahn_bootstrap_file, hbfile",

--- a/cmd/tools/cli/main.go
+++ b/cmd/tools/cli/main.go
@@ -53,7 +53,7 @@ func main() {
 	})
 	app.Name = "cherami"
 	app.Usage = "A command-line tool for cherami users"
-	app.Version = "1.1.5"
+	app.Version = "1.1.6"
 	app.Flags = []cli.Flag{
 		cli.BoolTFlag{
 			Name:  "hyperbahn",

--- a/cmd/tools/cli/main.go
+++ b/cmd/tools/cli/main.go
@@ -53,7 +53,7 @@ func main() {
 	})
 	app.Name = "cherami"
 	app.Usage = "A command-line tool for cherami users"
-	app.Version = "1.1.6"
+	app.Version = "1.1.7"
 	app.Flags = []cli.Flag{
 		cli.BoolTFlag{
 			Name:  "hyperbahn",

--- a/cmd/tools/store/main.go
+++ b/cmd/tools/store/main.go
@@ -33,7 +33,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "store-tool"
 	app.Usage = "A command-line tool for storage debugging"
-	app.Version = "1.0"
+	app.Version = "1.0.1"
 	app.Flags = []cli.Flag{
 		cli.BoolTFlag{
 			Name:  "hyperbahn",
@@ -46,8 +46,8 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "env",
-			Value: "",
-			Usage: "env to connect. By default connects to prod, use \"staging\" to connect to staging",
+			Value: "staging",
+			Usage: "env to connect. By default connects to staging, use \"prod\" to connect to production",
 		},
 		cli.StringFlag{
 			Name:   "hyperbahn_bootstrap_file, hbfile",

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -721,6 +721,8 @@ const (
 	OutputhostCGMessageSentNAck
 	// OutputhostCGMessagesThrottled records the count of messages throttled
 	OutputhostCGMessagesThrottled
+	// OutputhostCGAckMgrSeqNotFound is the gauge to track acks whose seq number is not found
+	OutputhostCGAckMgrSeqNotFound
 	// OutputhostCGMessageSentLatency is the latency to send a message
 	OutputhostCGMessageSentLatency
 	//OutputhostCGMessageCacheSize is the cashe size of consumer group message
@@ -745,8 +747,6 @@ const (
 	OutputhostCGAckMgrResetMsgError
 	// OutputhostCGSkippedMessages is the gauge to track skipped messages
 	OutputhostCGSkippedMessages
-	// OutputhostCGAckMgrSeqNotFound is the gauge to track acks whose seq number is not found
-	OutputhostCGAckMgrSeqNotFound
 	// OutputhostCGCreditsAccumulated is a gauge to record credits that are accumulated locally per consumer group
 	OutputhostCGCreditsAccumulated
 
@@ -1123,6 +1123,7 @@ var dynamicMetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		OutputhostCGMessageSentAck:        {Counter, "outputhost.message.sent-ack.cg"},
 		OutputhostCGMessageSentNAck:       {Counter, "outputhost.message.sent-nack.cg"},
 		OutputhostCGMessagesThrottled:     {Counter, "outputhost.message.throttled"},
+		OutputhostCGAckMgrSeqNotFound:     {Counter, "outputhost.ackmgr.seq-not-found.cg"},
 		OutputhostCGMessageSentLatency:    {Timer, "outputhost.message.sent-latency.cg"},
 		OutputhostCGMessageCacheSize:      {Gauge, "outputhost.message.cache.size.cg"},
 		OutputhostCGConsConnection:        {Gauge, "outputhost.consconnection.cg"},
@@ -1135,7 +1136,6 @@ var dynamicMetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		OutputhostCGAckMgrResetMsg:        {Gauge, "outputhost.ackmgr.reset.message.cg"},
 		OutputhostCGAckMgrResetMsgError:   {Gauge, "outputhost.ackmgr.reset.message.error.cg"},
 		OutputhostCGSkippedMessages:       {Gauge, "outputhost.skipped.messages.cg"},
-		OutputhostCGAckMgrSeqNotFound:     {Gauge, "outputhost.ackmgr.seq-not-found.cg"},
 		OutputhostCGCreditsAccumulated:    {Gauge, "outputhost.credit-accumulated.cg"},
 	},
 

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -699,6 +699,8 @@ const (
 	OutputhostInternalFailures
 	// OutputhostConsConnection is the number of active connections
 	OutputhostConsConnection
+	// OutputhostCreditsAccumulated is a gauge to record credits that are accumulated locally
+	OutputhostCreditsAccumulated
 	// OutputhostLatencyTimer represents time taken by an operation
 	OutputhostLatencyTimer
 	// OutputhostCGMessageSent records the count of messages sent per consumer group
@@ -743,6 +745,10 @@ const (
 	OutputhostCGAckMgrResetMsgError
 	// OutputhostCGSkippedMessages is the gauge to track skipped messages
 	OutputhostCGSkippedMessages
+	// OutputhostCGAckMgrSeqNotFound is the gauge to track acks whose seq number is not found
+	OutputhostCGAckMgrSeqNotFound
+	// OutputhostCGCreditsAccumulated is a gauge to record credits that are accumulated locally per consumer group
+	OutputhostCGCreditsAccumulated
 
 	// -- Frontend metrics -- //
 
@@ -991,6 +997,7 @@ var metricDefs = map[ServiceIdx]map[int]metricDefinition{
 		OutputhostUserFailures:                          {Counter, "outputhost.user-errors"},
 		OutputhostInternalFailures:                      {Counter, "outputhost.internal-errors"},
 		OutputhostConsConnection:                        {Gauge, "outputhost.consconnection"},
+		OutputhostCreditsAccumulated:                    {Gauge, "outputhost.credit-accumulated"},
 		OutputhostLatencyTimer:                          {Timer, "outputhost.latency"},
 	},
 
@@ -1128,6 +1135,8 @@ var dynamicMetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		OutputhostCGAckMgrResetMsg:        {Gauge, "outputhost.ackmgr.reset.message.cg"},
 		OutputhostCGAckMgrResetMsgError:   {Gauge, "outputhost.ackmgr.reset.message.error.cg"},
 		OutputhostCGSkippedMessages:       {Gauge, "outputhost.skipped.messages.cg"},
+		OutputhostCGAckMgrSeqNotFound:     {Gauge, "outputhost.ackmgr.seq-not-found.cg"},
+		OutputhostCGCreditsAccumulated:    {Gauge, "outputhost.credit-accumulated.cg"},
 	},
 
 	// definitions for Controller metrics

--- a/common/util.go
+++ b/common/util.go
@@ -613,6 +613,15 @@ func (r *cliHelper) GetDefaultOwnerEmail() string {
 // GetCanonicalZone is the implementation of the corresponding method
 func (r *cliHelper) GetCanonicalZone(zone string) (cZone string, err error) {
 	var ok bool
+	if len(zone) == 0 {
+		return "", errors.New("Invalid Zone Name")
+	}
+
+	// If canonical zone list is empty, then any zone is valid
+	if len(r.cZones) == 0 {
+		return zone, nil
+	}
+
 	if cZone, ok = r.cZones[zone]; !ok {
 		return "", errors.New("Invalid Zone Name")
 	}

--- a/services/frontendhost/frontend.go
+++ b/services/frontendhost/frontend.go
@@ -238,11 +238,21 @@ func convertCreateDestRequestToInternal(createRequest *c.CreateDestinationReques
 func convertUpdateDestRequestToInternal(updateRequest *c.UpdateDestinationRequest, destUUID string) *shared.UpdateDestinationRequest {
 	internalUpdateRequest := shared.NewUpdateDestinationRequest()
 	internalUpdateRequest.DestinationUUID = common.StringPtr(destUUID)
-	internalUpdateRequest.Status = common.InternalDestinationStatusPtr(shared.DestinationStatus(updateRequest.GetStatus()))
-	internalUpdateRequest.ConsumedMessagesRetention = common.Int32Ptr(updateRequest.GetConsumedMessagesRetention())
-	internalUpdateRequest.UnconsumedMessagesRetention = common.Int32Ptr(updateRequest.GetUnconsumedMessagesRetention())
-	internalUpdateRequest.OwnerEmail = common.StringPtr(updateRequest.GetOwnerEmail())
-	internalUpdateRequest.ChecksumOption = common.InternalChecksumOptionPtr(shared.ChecksumOption(updateRequest.GetChecksumOption()))
+	if updateRequest.IsSetStatus() {
+		internalUpdateRequest.Status = common.InternalDestinationStatusPtr(shared.DestinationStatus(updateRequest.GetStatus()))
+	}
+	if updateRequest.IsSetConsumedMessagesRetention() {
+		internalUpdateRequest.ConsumedMessagesRetention = common.Int32Ptr(updateRequest.GetConsumedMessagesRetention())
+	}
+	if updateRequest.IsSetUnconsumedMessagesRetention() {
+		internalUpdateRequest.UnconsumedMessagesRetention = common.Int32Ptr(updateRequest.GetUnconsumedMessagesRetention())
+	}
+	if updateRequest.IsSetOwnerEmail() {
+		internalUpdateRequest.OwnerEmail = common.StringPtr(updateRequest.GetOwnerEmail())
+	}
+	if updateRequest.IsSetChecksumOption() {
+		internalUpdateRequest.ChecksumOption = common.InternalChecksumOptionPtr(shared.ChecksumOption(updateRequest.GetChecksumOption()))
+	}
 	return internalUpdateRequest
 }
 

--- a/services/outputhost/ackmanager.go
+++ b/services/outputhost/ackmanager.go
@@ -382,7 +382,8 @@ func (ackMgr *ackManager) acknowledgeMessage(ackID AckID, seqNum uint32, address
 			}
 		}
 	} else {
-		ackMgr.logger.WithField(common.TagSeq, seqNum).Error(`seqNum of acked msg not found!`)
+		// Update metric to reflect that the sequence number is not found
+		ackMgr.cgCache.consumerM3Client.UpdateGauge(metrics.ConsConnectionScope, metrics.OutputhostCGAckMgrSeqNotFound, 1)
 	}
 	ackMgr.lk.Unlock()
 

--- a/services/outputhost/ackmanager.go
+++ b/services/outputhost/ackmanager.go
@@ -383,7 +383,7 @@ func (ackMgr *ackManager) acknowledgeMessage(ackID AckID, seqNum uint32, address
 		}
 	} else {
 		// Update metric to reflect that the sequence number is not found
-		ackMgr.cgCache.consumerM3Client.UpdateGauge(metrics.ConsConnectionScope, metrics.OutputhostCGAckMgrSeqNotFound, 1)
+		ackMgr.cgCache.consumerM3Client.IncCounter(metrics.ConsConnectionScope, metrics.OutputhostCGAckMgrSeqNotFound)
 	}
 	ackMgr.lk.Unlock()
 

--- a/services/outputhost/cgcache.go
+++ b/services/outputhost/cgcache.go
@@ -445,7 +445,7 @@ func (cgCache *consumerGroupCache) manageConsumerGroupCache() {
 }
 
 // refreshCgCacheNoLock is a routine which is called without the extMutex held.
-// It takes the mutex and in turn refreshes the cg by contactingmetadata to
+// It takes the mutex and in turn refreshes the cg by contacting metadata to
 // get all the open extents and then loads them if needed
 func (cgCache *consumerGroupCache) refreshCgCacheNoLock(ctx thrift.Context) error {
 	cgCache.extMutex.Lock()

--- a/services/outputhost/consconnection.go
+++ b/services/outputhost/consconnection.go
@@ -168,8 +168,9 @@ func (conn *consConnection) sendCreditsToWritePump(localCredits *int32) {
 	default:
 		// If we cannot send the credits at this time, just accumulate it
 		// but don't reset the counter
-		conn.logger.WithField(`localCredits`, *localCredits).
-			Info("unable to send credits to write pump; accumulating locally")
+		// update M3 to record this
+		conn.cgCache.m3Client.UpdateGauge(metrics.ConsConnectionStreamScope, metrics.OutputhostCreditsAccumulated, int64(*localCredits))
+		conn.cgCache.consumerM3Client.UpdateGauge(metrics.ConsConnectionScope, metrics.OutputhostCGCreditsAccumulated, int64(*localCredits))
 	}
 
 }

--- a/services/outputhost/outputhost.go
+++ b/services/outputhost/outputhost.go
@@ -596,10 +596,16 @@ func (h *OutputHost) ConsumerGroupsUpdated(ctx thrift.Context, request *admin.Co
 				// Notify the client
 				cg.reconfigureClients(updateUUID)
 			case admin.NotificationType_HOST:
-				_, intErr = h.loadCGCache(ctx, ok, cg)
+				// just refresh the cg directly.
+				// at this point cg is already loaded
+				intErr = cg.refreshCgCacheNoLock(ctx)
 			case admin.NotificationType_ALL:
-				_, intErr = h.loadCGCache(ctx, ok, cg)
-				cg.reconfigureClients(updateUUID)
+				// just refresh the cg directly.
+				// at this point cg is already loaded
+				intErr = cg.refreshCgCacheNoLock(ctx)
+				if intErr == nil {
+					cg.reconfigureClients(updateUUID)
+				}
 			default:
 				h.logger.WithFields(bark.Fields{
 					common.TagCnsm:       common.FmtCnsm(cgUUID),

--- a/services/retentionmgr/metadataDep.go
+++ b/services/retentionmgr/metadataDep.go
@@ -397,12 +397,15 @@ func (t *metadataDepImpl) GetAckLevel(destID destinationID, extID extentID, cgID
 	switch resp.GetExtent().GetStatus() {
 
 	case metadata.ConsumerGroupExtentStatus_OPEN:
+		// return the ack-level from metadata
 		ackLevel = resp.GetExtent().GetAckLevelOffset()
 
 	case metadata.ConsumerGroupExtentStatus_CONSUMED:
+		// 'ADDR_SEAL' indicates to the caller that this CG has fully consumed the extent
 		ackLevel = store.ADDR_SEAL
 
 	case metadata.ConsumerGroupExtentStatus_DELETED:
+		// set to 'ADDR_BEGIN' if cg-extent is deleted
 		ackLevel = store.ADDR_BEGIN
 
 	default:

--- a/services/retentionmgr/retention.go
+++ b/services/retentionmgr/retention.go
@@ -483,6 +483,9 @@ func (t *RetentionManager) computeRetention(job *retentionJob, log bark.Logger) 
 		}
 	}
 
+	// isRemoteZoneExtent is set if the extent is a remote multi-zone extent
+	var isRemoteZoneExtent = dest.isMultiZone && !common.IsRemoteZoneExtent(ext.originZone, t.Options.LocalZone)
+
 	// -- step 1: take a snapshot of the current time and compute retention timestamps -- //
 
 	tNow := time.Now().UnixNano()
@@ -601,12 +604,15 @@ func (t *RetentionManager) computeRetention(job *retentionJob, log bark.Logger) 
 		}
 	}
 
-	// If this is a multi_zone destination and local extent, disable soft retention
-	// The reason is if soft retention is very short, we may delete messages before remote zone has a chance to replicate the messages
-	// Long term solution should create a fake consumer for the remote zone
+	// If this is a multi_zone destination and local extent, disable soft retention -- and fall
+	// back to using only hard-retention. The reason is if soft retention is very short, we may
+	// delete messages before remote zone has a chance to replicate the messages Long term solution
+	// should create a fake consumer for the remote zone.
+	// Note: we also move the extent to the "consumed" state only based on hard-retention.
 	if dest.isMultiZone && !common.IsRemoteZoneExtent(ext.originZone, t.Options.LocalZone) {
 		log.Info(`overridden: soft retention overridden for multi_zone extent`)
 		softRetentionAddr = int64(store.ADDR_BEGIN)
+		softRetentionConsumed = false
 	}
 
 	log.WithFields(bark.Fields{
@@ -668,10 +674,14 @@ func (t *RetentionManager) computeRetention(job *retentionJob, log bark.Logger) 
 		}
 	}
 
-	// if we were unable to find any consumer groups, set minAckAddr to ADDR_BEGIN
+	// if we were unable to find any consumer groups, set minAckAddr to
+	// ADDR_BEGIN, effectively disabling soft-retention. that said, hard
+	// retention could still be enforced.
 	if minAckAddr == store.ADDR_END {
+
 		log.Debug("could not compute ackLevel, using 'ADDR_BEGIN'")
 		minAckAddr = store.ADDR_BEGIN
+		allHaveConsumed = false
 	}
 
 	job.minAckAddr = minAckAddr // remember the minAckAddr for doing checks later
@@ -704,11 +714,11 @@ func (t *RetentionManager) computeRetention(job *retentionJob, log bark.Logger) 
 	// -- step 6: check to see if the extent status can be updated to 'consumed' -- //
 
 	// move the extent to 'consumed' if the extent is "sealed" _and_ either:
-	// A. all of the following are true:
+	// A.
 	// 	1. the extent was fully consumed by all of the consumer groups
-	// 	2. a period of 'soft retention period' has passed (in other words,
-	// 	   a consumer that is consuming along the soft retention time has
-	//	   "consumed" the extent)
+	// 	2. and, a period of 'soft retention period' has passed (in other
+	//         words, a consumer that is consuming along the soft retention
+	//         time has "consumed" the extent)
 	// B. or, the hard-retention has reached the end of the sealed extent,
 	// 	in which case we will force the extent to be "consumed"
 	// NB: if there was an error querying either the hard/soft retention addresses,

--- a/services/retentionmgr/retention_test.go
+++ b/services/retentionmgr/retention_test.go
@@ -85,6 +85,9 @@ func (s *RetentionMgrSuite) TestRetentionManager() {
 	// DEST2,EXT8:
 	// DEST2,EXT9:
 	// DEST2,EXTA: test DeleteConsumerGroupExtent returns EntityNotExistsError
+	// DEST2,EXTE0: test extent that is 'active', but hardRetentionConsumed = true (should not move to 'consumed')
+	// DEST2,EXTE1: test extent that is 'sealed', but hardRetentionConsumed = true (should move to 'consumed')
+	// DEST2,EXTE2: test extent that is 'sealed', but softRetentionConsumed = true (should move to 'consumed')
 
 	softRetSecs, hardRetSecs := int32(10), int32(20)
 
@@ -126,6 +129,11 @@ func (s *RetentionMgrSuite) TestRetentionManager() {
 		"EXTB":  {"STOR2", "STOR3", "STOR4"},
 		"EXTC":  {"STOR2", "STOR4", "STOR6"},
 		"EXTD1": {"STOR2", "STOR4", "STOR6"},
+		"EXTE0": {"STOR2", "STOR3", "STOR4"},
+		"EXTE1": {"STOR2", "STOR3", "STOR4"},
+		"EXTE2": {"STOR2", "STOR3", "STOR4"},
+		"EXTE3": {"STOR2", "STOR3", "STOR4"},
+		"EXTE4": {"STOR2", "STOR3", "STOR4"},
 		"EXTm":  {"STOR3"}, // Single CG Visible
 		"EXTn":  {"STOR7"}, // Single CG Visible
 	}
@@ -148,6 +156,11 @@ func (s *RetentionMgrSuite) TestRetentionManager() {
 		"EXTC":  shared.ExtentStatus_OPEN,
 		"EXTD":  shared.ExtentStatus_SEALED,
 		"EXTD1": shared.ExtentStatus_SEALED,
+		"EXTE0": shared.ExtentStatus_OPEN,
+		"EXTE1": shared.ExtentStatus_SEALED,
+		"EXTE2": shared.ExtentStatus_SEALED,
+		"EXTE3": shared.ExtentStatus_SEALED,
+		"EXTE4": shared.ExtentStatus_SEALED,
 		"EXTm":  shared.ExtentStatus_SEALED, // Merged DLQ extents should always be sealed
 		"EXTn":  shared.ExtentStatus_SEALED, //
 	}
@@ -230,6 +243,11 @@ func (s *RetentionMgrSuite) TestRetentionManager() {
 		"EXTC":  {"STOR2": {addrHard, false}, "STOR4": {addrHard, false}, "STOR6": {addrHard, false}},
 		"EXTD":  {"STOR2": {addrHard, false}, "STOR4": {addrHard, false}, "STOR6": {addrHard, false}},
 		"EXTD1": {"STOR2": {addrHard, true}, "STOR4": {addrHard, false}, "STOR6": {addrHard, false}},
+		"EXTE0": {"STOR2": {addrBegin, false}, "STOR3": {addrBegin, true}, "STOR4": {addrBegin, false}},
+		"EXTE1": {"STOR2": {addrBegin, false}, "STOR3": {addrBegin, true}, "STOR4": {addrBegin, false}},
+		"EXTE2": {"STOR2": {addrBegin, false}, "STOR3": {addrBegin, false}, "STOR4": {addrBegin, false}},
+		"EXTE3": {"STOR2": {addrBegin, false}, "STOR3": {addrBegin, false}, "STOR4": {addrBegin, false}},
+		"EXTE4": {"STOR2": {addrBegin, false}, "STOR3": {addrBegin, false}, "STOR4": {addrBegin, false}},
 		"EXTm":  {"STOR3": {addrHard - 100, true}},
 		"EXTn":  {"STOR7": {addrHard - 100, true}},
 	}
@@ -253,6 +271,11 @@ func (s *RetentionMgrSuite) TestRetentionManager() {
 		"EXTC":  {"STOR2": {addrSoft, true}, "STOR4": {addrSoft, true}, "STOR6": {addrSoft, true}},
 		"EXTD":  {"STOR2": {addrSoft, true}, "STOR4": {addrSoft, true}, "STOR6": {addrSoft, true}},
 		"EXTD1": {"STOR2": {addrBegin, false}, "STOR4": {addrBegin, false}, "STOR6": {addrBegin, false}},
+		"EXTE0": {"STOR2": {addrBegin, false}, "STOR3": {addrBegin, false}, "STOR4": {addrBegin, false}},
+		"EXTE1": {"STOR2": {addrBegin, false}, "STOR3": {addrBegin, false}, "STOR4": {addrBegin, false}},
+		"EXTE2": {"STOR2": {addrBegin, false}, "STOR3": {addrBegin, false}, "STOR4": {addrBegin, true}},
+		"EXTE3": {"STOR2": {addrBegin, false}, "STOR3": {addrBegin, false}, "STOR4": {addrBegin, false}},
+		"EXTE4": {"STOR2": {addrBegin, false}, "STOR3": {addrBegin, false}, "STOR4": {addrBegin, true}},
 		"EXTm":  {"STOR3": {addrSoft, true}},
 		"EXTn":  {"STOR7": {addrSoft, true}},
 	}
@@ -275,6 +298,11 @@ func (s *RetentionMgrSuite) TestRetentionManager() {
 		"EXTC":  {"CGm": addrSeal, "CG1": addrSeal, "CG2": addrSeal, "CG3": addrSeal},
 		"EXTD":  {"CGm": addrSeal, "CG1": addrSeal, "CG2": addrSeal, "CG3": addrSeal},
 		"EXTD1": {"CGm": addrBegin, "CG1": addrBegin, "CG2": addrBegin, "CG3": addrBegin},
+		"EXTE0": {"CGm": addrBegin, "CG1": addrBegin, "CG2": addrBegin, "CG3": addrBegin},
+		"EXTE1": {"CGm": addrBegin, "CG1": addrBegin, "CG2": addrBegin, "CG3": addrBegin},
+		"EXTE2": {"CGm": addrBegin, "CG1": addrBegin, "CG2": addrBegin, "CG3": addrBegin},
+		"EXTE3": {"CGm": addrBegin, "CG1": addrBegin, "CG2": addrSeal, "CG3": addrBegin},
+		"EXTE4": {"CGm": addrSeal, "CG1": addrBegin, "CG2": addrBegin, "CG3": addrBegin},
 		"EXTm":  {"CGm": addrPostSoft},
 		"EXTn":  {"CGm": addrPreSoft},
 	}
@@ -303,6 +331,8 @@ func (s *RetentionMgrSuite) TestRetentionManager() {
 	s.metadata.On("MarkExtentConsumed", destinationID("DEST2"), extentID("EXTB")).Return(nil).Once()
 	s.metadata.On("MarkExtentConsumed", destinationID("DEST2"), extentID("EXTD")).Return(nil).Once()
 	s.metadata.On("MarkExtentConsumed", destinationID("DEST2"), extentID("EXTD1")).Return(nil).Once()
+	s.metadata.On("MarkExtentConsumed", destinationID("DEST2"), extentID("EXTE1")).Return(nil).Once()
+	s.metadata.On("MarkExtentConsumed", destinationID("DEST2"), extentID("EXTE4")).Return(nil).Once()
 	s.metadata.On("MarkExtentConsumed", destinationID("DEST2"), extentID("EXTm")).Return(nil).Once()
 	s.metadata.On("MarkExtentConsumed", destinationID("DEST2"), extentID("EXTn")).Return(nil).Once()
 
@@ -359,7 +389,7 @@ func (s *RetentionMgrSuite) TestRetentionManager() {
 	// retMgr.Start()
 	// retMgr.wait()
 
-	//s.metadata.AssertExpectations(s.T())
+	// s.metadata.AssertExpectations(s.T())
 }
 
 func (s *RetentionMgrSuite) TestRetentionManagerOnDeletedDestinations() {

--- a/tools/admin/lib.go
+++ b/tools/admin/lib.go
@@ -52,7 +52,8 @@ func CreateDestination(c *cli.Context, cliHelper common.CliHelper) {
 // UpdateDestination updates properties of a destination
 func UpdateDestination(c *cli.Context) {
 	cClient := toolscommon.GetCClient(c, adminToolService)
-	toolscommon.UpdateDestination(c, cClient)
+	mClient := toolscommon.GetMClient(c, adminToolService)
+	toolscommon.UpdateDestination(c, cClient, mClient)
 }
 
 // CreateConsumerGroup creates a consumer group

--- a/tools/cli/lib.go
+++ b/tools/cli/lib.go
@@ -44,8 +44,9 @@ func CreateDestination(c *cli.Context, cliHelper scommon.CliHelper) {
 
 // UpdateDestination updates the destination
 func UpdateDestination(c *cli.Context) {
+	mClient := common.GetMClient(c, serviceName)
 	cClient := common.GetCClient(c, serviceName)
-	common.UpdateDestination(c, cClient)
+	common.UpdateDestination(c, cClient, mClient)
 }
 
 // CreateConsumerGroup creates the CG

--- a/tools/common/lib.go
+++ b/tools/common/lib.go
@@ -90,8 +90,10 @@ var uuidRegex, _ = regexp.Compile(`^[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]
 // ExitIfError exit while err is not nil and print the calling stack also
 func ExitIfError(err error) {
 	const stacksEnv = `CHERAMI_SHOW_STACKS`
+	envReminder := "\n--env=staging is now the default. Did you mean '--env=prod' ?\n"
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
+		fmt.Fprintln(os.Stderr, envReminder)
 		if os.Getenv(stacksEnv) != `` {
 			debug.PrintStack()
 		} else {

--- a/tools/common/lib.go
+++ b/tools/common/lib.go
@@ -69,17 +69,20 @@ const (
 	DestinationType = "DST"
 	// ConsumerGroupType is the name for entity type for consumer group in listEntityOps
 	ConsumerGroupType = "CG"
+	// MinUnconsumedMessagesRetentionForMultiZoneDest is the minimum unconsumed retention allowed
+	MinUnconsumedMessagesRetentionForMultiZoneDest = 3 * 24 * 3600
 )
 
 const (
-	strNotEnoughArgs        = "Not enough arguments. Try \"--help\""
-	strNoChange             = "Update must update something. Try \"--help\""
-	strCGSpecIncorrectArgs  = "Incorrect consumer group specification. Use \"<cg_uuid>\" or \"<dest_path> <cg_name>\""
-	strDestStatus           = "Destination status must be \"enabled\", \"disabled\", \"sendonly\", or \"recvonly\""
-	strCGStatus             = "Consumer group status must be \"enabled\", or \"disabled\""
-	strWrongDestZoneConfig  = "Format of destination zone config is wrong, should be \"ZoneName,AllowPublish,AllowConsume,ReplicaCount\". For example: \"zone1,true,true,3\""
-	strWrongReplicaCount    = "Replica count must be within 1 to 3"
-	strWrongZoneConfigCount = "Multi zone destination must have at least 2 zone configs"
+	strNotEnoughArgs               = "Not enough arguments. Try \"--help\""
+	strNoChange                    = "Update must update something. Try \"--help\""
+	strCGSpecIncorrectArgs         = "Incorrect consumer group specification. Use \"<cg_uuid>\" or \"<dest_path> <cg_name>\""
+	strDestStatus                  = "Destination status must be \"enabled\", \"disabled\", \"sendonly\", or \"recvonly\""
+	strCGStatus                    = "Consumer group status must be \"enabled\", or \"disabled\""
+	strWrongDestZoneConfig         = "Format of destination zone config is wrong, should be \"ZoneName,AllowPublish,AllowConsume,ReplicaCount\". For example: \"zone1,true,true,3\""
+	strWrongReplicaCount           = "Replica count must be within 1 to 3"
+	strWrongZoneConfigCount        = "Multi zone destination must have at least 2 zone configs"
+	strUnconsumedRetentionTooSmall = "Unconsumed retention period for multi zone destination should be at least 3 days"
 )
 
 var uuidRegex, _ = regexp.Compile(`^[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}$`)
@@ -228,6 +231,13 @@ func CreateDestination(c *cli.Context, cClient ccli.Client, cliHelper common.Cli
 		ExitIfError(errors.New(strWrongZoneConfigCount))
 	}
 
+	// don't allow short unconsumed message retention for multi_zone destination
+	// this is a prevention mechanism to prevent messages from being deleted in source zone in case there's some
+	// issue with cross zone replication(for example, network down between zones)
+	if len(zoneConfigs.Configs) > 1 && unconsumedMessagesRetention < MinUnconsumedMessagesRetentionForMultiZoneDest {
+		ExitIfError(errors.New(strUnconsumedRetentionTooSmall))
+	}
+
 	desc, err := cClient.CreateDestination(&cherami.CreateDestinationRequest{
 		Path: &path,
 		Type: &dType,
@@ -244,7 +254,7 @@ func CreateDestination(c *cli.Context, cClient ccli.Client, cliHelper common.Cli
 }
 
 // UpdateDestination update destination based on cli
-func UpdateDestination(c *cli.Context, cClient ccli.Client) {
+func UpdateDestination(c *cli.Context, cClient ccli.Client, mClient mcli.Client) {
 	if len(c.Args()) < 1 {
 		ExitIfError(errors.New(strNotEnoughArgs))
 	}
@@ -263,6 +273,19 @@ func UpdateDestination(c *cli.Context, cClient ccli.Client) {
 	default:
 		if c.IsSet(`status`) {
 			ExitIfError(errors.New(strDestStatus))
+		}
+	}
+
+	// don't allow short unconsumed message retention for multi_zone destination
+	// this is a prevention mechanism to prevent messages from being deleted in source zone in case there's some
+	// issue with cross zone replication(for example, network down between zones)
+	if c.IsSet(`unconsumed_messages_retention`) && int32(c.Int(`unconsumed_messages_retention`)) < MinUnconsumedMessagesRetentionForMultiZoneDest {
+		desc, err := mClient.ReadDestination(&metadata.ReadDestinationRequest{
+			Path: &path,
+		})
+		ExitIfError(err)
+		if desc.GetIsMultiZone() {
+			ExitIfError(errors.New(strUnconsumedRetentionTooSmall))
 		}
 	}
 
@@ -403,17 +426,19 @@ func UnloadConsumerGroup(c *cli.Context, mClient mcli.Client) {
 }
 
 type destDescJSONOutputFields struct {
-	Path                        string                   `json:"path"`
-	UUID                        string                   `json:"uuid"`
-	Status                      shared.DestinationStatus `json:"status"`
-	Type                        shared.DestinationType   `json:"type"`
-	ChecksumOption              string                   `json:"checksum_option"`
-	OwnerEmail                  string                   `json:"owner_email"`
-	ConsumedMessagesRetention   int32                    `json:"consumed_messages_retention"`
-	UnconsumedMessagesRetention int32                    `json:"unconsumed_messages_retention"`
-	DLQCGUUID                   string                   `json:"dlq_cg_uuid"`
-	DLQPurgeBefore              int64                    `json:"dlq_purge_before"`
-	DLQMergeBefore              int64                    `json:"dlq_merge_before"`
+	Path                        string                          `json:"path"`
+	UUID                        string                          `json:"uuid"`
+	Status                      shared.DestinationStatus        `json:"status"`
+	Type                        shared.DestinationType          `json:"type"`
+	ChecksumOption              string                          `json:"checksum_option"`
+	OwnerEmail                  string                          `json:"owner_email"`
+	ConsumedMessagesRetention   int32                           `json:"consumed_messages_retention"`
+	UnconsumedMessagesRetention int32                           `json:"unconsumed_messages_retention"`
+	DLQCGUUID                   string                          `json:"dlq_cg_uuid"`
+	DLQPurgeBefore              int64                           `json:"dlq_purge_before"`
+	DLQMergeBefore              int64                           `json:"dlq_merge_before"`
+	IsMultiZone                 bool                            `json:"is_multi_zone"`
+	ZoneConfigs                 []*shared.DestinationZoneConfig `json:"zone_configs"`
 }
 
 func printDest(dest *shared.DestinationDescription) {
@@ -428,6 +453,8 @@ func printDest(dest *shared.DestinationDescription) {
 		DLQCGUUID:                   dest.GetDLQConsumerGroupUUID(),
 		DLQPurgeBefore:              dest.GetDLQPurgeBefore(),
 		DLQMergeBefore:              dest.GetDLQMergeBefore(),
+		IsMultiZone:                 dest.GetIsMultiZone(),
+		ZoneConfigs:                 dest.GetZoneConfigs(),
 	}
 
 	switch dest.GetChecksumOption() {
@@ -670,18 +697,20 @@ func PurgeDLQForConsumerGroup(c *cli.Context, cClient ccli.Client) {
 }
 
 type destJSONOutputFields struct {
-	DestinationName             string                   `json:"destination_name"`
-	DestinationUUID             string                   `json:"destination_uuid"`
-	Status                      shared.DestinationStatus `json:"status"`
-	Type                        shared.DestinationType   `json:"type"`
-	OwnerEmail                  string                   `json:"owner_email"`
-	TotalExts                   int                      `json:"total_ext"`
-	OpenExts                    int                      `json:"open"`
-	SealedExts                  int                      `json:"sealed"`
-	ConsumedExts                int                      `json:"consumed"`
-	DeletedExts                 int                      `json:"Deleted"`
-	ConsumedMessagesRetention   int32                    `json:"consumed_messages_retention"`
-	UnconsumedMessagesRetention int32                    `json:"unconsumed_messages_retention"`
+	DestinationName             string                          `json:"destination_name"`
+	DestinationUUID             string                          `json:"destination_uuid"`
+	Status                      shared.DestinationStatus        `json:"status"`
+	Type                        shared.DestinationType          `json:"type"`
+	OwnerEmail                  string                          `json:"owner_email"`
+	TotalExts                   int                             `json:"total_ext"`
+	OpenExts                    int                             `json:"open"`
+	SealedExts                  int                             `json:"sealed"`
+	ConsumedExts                int                             `json:"consumed"`
+	DeletedExts                 int                             `json:"Deleted"`
+	ConsumedMessagesRetention   int32                           `json:"consumed_messages_retention"`
+	UnconsumedMessagesRetention int32                           `json:"unconsumed_messages_retention"`
+	IsMultiZone                 bool                            `json:"is_multi_zone"`
+	ZoneConfigs                 []*shared.DestinationZoneConfig `json:"zone_configs"`
 }
 
 func matchDestStatus(status string, wantStatus shared.DestinationStatus) bool {
@@ -851,6 +880,8 @@ func ListDestinations(c *cli.Context, mClient mcli.Client) {
 					DeletedExts:                 nDeleted,
 					ConsumedMessagesRetention:   desc.GetConsumedMessagesRetention(),
 					UnconsumedMessagesRetention: desc.GetUnconsumedMessagesRetention(),
+					IsMultiZone:                 desc.GetIsMultiZone(),
+					ZoneConfigs:                 desc.GetZoneConfigs(),
 				}
 				destsInfo[status] = append(destsInfo[status], outputDest)
 			}


### PR DESCRIPTION
The change fixes the issue with retention-manager where it fails to move empty, sealed extents into "consumed" (and "deleted") states.