### PR TITLE
Add a reminder about env+staging to all cherami CLI errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,10 @@ cherami-replicator-tool: $(DEPS)
 cherami-cassandra-tool: $(DEPS)
 	go build -i -o cherami-cassandra-tool cmd/tools/cassandra/main.go
 
-bins: cherami-server cherami-replicator-server cherami-cli cherami-admin cherami-replicator-tool cherami-cassandra-tool
+cherami-store-tool: $(DEPS)
+	go build -i $(EMBED) -o cherami-store-tool cmd/tools/store/main.go
+
+bins: cherami-server cherami-replicator-server cherami-cli cherami-admin cherami-replicator-tool cherami-cassandra-tool cherami-store-tool
 
 cover_profile: bins
 	@echo Testing packages:

--- a/cmd/tools/admin/main.go
+++ b/cmd/tools/admin/main.go
@@ -43,7 +43,7 @@ func main() {
 	})
 	app.Name = "cherami"
 	app.Usage = "A command-line tool for cherami developer, including debugging tool"
-	app.Version = "1.1"
+	app.Version = "1.1.1"
 	app.Flags = []cli.Flag{
 		cli.BoolTFlag{
 			Name:  "hyperbahn",
@@ -56,8 +56,8 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "env",
-			Value: "",
-			Usage: "env to connect. By default connects to prod, use \"staging\" to connect to staging",
+			Value: "staging",
+			Usage: "env to connect. By default connects to staging, use \"prod\" to connect to production",
 		},
 		cli.StringFlag{
 			Name:   "hyperbahn_bootstrap_file, hbfile",

--- a/cmd/tools/cli/main.go
+++ b/cmd/tools/cli/main.go
@@ -53,7 +53,7 @@ func main() {
 	})
 	app.Name = "cherami"
 	app.Usage = "A command-line tool for cherami users"
-	app.Version = "1.1.6"
+	app.Version = "1.1.7"
 	app.Flags = []cli.Flag{
 		cli.BoolTFlag{
 			Name:  "hyperbahn",

--- a/cmd/tools/store/main.go
+++ b/cmd/tools/store/main.go
@@ -33,7 +33,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "store-tool"
 	app.Usage = "A command-line tool for storage debugging"
-	app.Version = "1.0"
+	app.Version = "1.0.1"
 	app.Flags = []cli.Flag{
 		cli.BoolTFlag{
 			Name:  "hyperbahn",
@@ -46,8 +46,8 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "env",
-			Value: "",
-			Usage: "env to connect. By default connects to prod, use \"staging\" to connect to staging",
+			Value: "staging",
+			Usage: "env to connect. By default connects to staging, use \"prod\" to connect to production",
 		},
 		cli.StringFlag{
 			Name:   "hyperbahn_bootstrap_file, hbfile",

--- a/tools/common/lib.go
+++ b/tools/common/lib.go
@@ -90,8 +90,10 @@ var uuidRegex, _ = regexp.Compile(`^[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]
 // ExitIfError exit while err is not nil and print the calling stack also
 func ExitIfError(err error) {
 	const stacksEnv = `CHERAMI_SHOW_STACKS`
+	envReminder := "\n--env=staging is now the default. Did you mean '--env=prod' ?\n"
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
+		fmt.Fprintln(os.Stderr, envReminder)
 		if os.Getenv(stacksEnv) != `` {
 			debug.PrintStack()
 		} else {


### PR DESCRIPTION

This change:

* Adds a reminder to all cherami-cli errors that env staging is now the default
* Change the default environment to staging for all of our CLI tools, for consistency
* Build the cherami-store-tool, which had been overlooked