### PR TITLE
Miscellaneous improvements on outputhost

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -721,6 +721,8 @@ const (
 	OutputhostCGMessageSentNAck
 	// OutputhostCGMessagesThrottled records the count of messages throttled
 	OutputhostCGMessagesThrottled
+	// OutputhostCGAckMgrSeqNotFound is the gauge to track acks whose seq number is not found
+	OutputhostCGAckMgrSeqNotFound
 	// OutputhostCGMessageSentLatency is the latency to send a message
 	OutputhostCGMessageSentLatency
 	//OutputhostCGMessageCacheSize is the cashe size of consumer group message
@@ -745,8 +747,6 @@ const (
 	OutputhostCGAckMgrResetMsgError
 	// OutputhostCGSkippedMessages is the gauge to track skipped messages
 	OutputhostCGSkippedMessages
-	// OutputhostCGAckMgrSeqNotFound is the gauge to track acks whose seq number is not found
-	OutputhostCGAckMgrSeqNotFound
 	// OutputhostCGCreditsAccumulated is a gauge to record credits that are accumulated locally per consumer group
 	OutputhostCGCreditsAccumulated
 
@@ -1123,6 +1123,7 @@ var dynamicMetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		OutputhostCGMessageSentAck:        {Counter, "outputhost.message.sent-ack.cg"},
 		OutputhostCGMessageSentNAck:       {Counter, "outputhost.message.sent-nack.cg"},
 		OutputhostCGMessagesThrottled:     {Counter, "outputhost.message.throttled"},
+		OutputhostCGAckMgrSeqNotFound:     {Counter, "outputhost.ackmgr.seq-not-found.cg"},
 		OutputhostCGMessageSentLatency:    {Timer, "outputhost.message.sent-latency.cg"},
 		OutputhostCGMessageCacheSize:      {Gauge, "outputhost.message.cache.size.cg"},
 		OutputhostCGConsConnection:        {Gauge, "outputhost.consconnection.cg"},
@@ -1135,7 +1136,6 @@ var dynamicMetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		OutputhostCGAckMgrResetMsg:        {Gauge, "outputhost.ackmgr.reset.message.cg"},
 		OutputhostCGAckMgrResetMsgError:   {Gauge, "outputhost.ackmgr.reset.message.error.cg"},
 		OutputhostCGSkippedMessages:       {Gauge, "outputhost.skipped.messages.cg"},
-		OutputhostCGAckMgrSeqNotFound:     {Gauge, "outputhost.ackmgr.seq-not-found.cg"},
 		OutputhostCGCreditsAccumulated:    {Gauge, "outputhost.credit-accumulated.cg"},
 	},
 

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -699,6 +699,8 @@ const (
 	OutputhostInternalFailures
 	// OutputhostConsConnection is the number of active connections
 	OutputhostConsConnection
+	// OutputhostCreditsAccumulated is a gauge to record credits that are accumulated locally
+	OutputhostCreditsAccumulated
 	// OutputhostLatencyTimer represents time taken by an operation
 	OutputhostLatencyTimer
 	// OutputhostCGMessageSent records the count of messages sent per consumer group
@@ -743,6 +745,10 @@ const (
 	OutputhostCGAckMgrResetMsgError
 	// OutputhostCGSkippedMessages is the gauge to track skipped messages
 	OutputhostCGSkippedMessages
+	// OutputhostCGAckMgrSeqNotFound is the gauge to track acks whose seq number is not found
+	OutputhostCGAckMgrSeqNotFound
+	// OutputhostCGCreditsAccumulated is a gauge to record credits that are accumulated locally per consumer group
+	OutputhostCGCreditsAccumulated
 
 	// -- Frontend metrics -- //
 
@@ -991,6 +997,7 @@ var metricDefs = map[ServiceIdx]map[int]metricDefinition{
 		OutputhostUserFailures:                          {Counter, "outputhost.user-errors"},
 		OutputhostInternalFailures:                      {Counter, "outputhost.internal-errors"},
 		OutputhostConsConnection:                        {Gauge, "outputhost.consconnection"},
+		OutputhostCreditsAccumulated:                    {Gauge, "outputhost.credit-accumulated"},
 		OutputhostLatencyTimer:                          {Timer, "outputhost.latency"},
 	},
 
@@ -1128,6 +1135,8 @@ var dynamicMetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		OutputhostCGAckMgrResetMsg:        {Gauge, "outputhost.ackmgr.reset.message.cg"},
 		OutputhostCGAckMgrResetMsgError:   {Gauge, "outputhost.ackmgr.reset.message.error.cg"},
 		OutputhostCGSkippedMessages:       {Gauge, "outputhost.skipped.messages.cg"},
+		OutputhostCGAckMgrSeqNotFound:     {Gauge, "outputhost.ackmgr.seq-not-found.cg"},
+		OutputhostCGCreditsAccumulated:    {Gauge, "outputhost.credit-accumulated.cg"},
 	},
 
 	// definitions for Controller metrics

--- a/services/outputhost/ackmanager.go
+++ b/services/outputhost/ackmanager.go
@@ -382,7 +382,8 @@ func (ackMgr *ackManager) acknowledgeMessage(ackID AckID, seqNum uint32, address
 			}
 		}
 	} else {
-		ackMgr.logger.WithField(common.TagSeq, seqNum).Error(`seqNum of acked msg not found!`)
+		// Update metric to reflect that the sequence number is not found
+		ackMgr.cgCache.consumerM3Client.UpdateGauge(metrics.ConsConnectionScope, metrics.OutputhostCGAckMgrSeqNotFound, 1)
 	}
 	ackMgr.lk.Unlock()
 

--- a/services/outputhost/ackmanager.go
+++ b/services/outputhost/ackmanager.go
@@ -383,7 +383,7 @@ func (ackMgr *ackManager) acknowledgeMessage(ackID AckID, seqNum uint32, address
 		}
 	} else {
 		// Update metric to reflect that the sequence number is not found
-		ackMgr.cgCache.consumerM3Client.UpdateGauge(metrics.ConsConnectionScope, metrics.OutputhostCGAckMgrSeqNotFound, 1)
+		ackMgr.cgCache.consumerM3Client.IncCounter(metrics.ConsConnectionScope, metrics.OutputhostCGAckMgrSeqNotFound)
 	}
 	ackMgr.lk.Unlock()
 

--- a/services/outputhost/cgcache.go
+++ b/services/outputhost/cgcache.go
@@ -445,7 +445,7 @@ func (cgCache *consumerGroupCache) manageConsumerGroupCache() {
 }
 
 // refreshCgCacheNoLock is a routine which is called without the extMutex held.
-// It takes the mutex and in turn refreshes the cg by contactingmetadata to
+// It takes the mutex and in turn refreshes the cg by contacting metadata to
 // get all the open extents and then loads them if needed
 func (cgCache *consumerGroupCache) refreshCgCacheNoLock(ctx thrift.Context) error {
 	cgCache.extMutex.Lock()

--- a/services/outputhost/consconnection.go
+++ b/services/outputhost/consconnection.go
@@ -168,8 +168,9 @@ func (conn *consConnection) sendCreditsToWritePump(localCredits *int32) {
 	default:
 		// If we cannot send the credits at this time, just accumulate it
 		// but don't reset the counter
-		conn.logger.WithField(`localCredits`, *localCredits).
-			Info("unable to send credits to write pump; accumulating locally")
+		// update M3 to record this
+		conn.cgCache.m3Client.UpdateGauge(metrics.ConsConnectionStreamScope, metrics.OutputhostCreditsAccumulated, int64(*localCredits))
+		conn.cgCache.consumerM3Client.UpdateGauge(metrics.ConsConnectionScope, metrics.OutputhostCGCreditsAccumulated, int64(*localCredits))
 	}
 
 }

--- a/services/outputhost/outputhost.go
+++ b/services/outputhost/outputhost.go
@@ -596,10 +596,16 @@ func (h *OutputHost) ConsumerGroupsUpdated(ctx thrift.Context, request *admin.Co
 				// Notify the client
 				cg.reconfigureClients(updateUUID)
 			case admin.NotificationType_HOST:
-				_, intErr = h.loadCGCache(ctx, ok, cg)
+				// just refresh the cg directly.
+				// at this point cg is already loaded
+				intErr = cg.refreshCgCacheNoLock(ctx)
 			case admin.NotificationType_ALL:
-				_, intErr = h.loadCGCache(ctx, ok, cg)
-				cg.reconfigureClients(updateUUID)
+				// just refresh the cg directly.
+				// at this point cg is already loaded
+				intErr = cg.refreshCgCacheNoLock(ctx)
+				if intErr == nil {
+					cg.reconfigureClients(updateUUID)
+				}
 			default:
 				h.logger.WithFields(bark.Fields{
 					common.TagCnsm:       common.FmtCnsm(cgUUID),


### PR DESCRIPTION
1. Don't always refresh the CG during load. This was resulting
in one metadata cg extent call for every ReceiveMessageBatch call.
2. Convert spammy logs to metrics.
3. When the notify from controller is received, make sure to just
refresh the CG instead of loading completely.