### PR TITLE
Light weight listExtents API impl for use in controller

### DIFF
--- a/clients/metadata/metadata_cassandra.go
+++ b/clients/metadata/metadata_cassandra.go
@@ -2727,7 +2727,7 @@ func (s *CassandraMetadataService) listExtentsStatsHelper(request *shared.ListEx
 	return query.Iter(), nil
 }
 
-// ListDestinationExtens lists all the extents mapped to a given destination
+// ListDestinationExtents lists all the extents mapped to a given destination
 func (s *CassandraMetadataService) ListDestinationExtents(ctx thrift.Context, request *m.ListDestinationExtentsRequest) (*m.ListDestinationExtentsResult_, error) {
 
 	if len(request.GetDestinationUUID()) == 0 {
@@ -3804,7 +3804,7 @@ func (s *CassandraMetadataService) readConsumerGroupExtentsHelper(request *m.Rea
 // extents, see ReadConsumerGroupExtents
 func (s *CassandraMetadataService) ReadConsumerGroupExtentsLite(ctx thrift.Context, request *m.ReadConsumerGroupExtentsLiteRequest) (*m.ReadConsumerGroupExtentsLiteResult_, error) {
 
-	if request.GetMaxResults() < 1 {
+	if request.GetMaxResults() <= 0 {
 		return nil, errPageLimitOutOfRange
 	}
 
@@ -3819,9 +3819,7 @@ func (s *CassandraMetadataService) ReadConsumerGroupExtentsLite(ctx thrift.Conte
 	}
 
 	qry := s.session.Query(sql).Consistency(s.lowConsLevel).Bind(request.GetConsumerGroupUUID())
-	if request.GetMaxResults() > 0 {
-		qry = qry.PageSize(int(request.GetMaxResults())).PageState(request.GetPageToken())
-	}
+	qry = qry.PageSize(int(request.GetMaxResults())).PageState(request.GetPageToken())
 
 	iter := qry.Iter()
 	allocSize := iter.NumRows()

--- a/clients/metadata/metadata_cassandra.go
+++ b/clients/metadata/metadata_cassandra.go
@@ -2038,7 +2038,16 @@ const (
 		columnReplicaStats + `, ` +
 		`writeTime( ` + columnReplicaStats + `)` +
 		` FROM ` + tableStoreExtents + ` WHERE ` + columnStoreUUID + ` =? AND ` + columnExtentUUID + ` =? LIMIT 1`
+
+	sqlListDstExtents = `SELECT ` + columnExtentUUID + `, ` + columnStatus + `, ` + columnCreatedTime + `, ` +
+		columnStatusUpdatedTime + `, ` + columnConsumerGroupVisibility + `, ` + columnOriginZone +
+		`, extent.` + columnInputHostUUID + `, extent.` + columnStoreUUIDS +
+		` FROM ` + tableDestinationExtents +
+		` WHERE ` + columnDestinationUUID + `=?`
 )
+
+var errDstUUIDNil = &shared.BadRequestError{Message: "DestinationUUID is nil"}
+var errPageLimitOutOfRange = &shared.BadRequestError{Message: "PageLimit out of range, must be > 0"}
 
 // CreateExtent implements the corresponding TChanMetadataServiceClient API
 // TODO Have a storage background job to reconcile store view of extents with the metadata
@@ -2718,6 +2727,84 @@ func (s *CassandraMetadataService) listExtentsStatsHelper(request *shared.ListEx
 	return query.Iter(), nil
 }
 
+// ListDestinationExtens lists all the extents mapped to a given destination
+func (s *CassandraMetadataService) ListDestinationExtents(ctx thrift.Context, request *m.ListDestinationExtentsRequest) (*m.ListDestinationExtentsResult_, error) {
+
+	if len(request.GetDestinationUUID()) == 0 {
+		return nil, errDstUUIDNil
+	}
+
+	if request.GetLimit() <= 0 {
+		return nil, errPageLimitOutOfRange
+	}
+
+	filterLocally := false
+	if request.IsSetStatus() && request.GetStatus() != shared.ExtentStatus_OPEN {
+		filterLocally = true
+	}
+
+	sql := sqlListDstExtents
+	if !filterLocally && request.IsSetStatus() {
+		sql = fmt.Sprintf("%s AND %s=%d", sqlListDstExtents, columnStatus, request.GetStatus())
+	}
+
+	qry := s.session.Query(sql).Consistency(s.lowConsLevel).Bind(request.GetDestinationUUID())
+	qry = qry.PageSize(int(request.GetLimit())).PageState(request.GetPageToken())
+
+	iter := qry.Iter()
+
+	allocSize := iter.NumRows()
+	if filterLocally {
+		allocSize = common.MinInt(allocSize, 8)
+	}
+
+	allocSize = common.MaxInt(allocSize, 1)
+
+	result := m.NewListDestinationExtentsResult_()
+	result.Extents = make([]*m.DestinationExtent, 0, allocSize)
+	extents := make([]m.DestinationExtent, allocSize)
+
+	var cnt int
+	var createdTime time.Time
+	var statusUpdatedTime time.Time
+
+	for iter.Scan(&extents[cnt].ExtentUUID,
+		&extents[cnt].Status,
+		&createdTime,
+		&statusUpdatedTime,
+		&extents[cnt].ConsumerGroupVisibility,
+		&extents[cnt].OriginZone,
+		&extents[cnt].InputHostUUID,
+		&extents[cnt].StoreUUIDs) {
+
+		if filterLocally && request.GetStatus() != extents[cnt].GetStatus() {
+			continue
+		}
+
+		extents[cnt].CreatedTimeMillis = common.Int64Ptr(timeToMilliseconds(createdTime))
+		extents[cnt].StatusUpdatedTimeMillis = common.Int64Ptr(timeToMilliseconds(statusUpdatedTime))
+		result.Extents = append(result.Extents, &extents[cnt])
+
+		cnt++
+		if cnt == len(extents) {
+			cnt = 0
+			extents = make([]m.DestinationExtent, allocSize)
+		}
+	}
+
+	nextPageToken := iter.PageState()
+	result.NextPageToken = make([]byte, len(nextPageToken))
+	copy(result.NextPageToken, nextPageToken)
+
+	if err := iter.Close(); err != nil {
+		return nil, &shared.InternalServiceError{
+			Message: err.Error(),
+		}
+	}
+
+	return result, nil
+}
+
 // ListInputHostExtentsStats returns a list of extent stats for the given DstID/InputHostID
 // If the destinationID is not specified, this method will return all extent stats matching
 // the given input host id
@@ -3252,6 +3339,14 @@ const (
 		` FROM ` + tableConsumerGroupExtents +
 		` WHERE ` + columnConsumerGroupUUID + `=?`
 
+	sqlCGGetAllExtentsLite = `SELECT ` +
+		columnStatus + `, ` +
+		columnExtentUUID + `, ` +
+		columnOutputHostUUID + `, ` +
+		columnStoreUUIDS +
+		` FROM ` + tableConsumerGroupExtents +
+		` WHERE ` + columnConsumerGroupUUID + `=?`
+
 	sqlExtGetAllExtents = `SELECT ` +
 		columnConsumerGroupUUID + `, ` +
 		columnOutputHostUUID + `, ` +
@@ -3701,6 +3796,81 @@ func (s *CassandraMetadataService) readConsumerGroupExtentsHelper(request *m.Rea
 		query = query.PageSize(int(request.GetMaxResults())).PageState(request.GetPageToken())
 	}
 	return query.Iter(), nil
+}
+
+// ReadConsumerGroupExtentsLite returns the list all extents mapped to
+// the given consumer group. This API only returns a few interesting
+// columns for each extent in the result. For detailed info about
+// extents, see ReadConsumerGroupExtents
+func (s *CassandraMetadataService) ReadConsumerGroupExtentsLite(ctx thrift.Context, request *m.ReadConsumerGroupExtentsLiteRequest) (*m.ReadConsumerGroupExtentsLiteResult_, error) {
+
+	if request.GetMaxResults() < 1 {
+		return nil, errPageLimitOutOfRange
+	}
+
+	filterLocally := false
+	if request.IsSetStatus() && request.GetStatus() != m.ConsumerGroupExtentStatus_OPEN {
+		filterLocally = true
+	}
+
+	sql := sqlCGGetAllExtentsLite
+	if !filterLocally && request.IsSetStatus() {
+		sql += fmt.Sprintf(" AND %s=%d", columnStatus, request.GetStatus())
+	}
+
+	qry := s.session.Query(sql).Consistency(s.lowConsLevel).Bind(request.GetConsumerGroupUUID())
+	if request.GetMaxResults() > 0 {
+		qry = qry.PageSize(int(request.GetMaxResults())).PageState(request.GetPageToken())
+	}
+
+	iter := qry.Iter()
+	allocSize := iter.NumRows()
+	if filterLocally {
+		allocSize = common.MinInt(8, allocSize)
+	}
+
+	allocSize = common.MaxInt(allocSize, 1)
+
+	result := m.NewReadConsumerGroupExtentsLiteResult_()
+	result.Extents = make([]*m.ConsumerGroupExtentLite, 0, allocSize)
+	extents := make([]m.ConsumerGroupExtentLite, allocSize)
+
+	cnt := 0
+
+	for iter.Scan(
+		&extents[cnt].Status,
+		&extents[cnt].ExtentUUID,
+		&extents[cnt].OutputHostUUID,
+		&extents[cnt].StoreUUIDs) {
+
+		if filterLocally && extents[cnt].GetStatus() != request.GetStatus() {
+			continue
+		}
+
+		if request.IsSetOutputHostUUID() &&
+			strings.Compare(extents[cnt].GetOutputHostUUID(), request.GetOutputHostUUID()) != 0 {
+			continue
+		}
+
+		result.Extents = append(result.Extents, &extents[cnt])
+
+		cnt++
+		if cnt == len(extents) {
+			cnt = 0
+			extents = make([]m.ConsumerGroupExtentLite, allocSize)
+		}
+	}
+
+	nextPageToken := iter.PageState()
+	result.NextPageToken = make([]byte, len(nextPageToken))
+	copy(result.NextPageToken, nextPageToken)
+	if err := iter.Close(); err != nil {
+		return nil, &shared.InternalServiceError{
+			Message: err.Error(),
+		}
+	}
+
+	return result, nil
 }
 
 // CQL commands for UUIDToHostAddr and HostAddrToUUID CRUD go here

--- a/common/metadata/metaMetrics.go
+++ b/common/metadata/metaMetrics.go
@@ -136,6 +136,21 @@ func (m *metadataMetricsMgr) ListDestinationsByUUID(ctx thrift.Context, request 
 	return result, err
 }
 
+func (m *metadataMetricsMgr) ListDestinationExtents(ctx thrift.Context, request *m.ListDestinationExtentsRequest) (result *m.ListDestinationExtentsResult_, err error) {
+
+	m.m3.IncCounter(metrics.MetadataListDestinationExtentsScope, metrics.MetadataRequests)
+	sw := m.m3.StartTimer(metrics.MetadataListDestinationExtentsScope, metrics.MetadataLatency)
+	defer sw.Stop()
+
+	result, err = m.meta.ListDestinationExtents(ctx, request)
+
+	if err != nil {
+		m.m3.IncCounter(metrics.MetadataListDestinationExtentsScope, metrics.MetadataFailures)
+	}
+
+	return result, err
+}
+
 func (m *metadataMetricsMgr) ListExtentsStats(ctx thrift.Context, request *shared.ListExtentsStatsRequest) (result *shared.ListExtentsStatsResult_, err error) {
 
 	m.m3.IncCounter(metrics.MetadataListExtentsStatsScope, metrics.MetadataRequests)
@@ -251,6 +266,21 @@ func (m *metadataMetricsMgr) ReadConsumerGroupExtents(ctx thrift.Context, reques
 
 	if err != nil {
 		m.m3.IncCounter(metrics.MetadataReadConsumerGroupExtentsScope, metrics.MetadataFailures)
+	}
+
+	return result, err
+}
+
+func (m *metadataMetricsMgr) ReadConsumerGroupExtentsLite(ctx thrift.Context, request *m.ReadConsumerGroupExtentsLiteRequest) (result *m.ReadConsumerGroupExtentsLiteResult_, err error) {
+
+	m.m3.IncCounter(metrics.MetadataReadConsumerGroupExtentsLiteScope, metrics.MetadataRequests)
+	sw := m.m3.StartTimer(metrics.MetadataReadConsumerGroupExtentsLiteScope, metrics.MetadataLatency)
+	defer sw.Stop()
+
+	result, err = m.meta.ReadConsumerGroupExtentsLite(ctx, request)
+
+	if err != nil {
+		m.m3.IncCounter(metrics.MetadataReadConsumerGroupExtentsLiteScope, metrics.MetadataFailures)
 	}
 
 	return result, err

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -123,6 +123,8 @@ const (
 	MetadataListDestinationsScope
 	// MetadataListDestinationsByUUIDScope defines scope for an operation on metadata
 	MetadataListDestinationsByUUIDScope
+	// MetadataListDestinationExtentsScope defines the scope for an operation on metadata
+	MetadataListDestinationExtentsScope
 	// MetadataListExtentsStatsScope defines scope for an operation on metadata
 	MetadataListExtentsStatsScope
 	// MetadataListHostsScope defines scope for an operation on metadata
@@ -139,6 +141,8 @@ const (
 	MetadataReadConsumerGroupExtentScope
 	// MetadataReadConsumerGroupExtentsScope defines scope for an operation on metadata
 	MetadataReadConsumerGroupExtentsScope
+	// MetadataReadConsumerGroupExtentsLiteScope defines scope for an operation on metadata
+	MetadataReadConsumerGroupExtentsLiteScope
 	// MetadataReadConsumerGroupExtentsByExtUUIDScope defines scope for an operation on metadata
 	MetadataReadConsumerGroupExtentsByExtUUIDScope
 	// MetadataReadDestinationScope defines scope for an operation on metadata
@@ -411,6 +415,7 @@ var scopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		MetadataListConsumerGroupsScope:                {operation: "MetadataListConsumerGroups"},
 		MetadataListDestinationsScope:                  {operation: "MetadataListDestinations"},
 		MetadataListDestinationsByUUIDScope:            {operation: "MetadataListDestinationsByUUID"},
+		MetadataListDestinationExtentsScope:            {operation: "MetadataListDestinationExtents"},
 		MetadataListExtentsStatsScope:                  {operation: "MetadataListExtentsStats"},
 		MetadataListHostsScope:                         {operation: "MetadataListHosts"},
 		MetadataListInputHostExtentsStatsScope:         {operation: "MetadataListInputHostExtentsStats"},
@@ -419,6 +424,7 @@ var scopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		MetadataReadConsumerGroupByUUIDScope:           {operation: "MetadataReadConsumerGroupByUUID"},
 		MetadataReadConsumerGroupExtentScope:           {operation: "MetadataReadConsumerGroupExtent"},
 		MetadataReadConsumerGroupExtentsScope:          {operation: "MetadataReadConsumerGroupExtents"},
+		MetadataReadConsumerGroupExtentsLiteScope:      {operation: "MetadataReadConsumerGroupExtentsLite"},
 		MetadataReadConsumerGroupExtentsByExtUUIDScope: {operation: "MetadataReadConsumerGroupExtentsByExtUUID"},
 		MetadataReadDestinationScope:                   {operation: "MetadataReadDestination"},
 		MetadataReadExtentStatsScope:                   {operation: "MetadataReadExtentStats"},

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
 hash: 95f30a537dc5b2841e061722d66e26c58126e82c19e9ba29bb6b0f44cf1741d0
-updated: 2017-01-20T14:50:39.862787375-08:00
+updated: 2017-01-31T14:55:02.42070453-08:00
 imports:
 - name: github.com/apache/thrift
-  version: 366e89ead7df34b4132c2accb59dc14fce564883
+  version: 2d6060d882069ed3e3d6302aa63ea7eb4bb155ad
   subpackages:
   - lib/go/thrift
 - name: github.com/aws/aws-sdk-go
-  version: 8e3cbe8bc6116511806e5627b0dbc03d5b79ce0a
+  version: 7524cb911daddd6e5c9195def8e59ae892bef8d9
   subpackages:
   - aws
   - aws/awserr
@@ -42,15 +42,15 @@ imports:
   subpackages:
   - statsd
 - name: github.com/cockroachdb/c-jemalloc
-  version: d726b40f0bc9c90ced1e00c044cf172ae094c083
+  version: 2582439cfbace368ad093c71209ad72efef8aa4d
 - name: github.com/cockroachdb/c-lz4
   version: 834d3303c9e84b1045bc57c3eb3723ee8cb4d33b
 - name: github.com/cockroachdb/c-rocksdb
-  version: 894d369c4ea259b65f75563feeb06bea322a8450
+  version: 09d6d520b61160d194c06768ed85415cd8abee57
 - name: github.com/cockroachdb/c-snappy
   version: c0cd3c9ce92f195001595e1fbbe66f045daad34f
 - name: github.com/codegangsta/cli
-  version: 0bdeddeeb0f650497d603c4ad7b20cfe685682f6
+  version: 347a9884a87374d000eec7e6445a34487c1f4a2b
 - name: github.com/davecgh/go-spew
   version: 346938d642f2ec3594ed81d874461961cd0faa76
   subpackages:
@@ -58,28 +58,28 @@ imports:
 - name: github.com/dgryski/go-farm
   version: 83948bc0eb076b6b72c28abe5282fa8cf5240db6
 - name: github.com/go-ini/ini
-  version: 2ba15ac2dc9cdf88c110ec2dc0ced7fa45f5678c
+  version: e3c2d47c61e5333f9aa2974695dd94396eb69c75
 - name: github.com/gocql/gocql
-  version: db6f35eb602dd0770a7162e0e23e5cfb1cc05b91
+  version: 4d2d1ac71932f7c4a6c7feb0d654462e4116c58b
   subpackages:
   - internal/lru
   - internal/murmur
   - internal/streams
 - name: github.com/golang/snappy
-  version: d9eb7a3d35ec988b8585d4a0068e462c27d28380
+  version: 7db9049039a047d955fe8c19b83c8ff5abd765c7
 - name: github.com/gorilla/websocket
-  version: 0868951cdb8e69bc42df4598bdc6164ff2f1a072
+  version: c36f2fe5c330f0ac404b616b96c438b8616b1aaf
 - name: github.com/hailocab/go-hostpool
   version: e80d13ce29ede4452c43dea11e79b9bc8a15b478
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/opentracing/opentracing-go
-  version: ac5446f53f2c0fc68dc16dc5f426eae1cd288b34
+  version: f2364047356159ed6494d3c50ca004939f79a557
   subpackages:
   - ext
   - log
 - name: github.com/pborman/uuid
-  version: 5007efa264d92316c43112bc573e754bc889b7b1
+  version: 1b00554d822231195d1babd97ff4a781231955c9
 - name: github.com/pmezard/go-difflib
   version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
@@ -87,24 +87,24 @@ imports:
 - name: github.com/rcrowley/go-metrics
   version: 1f30fe9094a513ce4c700b9a54458bbb0c96996c
 - name: github.com/Sirupsen/logrus
-  version: 881bee4e20a5d11a6a88a5667c6f292072ac1963
+  version: 61e43dc76f7ee59a82bdf3d71033dc12bea4c77d
 - name: github.com/stretchr/objx
   version: 1a9d0bb9f541897e62256577b352fdbc1fb4fd94
 - name: github.com/stretchr/testify
-  version: 2402e8e7a02fc811447d11f881aa9746cdc57983
+  version: 4d4bfba8f1d1027c4fdbe371823030df51419987
   subpackages:
   - assert
   - mock
   - require
   - suite
 - name: github.com/tecbot/gorocksdb
-  version: f2a0b10f7228cff360e2d9efa081a15a8cbd68b7
+  version: 17991d3138a879b166adebf86f7c84da3c1517a7
 - name: github.com/uber-common/bark
   version: 8841a0f8e7ca869284ccb29c08a14cf3f4310f46
 - name: github.com/uber-go/atomic
-  version: 14746df0c213f3a48f7f64637c6981f9285005f3
+  version: 3b8db5e93c4c02efbc313e17b2e796b0914a01fb
 - name: github.com/uber/cherami-client-go
-  version: a2036234af07e1cd9cfae68b900cf3d52222bcb5
+  version: f6da4234a00f2494cacf22e364b92c3972e2050a
   subpackages:
   - client/cherami
   - common
@@ -113,7 +113,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: 158732d2fb0296d02c0b23aa343c0310b7b9a749
+  version: 0f0585c53937209f08a57c6ae51d8a7fd281e100
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami
@@ -152,13 +152,13 @@ imports:
   subpackages:
   - context
 - name: golang.org/x/sys
-  version: 478fcf54317e52ab69f40bb4c7a1520288d7f7ea
+  version: d75a52659825e75fff6158388dddc6a5b04f9ba5
   subpackages:
   - unix
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/validator.v2
-  version: 3e4f037f12a1221a0864cf0dd2e81c452ab22448
+  version: 0a9835d809fb647a62611d30cb792e0b5dd65b11
 - name: gopkg.in/yaml.v2
-  version: a5b47d31c556af34a302ce5d659e6fea44d90de0
+  version: 4c78c975fe7c825c6d1466c42be594d1d6f3aba6
 testImports: []

--- a/test/mocks/metadata/TChanMetadataExposable.go
+++ b/test/mocks/metadata/TChanMetadataExposable.go
@@ -31,6 +31,57 @@ type TChanMetadataExposable struct {
 	mock.Mock
 }
 
+// ListEntityOps provides a mock function with given fields: ctx, listRequest
+func (_m *TChanMetadataExposable) ListEntityOps(ctx thrift.Context, listRequest *metadata.ListEntityOpsRequest) (*metadata.ListEntityOpsResult_, error) {
+	ret := _m.Called(ctx, listRequest)
+
+	var r0 *metadata.ListEntityOpsResult_
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ListEntityOpsRequest) *metadata.ListEntityOpsResult_); ok {
+		r0 = rf(ctx, listRequest)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*metadata.ListEntityOpsResult_)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ListEntityOpsRequest) error); ok {
+		r1 = rf(ctx, listRequest)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// CreateServiceConfig provides a mock function with given fields: ctx, request
+func (_m *TChanMetadataExposable) CreateServiceConfig(ctx thrift.Context, request *metadata.CreateServiceConfigRequest) error {
+	ret := _m.Called(ctx, request)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.CreateServiceConfigRequest) error); ok {
+		r0 = rf(ctx, request)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// DeleteServiceConfig provides a mock function with given fields: ctx, request
+func (_m *TChanMetadataExposable) DeleteServiceConfig(ctx thrift.Context, request *metadata.DeleteServiceConfigRequest) error {
+	ret := _m.Called(ctx, request)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.DeleteServiceConfigRequest) error); ok {
+		r0 = rf(ctx, request)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // HostAddrToUUID provides a mock function with given fields: ctx, hostAddr
 func (_m *TChanMetadataExposable) HostAddrToUUID(ctx thrift.Context, hostAddr string) (string, error) {
 	ret := _m.Called(ctx, hostAddr)
@@ -45,6 +96,98 @@ func (_m *TChanMetadataExposable) HostAddrToUUID(ctx thrift.Context, hostAddr st
 	var r1 error
 	if rf, ok := ret.Get(1).(func(thrift.Context, string) error); ok {
 		r1 = rf(ctx, hostAddr)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ListAllConsumerGroups provides a mock function with given fields: ctx, listRequest
+func (_m *TChanMetadataExposable) ListAllConsumerGroups(ctx thrift.Context, listRequest *metadata.ListConsumerGroupRequest) (*metadata.ListConsumerGroupResult_, error) {
+	ret := _m.Called(ctx, listRequest)
+
+	var r0 *metadata.ListConsumerGroupResult_
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ListConsumerGroupRequest) *metadata.ListConsumerGroupResult_); ok {
+		r0 = rf(ctx, listRequest)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*metadata.ListConsumerGroupResult_)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ListConsumerGroupRequest) error); ok {
+		r1 = rf(ctx, listRequest)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ListConsumerGroups provides a mock function with given fields: ctx, listRequest
+func (_m *TChanMetadataExposable) ListConsumerGroups(ctx thrift.Context, listRequest *metadata.ListConsumerGroupRequest) (*metadata.ListConsumerGroupResult_, error) {
+	ret := _m.Called(ctx, listRequest)
+
+	var r0 *metadata.ListConsumerGroupResult_
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ListConsumerGroupRequest) *metadata.ListConsumerGroupResult_); ok {
+		r0 = rf(ctx, listRequest)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*metadata.ListConsumerGroupResult_)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ListConsumerGroupRequest) error); ok {
+		r1 = rf(ctx, listRequest)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ListDestinations provides a mock function with given fields: ctx, listRequest
+func (_m *TChanMetadataExposable) ListDestinations(ctx thrift.Context, listRequest *shared.ListDestinationsRequest) (*shared.ListDestinationsResult_, error) {
+	ret := _m.Called(ctx, listRequest)
+
+	var r0 *shared.ListDestinationsResult_
+	if rf, ok := ret.Get(0).(func(thrift.Context, *shared.ListDestinationsRequest) *shared.ListDestinationsResult_); ok {
+		r0 = rf(ctx, listRequest)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*shared.ListDestinationsResult_)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, *shared.ListDestinationsRequest) error); ok {
+		r1 = rf(ctx, listRequest)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ListDestinationsByUUID provides a mock function with given fields: ctx, listRequest
+func (_m *TChanMetadataExposable) ListDestinationsByUUID(ctx thrift.Context, listRequest *shared.ListDestinationsByUUIDRequest) (*shared.ListDestinationsResult_, error) {
+	ret := _m.Called(ctx, listRequest)
+
+	var r0 *shared.ListDestinationsResult_
+	if rf, ok := ret.Get(0).(func(thrift.Context, *shared.ListDestinationsByUUIDRequest) *shared.ListDestinationsResult_); ok {
+		r0 = rf(ctx, listRequest)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*shared.ListDestinationsResult_)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, *shared.ListDestinationsByUUIDRequest) error); ok {
+		r1 = rf(ctx, listRequest)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -144,6 +287,52 @@ func (_m *TChanMetadataExposable) ListStoreExtentsStats(ctx thrift.Context, requ
 	return r0, r1
 }
 
+// ReadConsumerGroup provides a mock function with given fields: ctx, getRequest
+func (_m *TChanMetadataExposable) ReadConsumerGroup(ctx thrift.Context, getRequest *metadata.ReadConsumerGroupRequest) (*shared.ConsumerGroupDescription, error) {
+	ret := _m.Called(ctx, getRequest)
+
+	var r0 *shared.ConsumerGroupDescription
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ReadConsumerGroupRequest) *shared.ConsumerGroupDescription); ok {
+		r0 = rf(ctx, getRequest)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*shared.ConsumerGroupDescription)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ReadConsumerGroupRequest) error); ok {
+		r1 = rf(ctx, getRequest)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ReadConsumerGroupByUUID provides a mock function with given fields: ctx, request
+func (_m *TChanMetadataExposable) ReadConsumerGroupByUUID(ctx thrift.Context, request *metadata.ReadConsumerGroupRequest) (*shared.ConsumerGroupDescription, error) {
+	ret := _m.Called(ctx, request)
+
+	var r0 *shared.ConsumerGroupDescription
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ReadConsumerGroupRequest) *shared.ConsumerGroupDescription); ok {
+		r0 = rf(ctx, request)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*shared.ConsumerGroupDescription)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ReadConsumerGroupRequest) error); ok {
+		r1 = rf(ctx, request)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ReadConsumerGroupExtent provides a mock function with given fields: ctx, request
 func (_m *TChanMetadataExposable) ReadConsumerGroupExtent(ctx thrift.Context, request *metadata.ReadConsumerGroupExtentRequest) (*metadata.ReadConsumerGroupExtentResult_, error) {
 	ret := _m.Called(ctx, request)
@@ -190,6 +379,52 @@ func (_m *TChanMetadataExposable) ReadConsumerGroupExtents(ctx thrift.Context, r
 	return r0, r1
 }
 
+// ReadConsumerGroupExtentsByExtUUID provides a mock function with given fields: ctx, request
+func (_m *TChanMetadataExposable) ReadConsumerGroupExtentsByExtUUID(ctx thrift.Context, request *metadata.ReadConsumerGroupExtentsByExtUUIDRequest) (*metadata.ReadConsumerGroupExtentsByExtUUIDResult_, error) {
+	ret := _m.Called(ctx, request)
+
+	var r0 *metadata.ReadConsumerGroupExtentsByExtUUIDResult_
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ReadConsumerGroupExtentsByExtUUIDRequest) *metadata.ReadConsumerGroupExtentsByExtUUIDResult_); ok {
+		r0 = rf(ctx, request)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*metadata.ReadConsumerGroupExtentsByExtUUIDResult_)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ReadConsumerGroupExtentsByExtUUIDRequest) error); ok {
+		r1 = rf(ctx, request)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ReadDestination provides a mock function with given fields: ctx, getRequest
+func (_m *TChanMetadataExposable) ReadDestination(ctx thrift.Context, getRequest *metadata.ReadDestinationRequest) (*shared.DestinationDescription, error) {
+	ret := _m.Called(ctx, getRequest)
+
+	var r0 *shared.DestinationDescription
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ReadDestinationRequest) *shared.DestinationDescription); ok {
+		r0 = rf(ctx, getRequest)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*shared.DestinationDescription)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ReadDestinationRequest) error); ok {
+		r1 = rf(ctx, getRequest)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ReadExtentStats provides a mock function with given fields: ctx, request
 func (_m *TChanMetadataExposable) ReadExtentStats(ctx thrift.Context, request *metadata.ReadExtentStatsRequest) (*metadata.ReadExtentStatsResult_, error) {
 	ret := _m.Called(ctx, request)
@@ -205,6 +440,29 @@ func (_m *TChanMetadataExposable) ReadExtentStats(ctx thrift.Context, request *m
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ReadExtentStatsRequest) error); ok {
+		r1 = rf(ctx, request)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ReadServiceConfig provides a mock function with given fields: ctx, request
+func (_m *TChanMetadataExposable) ReadServiceConfig(ctx thrift.Context, request *metadata.ReadServiceConfigRequest) (*metadata.ReadServiceConfigResult_, error) {
+	ret := _m.Called(ctx, request)
+
+	var r0 *metadata.ReadServiceConfigResult_
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ReadServiceConfigRequest) *metadata.ReadServiceConfigResult_); ok {
+		r0 = rf(ctx, request)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*metadata.ReadServiceConfigResult_)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ReadServiceConfigRequest) error); ok {
 		r1 = rf(ctx, request)
 	} else {
 		r1 = ret.Error(1)
@@ -232,4 +490,18 @@ func (_m *TChanMetadataExposable) UUIDToHostAddr(ctx thrift.Context, hostUUID st
 	}
 
 	return r0, r1
+}
+
+// UpdateServiceConfig provides a mock function with given fields: ctx, request
+func (_m *TChanMetadataExposable) UpdateServiceConfig(ctx thrift.Context, request *metadata.UpdateServiceConfigRequest) error {
+	ret := _m.Called(ctx, request)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.UpdateServiceConfigRequest) error); ok {
+		r0 = rf(ctx, request)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }

--- a/test/mocks/metadata/TChanMetadataService.go
+++ b/test/mocks/metadata/TChanMetadataService.go
@@ -31,13 +31,13 @@ type TChanMetadataService struct {
 	mock.Mock
 }
 
-// CreateConsumerGroup provides a mock function with given fields: ctx, registerRequest
-func (_m *TChanMetadataService) CreateConsumerGroup(ctx thrift.Context, registerRequest *shared.CreateConsumerGroupRequest) (*shared.ConsumerGroupDescription, error) {
-	ret := _m.Called(ctx, registerRequest)
+// CreateConsumerGroup provides a mock function with given fields: ctx, createRequest
+func (_m *TChanMetadataService) CreateConsumerGroup(ctx thrift.Context, createRequest *shared.CreateConsumerGroupRequest) (*shared.ConsumerGroupDescription, error) {
+	ret := _m.Called(ctx, createRequest)
 
 	var r0 *shared.ConsumerGroupDescription
 	if rf, ok := ret.Get(0).(func(thrift.Context, *shared.CreateConsumerGroupRequest) *shared.ConsumerGroupDescription); ok {
-		r0 = rf(ctx, registerRequest)
+		r0 = rf(ctx, createRequest)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*shared.ConsumerGroupDescription)
@@ -46,30 +46,7 @@ func (_m *TChanMetadataService) CreateConsumerGroup(ctx thrift.Context, register
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(thrift.Context, *shared.CreateConsumerGroupRequest) error); ok {
-		r1 = rf(ctx, registerRequest)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// ReadConsumerGroupByUUID provides a mock function with given fields: ctx, getRequest
-func (_m *TChanMetadataService) ReadConsumerGroupByUUID(ctx thrift.Context, getRequest *metadata.ReadConsumerGroupRequest) (*shared.ConsumerGroupDescription, error) {
-	ret := _m.Called(ctx, getRequest)
-
-	var r0 *shared.ConsumerGroupDescription
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ReadConsumerGroupRequest) *shared.ConsumerGroupDescription); ok {
-		r0 = rf(ctx, getRequest)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*shared.ConsumerGroupDescription)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ReadConsumerGroupRequest) error); ok {
-		r1 = rf(ctx, getRequest)
+		r1 = rf(ctx, createRequest)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -160,6 +137,20 @@ func (_m *TChanMetadataService) CreateExtent(ctx thrift.Context, request *shared
 	return r0, r1
 }
 
+// CreateHostInfo provides a mock function with given fields: ctx, request
+func (_m *TChanMetadataService) CreateHostInfo(ctx thrift.Context, request *metadata.CreateHostInfoRequest) error {
+	ret := _m.Called(ctx, request)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.CreateHostInfoRequest) error); ok {
+		r0 = rf(ctx, request)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // DeleteConsumerGroup provides a mock function with given fields: ctx, deleteRequest
 func (_m *TChanMetadataService) DeleteConsumerGroup(ctx thrift.Context, deleteRequest *shared.DeleteConsumerGroupRequest) error {
 	ret := _m.Called(ctx, deleteRequest)
@@ -195,6 +186,381 @@ func (_m *TChanMetadataService) DeleteDestinationUUID(ctx thrift.Context, delete
 	var r0 error
 	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.DeleteDestinationUUIDRequest) error); ok {
 		r0 = rf(ctx, deleteRequest)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// DeleteHostInfo provides a mock function with given fields: ctx, request
+func (_m *TChanMetadataService) DeleteHostInfo(ctx thrift.Context, request *metadata.DeleteHostInfoRequest) error {
+	ret := _m.Called(ctx, request)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.DeleteHostInfoRequest) error); ok {
+		r0 = rf(ctx, request)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// ListDestinationExtents provides a mock function with given fields: ctx, request
+func (_m *TChanMetadataService) ListDestinationExtents(ctx thrift.Context, request *metadata.ListDestinationExtentsRequest) (*metadata.ListDestinationExtentsResult_, error) {
+	ret := _m.Called(ctx, request)
+
+	var r0 *metadata.ListDestinationExtentsResult_
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ListDestinationExtentsRequest) *metadata.ListDestinationExtentsResult_); ok {
+		r0 = rf(ctx, request)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*metadata.ListDestinationExtentsResult_)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ListDestinationExtentsRequest) error); ok {
+		r1 = rf(ctx, request)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MoveExtent provides a mock function with given fields: ctx, request
+func (_m *TChanMetadataService) MoveExtent(ctx thrift.Context, request *metadata.MoveExtentRequest) error {
+	ret := _m.Called(ctx, request)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.MoveExtentRequest) error); ok {
+		r0 = rf(ctx, request)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// ReadConsumerGroupExtentsLite provides a mock function with given fields: ctx, request
+func (_m *TChanMetadataService) ReadConsumerGroupExtentsLite(ctx thrift.Context, request *metadata.ReadConsumerGroupExtentsLiteRequest) (*metadata.ReadConsumerGroupExtentsLiteResult_, error) {
+	ret := _m.Called(ctx, request)
+
+	var r0 *metadata.ReadConsumerGroupExtentsLiteResult_
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ReadConsumerGroupExtentsLiteRequest) *metadata.ReadConsumerGroupExtentsLiteResult_); ok {
+		r0 = rf(ctx, request)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*metadata.ReadConsumerGroupExtentsLiteResult_)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ReadConsumerGroupExtentsLiteRequest) error); ok {
+		r1 = rf(ctx, request)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ReadHostInfo provides a mock function with given fields: ctx, request
+func (_m *TChanMetadataService) ReadHostInfo(ctx thrift.Context, request *metadata.ReadHostInfoRequest) (*metadata.ReadHostInfoResult_, error) {
+	ret := _m.Called(ctx, request)
+
+	var r0 *metadata.ReadHostInfoResult_
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ReadHostInfoRequest) *metadata.ReadHostInfoResult_); ok {
+		r0 = rf(ctx, request)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*metadata.ReadHostInfoResult_)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ReadHostInfoRequest) error); ok {
+		r1 = rf(ctx, request)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ReadStoreExtentReplicaStats provides a mock function with given fields: ctx, request
+func (_m *TChanMetadataService) ReadStoreExtentReplicaStats(ctx thrift.Context, request *metadata.ReadStoreExtentReplicaStatsRequest) (*metadata.ReadStoreExtentReplicaStatsResult_, error) {
+	ret := _m.Called(ctx, request)
+
+	var r0 *metadata.ReadStoreExtentReplicaStatsResult_
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ReadStoreExtentReplicaStatsRequest) *metadata.ReadStoreExtentReplicaStatsResult_); ok {
+		r0 = rf(ctx, request)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*metadata.ReadStoreExtentReplicaStatsResult_)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ReadStoreExtentReplicaStatsRequest) error); ok {
+		r1 = rf(ctx, request)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// RegisterHostUUID provides a mock function with given fields: ctx, request
+func (_m *TChanMetadataService) RegisterHostUUID(ctx thrift.Context, request *metadata.RegisterHostUUIDRequest) error {
+	ret := _m.Called(ctx, request)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.RegisterHostUUIDRequest) error); ok {
+		r0 = rf(ctx, request)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SealExtent provides a mock function with given fields: ctx, request
+func (_m *TChanMetadataService) SealExtent(ctx thrift.Context, request *metadata.SealExtentRequest) error {
+	ret := _m.Called(ctx, request)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.SealExtentRequest) error); ok {
+		r0 = rf(ctx, request)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SetAckOffset provides a mock function with given fields: ctx, request
+func (_m *TChanMetadataService) SetAckOffset(ctx thrift.Context, request *metadata.SetAckOffsetRequest) error {
+	ret := _m.Called(ctx, request)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.SetAckOffsetRequest) error); ok {
+		r0 = rf(ctx, request)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SetOutputHost provides a mock function with given fields: ctx, request
+func (_m *TChanMetadataService) SetOutputHost(ctx thrift.Context, request *metadata.SetOutputHostRequest) error {
+	ret := _m.Called(ctx, request)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.SetOutputHostRequest) error); ok {
+		r0 = rf(ctx, request)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// UpdateConsumerGroup provides a mock function with given fields: ctx, updateRequest
+func (_m *TChanMetadataService) UpdateConsumerGroup(ctx thrift.Context, updateRequest *shared.UpdateConsumerGroupRequest) (*shared.ConsumerGroupDescription, error) {
+	ret := _m.Called(ctx, updateRequest)
+
+	var r0 *shared.ConsumerGroupDescription
+	if rf, ok := ret.Get(0).(func(thrift.Context, *shared.UpdateConsumerGroupRequest) *shared.ConsumerGroupDescription); ok {
+		r0 = rf(ctx, updateRequest)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*shared.ConsumerGroupDescription)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, *shared.UpdateConsumerGroupRequest) error); ok {
+		r1 = rf(ctx, updateRequest)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// UpdateConsumerGroupExtentStatus provides a mock function with given fields: ctx, request
+func (_m *TChanMetadataService) UpdateConsumerGroupExtentStatus(ctx thrift.Context, request *metadata.UpdateConsumerGroupExtentStatusRequest) error {
+	ret := _m.Called(ctx, request)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.UpdateConsumerGroupExtentStatusRequest) error); ok {
+		r0 = rf(ctx, request)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// UpdateDestination provides a mock function with given fields: ctx, updateRequest
+func (_m *TChanMetadataService) UpdateDestination(ctx thrift.Context, updateRequest *shared.UpdateDestinationRequest) (*shared.DestinationDescription, error) {
+	ret := _m.Called(ctx, updateRequest)
+
+	var r0 *shared.DestinationDescription
+	if rf, ok := ret.Get(0).(func(thrift.Context, *shared.UpdateDestinationRequest) *shared.DestinationDescription); ok {
+		r0 = rf(ctx, updateRequest)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*shared.DestinationDescription)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, *shared.UpdateDestinationRequest) error); ok {
+		r1 = rf(ctx, updateRequest)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// UpdateDestinationDLQCursors provides a mock function with given fields: ctx, updateRequest
+func (_m *TChanMetadataService) UpdateDestinationDLQCursors(ctx thrift.Context, updateRequest *metadata.UpdateDestinationDLQCursorsRequest) (*shared.DestinationDescription, error) {
+	ret := _m.Called(ctx, updateRequest)
+
+	var r0 *shared.DestinationDescription
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.UpdateDestinationDLQCursorsRequest) *shared.DestinationDescription); ok {
+		r0 = rf(ctx, updateRequest)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*shared.DestinationDescription)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.UpdateDestinationDLQCursorsRequest) error); ok {
+		r1 = rf(ctx, updateRequest)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// UpdateExtentReplicaStats provides a mock function with given fields: ctx, request
+func (_m *TChanMetadataService) UpdateExtentReplicaStats(ctx thrift.Context, request *metadata.UpdateExtentReplicaStatsRequest) error {
+	ret := _m.Called(ctx, request)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.UpdateExtentReplicaStatsRequest) error); ok {
+		r0 = rf(ctx, request)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// UpdateExtentStats provides a mock function with given fields: ctx, request
+func (_m *TChanMetadataService) UpdateExtentStats(ctx thrift.Context, request *metadata.UpdateExtentStatsRequest) (*metadata.UpdateExtentStatsResult_, error) {
+	ret := _m.Called(ctx, request)
+
+	var r0 *metadata.UpdateExtentStatsResult_
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.UpdateExtentStatsRequest) *metadata.UpdateExtentStatsResult_); ok {
+		r0 = rf(ctx, request)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*metadata.UpdateExtentStatsResult_)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.UpdateExtentStatsRequest) error); ok {
+		r1 = rf(ctx, request)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// UpdateHostInfo provides a mock function with given fields: ctx, request
+func (_m *TChanMetadataService) UpdateHostInfo(ctx thrift.Context, request *metadata.UpdateHostInfoRequest) error {
+	ret := _m.Called(ctx, request)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.UpdateHostInfoRequest) error); ok {
+		r0 = rf(ctx, request)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// UpdateStoreExtentReplicaStats provides a mock function with given fields: ctx, request
+func (_m *TChanMetadataService) UpdateStoreExtentReplicaStats(ctx thrift.Context, request *metadata.UpdateStoreExtentReplicaStatsRequest) error {
+	ret := _m.Called(ctx, request)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.UpdateStoreExtentReplicaStatsRequest) error); ok {
+		r0 = rf(ctx, request)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// ListEntityOps provides a mock function with given fields: ctx, listRequest
+func (_m *TChanMetadataService) ListEntityOps(ctx thrift.Context, listRequest *metadata.ListEntityOpsRequest) (*metadata.ListEntityOpsResult_, error) {
+	ret := _m.Called(ctx, listRequest)
+
+	var r0 *metadata.ListEntityOpsResult_
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ListEntityOpsRequest) *metadata.ListEntityOpsResult_); ok {
+		r0 = rf(ctx, listRequest)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*metadata.ListEntityOpsResult_)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ListEntityOpsRequest) error); ok {
+		r1 = rf(ctx, listRequest)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// CreateServiceConfig provides a mock function with given fields: ctx, request
+func (_m *TChanMetadataService) CreateServiceConfig(ctx thrift.Context, request *metadata.CreateServiceConfigRequest) error {
+	ret := _m.Called(ctx, request)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.CreateServiceConfigRequest) error); ok {
+		r0 = rf(ctx, request)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// DeleteServiceConfig provides a mock function with given fields: ctx, request
+func (_m *TChanMetadataService) DeleteServiceConfig(ctx thrift.Context, request *metadata.DeleteServiceConfigRequest) error {
+	ret := _m.Called(ctx, request)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.DeleteServiceConfigRequest) error); ok {
+		r0 = rf(ctx, request)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -238,29 +604,6 @@ func (_m *TChanMetadataService) ListAllConsumerGroups(ctx thrift.Context, listRe
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ListConsumerGroupRequest) error); ok {
-		r1 = rf(ctx, listRequest)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// ListAllConsumerGroups provides a mock function with given fields: ctx, listRequest
-func (_m *TChanMetadataService) ListEntityOps(ctx thrift.Context, listRequest *metadata.ListEntityOpsRequest) (*metadata.ListEntityOpsResult_, error) {
-	ret := _m.Called(ctx, listRequest)
-
-	var r0 *metadata.ListEntityOpsResult_
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ListEntityOpsRequest) *metadata.ListEntityOpsResult_); ok {
-		r0 = rf(ctx, listRequest)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*metadata.ListEntityOpsResult_)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ListEntityOpsRequest) error); ok {
 		r1 = rf(ctx, listRequest)
 	} else {
 		r1 = ret.Error(1)
@@ -430,20 +773,6 @@ func (_m *TChanMetadataService) ListStoreExtentsStats(ctx thrift.Context, reques
 	return r0, r1
 }
 
-// MoveExtent provides a mock function with given fields: ctx, request
-func (_m *TChanMetadataService) MoveExtent(ctx thrift.Context, request *metadata.MoveExtentRequest) error {
-	ret := _m.Called(ctx, request)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.MoveExtentRequest) error); ok {
-		r0 = rf(ctx, request)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // ReadConsumerGroup provides a mock function with given fields: ctx, getRequest
 func (_m *TChanMetadataService) ReadConsumerGroup(ctx thrift.Context, getRequest *metadata.ReadConsumerGroupRequest) (*shared.ConsumerGroupDescription, error) {
 	ret := _m.Called(ctx, getRequest)
@@ -460,6 +789,29 @@ func (_m *TChanMetadataService) ReadConsumerGroup(ctx thrift.Context, getRequest
 	var r1 error
 	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ReadConsumerGroupRequest) error); ok {
 		r1 = rf(ctx, getRequest)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ReadConsumerGroupByUUID provides a mock function with given fields: ctx, request
+func (_m *TChanMetadataService) ReadConsumerGroupByUUID(ctx thrift.Context, request *metadata.ReadConsumerGroupRequest) (*shared.ConsumerGroupDescription, error) {
+	ret := _m.Called(ctx, request)
+
+	var r0 *shared.ConsumerGroupDescription
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ReadConsumerGroupRequest) *shared.ConsumerGroupDescription); ok {
+		r0 = rf(ctx, request)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*shared.ConsumerGroupDescription)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ReadConsumerGroupRequest) error); ok {
+		r1 = rf(ctx, request)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -582,333 +934,6 @@ func (_m *TChanMetadataService) ReadExtentStats(ctx thrift.Context, request *met
 	return r0, r1
 }
 
-// ReadStoreExtentReplicaStats provides a mock function with given fields: ctx, request
-func (_m *TChanMetadataService) ReadStoreExtentReplicaStats(ctx thrift.Context, request *metadata.ReadStoreExtentReplicaStatsRequest) (*metadata.ReadStoreExtentReplicaStatsResult_, error) {
-	ret := _m.Called(ctx, request)
-
-	var r0 *metadata.ReadStoreExtentReplicaStatsResult_
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ReadStoreExtentReplicaStatsRequest) *metadata.ReadStoreExtentReplicaStatsResult_); ok {
-		r0 = rf(ctx, request)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*metadata.ReadStoreExtentReplicaStatsResult_)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ReadStoreExtentReplicaStatsRequest) error); ok {
-		r1 = rf(ctx, request)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// RegisterHostUUID provides a mock function with given fields: ctx, request
-func (_m *TChanMetadataService) RegisterHostUUID(ctx thrift.Context, request *metadata.RegisterHostUUIDRequest) error {
-	ret := _m.Called(ctx, request)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.RegisterHostUUIDRequest) error); ok {
-		r0 = rf(ctx, request)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// SealExtent provides a mock function with given fields: ctx, request
-func (_m *TChanMetadataService) SealExtent(ctx thrift.Context, request *metadata.SealExtentRequest) error {
-	ret := _m.Called(ctx, request)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.SealExtentRequest) error); ok {
-		r0 = rf(ctx, request)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// SetAckOffset provides a mock function with given fields: ctx, request
-func (_m *TChanMetadataService) SetAckOffset(ctx thrift.Context, request *metadata.SetAckOffsetRequest) error {
-	ret := _m.Called(ctx, request)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.SetAckOffsetRequest) error); ok {
-		r0 = rf(ctx, request)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// SetOutputHost provides a mock function with given fields: ctx, request
-func (_m *TChanMetadataService) SetOutputHost(ctx thrift.Context, request *metadata.SetOutputHostRequest) error {
-	ret := _m.Called(ctx, request)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.SetOutputHostRequest) error); ok {
-		r0 = rf(ctx, request)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// UUIDToHostAddr provides a mock function with given fields: ctx, hostUUID
-func (_m *TChanMetadataService) UUIDToHostAddr(ctx thrift.Context, hostUUID string) (string, error) {
-	ret := _m.Called(ctx, hostUUID)
-
-	var r0 string
-	if rf, ok := ret.Get(0).(func(thrift.Context, string) string); ok {
-		r0 = rf(ctx, hostUUID)
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(thrift.Context, string) error); ok {
-		r1 = rf(ctx, hostUUID)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// UpdateConsumerGroup provides a mock function with given fields: ctx, updateRequest
-func (_m *TChanMetadataService) UpdateConsumerGroup(ctx thrift.Context, updateRequest *shared.UpdateConsumerGroupRequest) (*shared.ConsumerGroupDescription, error) {
-	ret := _m.Called(ctx, updateRequest)
-
-	var r0 *shared.ConsumerGroupDescription
-	if rf, ok := ret.Get(0).(func(thrift.Context, *shared.UpdateConsumerGroupRequest) *shared.ConsumerGroupDescription); ok {
-		r0 = rf(ctx, updateRequest)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*shared.ConsumerGroupDescription)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(thrift.Context, *shared.UpdateConsumerGroupRequest) error); ok {
-		r1 = rf(ctx, updateRequest)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// UpdateConsumerGroupExtentStatus provides a mock function with given fields: ctx, request
-func (_m *TChanMetadataService) UpdateConsumerGroupExtentStatus(ctx thrift.Context, request *metadata.UpdateConsumerGroupExtentStatusRequest) error {
-	ret := _m.Called(ctx, request)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.UpdateConsumerGroupExtentStatusRequest) error); ok {
-		r0 = rf(ctx, request)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// UpdateDestination provides a mock function with given fields: ctx, updateRequest
-func (_m *TChanMetadataService) UpdateDestination(ctx thrift.Context, updateRequest *shared.UpdateDestinationRequest) (*shared.DestinationDescription, error) {
-	ret := _m.Called(ctx, updateRequest)
-
-	var r0 *shared.DestinationDescription
-	if rf, ok := ret.Get(0).(func(thrift.Context, *shared.UpdateDestinationRequest) *shared.DestinationDescription); ok {
-		r0 = rf(ctx, updateRequest)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*shared.DestinationDescription)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(thrift.Context, *shared.UpdateDestinationRequest) error); ok {
-		r1 = rf(ctx, updateRequest)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// UpdateDestinationDLQCursors provides a mock function with given fields: ctx, updateRequest
-func (_m *TChanMetadataService) UpdateDestinationDLQCursors(ctx thrift.Context, updateRequest *metadata.UpdateDestinationDLQCursorsRequest) (*shared.DestinationDescription, error) {
-	ret := _m.Called(ctx, updateRequest)
-
-	var r0 *shared.DestinationDescription
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.UpdateDestinationDLQCursorsRequest) *shared.DestinationDescription); ok {
-		r0 = rf(ctx, updateRequest)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*shared.DestinationDescription)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.UpdateDestinationDLQCursorsRequest) error); ok {
-		r1 = rf(ctx, updateRequest)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// UpdateExtentReplicaStats provides a mock function with given fields: ctx, request
-func (_m *TChanMetadataService) UpdateExtentReplicaStats(ctx thrift.Context, request *metadata.UpdateExtentReplicaStatsRequest) error {
-	ret := _m.Called(ctx, request)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.UpdateExtentReplicaStatsRequest) error); ok {
-		r0 = rf(ctx, request)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// UpdateExtentStats provides a mock function with given fields: ctx, request
-func (_m *TChanMetadataService) UpdateExtentStats(ctx thrift.Context, request *metadata.UpdateExtentStatsRequest) (*metadata.UpdateExtentStatsResult_, error) {
-	ret := _m.Called(ctx, request)
-
-	var r0 *metadata.UpdateExtentStatsResult_
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.UpdateExtentStatsRequest) *metadata.UpdateExtentStatsResult_); ok {
-		r0 = rf(ctx, request)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*metadata.UpdateExtentStatsResult_)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.UpdateExtentStatsRequest) error); ok {
-		r1 = rf(ctx, request)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// UpdateStoreExtentReplicaStats provides a mock function with given fields: ctx, request
-func (_m *TChanMetadataService) UpdateStoreExtentReplicaStats(ctx thrift.Context, request *metadata.UpdateStoreExtentReplicaStatsRequest) error {
-	ret := _m.Called(ctx, request)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.UpdateStoreExtentReplicaStatsRequest) error); ok {
-		r0 = rf(ctx, request)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// CreateHostInfo provides a mock function with given fields: ctx, request
-func (_m *TChanMetadataService) CreateHostInfo(ctx thrift.Context, request *metadata.CreateHostInfoRequest) error {
-	ret := _m.Called(ctx, request)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.CreateHostInfoRequest) error); ok {
-		r0 = rf(ctx, request)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// DeleteHostInfo provides a mock function with given fields: ctx, request
-func (_m *TChanMetadataService) DeleteHostInfo(ctx thrift.Context, request *metadata.DeleteHostInfoRequest) error {
-	ret := _m.Called(ctx, request)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.DeleteHostInfoRequest) error); ok {
-		r0 = rf(ctx, request)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// ReadHostInfo provides a mock function with given fields: ctx, request
-func (_m *TChanMetadataService) ReadHostInfo(ctx thrift.Context, request *metadata.ReadHostInfoRequest) (*metadata.ReadHostInfoResult_, error) {
-	ret := _m.Called(ctx, request)
-
-	var r0 *metadata.ReadHostInfoResult_
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ReadHostInfoRequest) *metadata.ReadHostInfoResult_); ok {
-		r0 = rf(ctx, request)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*metadata.ReadHostInfoResult_)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ReadHostInfoRequest) error); ok {
-		r1 = rf(ctx, request)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// UpdateHostInfo provides a mock function with given fields: ctx, request
-func (_m *TChanMetadataService) UpdateHostInfo(ctx thrift.Context, request *metadata.UpdateHostInfoRequest) error {
-	ret := _m.Called(ctx, request)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.UpdateHostInfoRequest) error); ok {
-		r0 = rf(ctx, request)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// CreateServiceConfig provides a mock function with given fields: ctx, request
-func (_m *TChanMetadataService) CreateServiceConfig(ctx thrift.Context, request *metadata.CreateServiceConfigRequest) error {
-	ret := _m.Called(ctx, request)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.CreateServiceConfigRequest) error); ok {
-		r0 = rf(ctx, request)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// DeleteServiceConfig provides a mock function with given fields: ctx, request
-func (_m *TChanMetadataService) DeleteServiceConfig(ctx thrift.Context, request *metadata.DeleteServiceConfigRequest) error {
-	ret := _m.Called(ctx, request)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.DeleteServiceConfigRequest) error); ok {
-		r0 = rf(ctx, request)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // ReadServiceConfig provides a mock function with given fields: ctx, request
 func (_m *TChanMetadataService) ReadServiceConfig(ctx thrift.Context, request *metadata.ReadServiceConfigRequest) (*metadata.ReadServiceConfigResult_, error) {
 	ret := _m.Called(ctx, request)
@@ -925,6 +950,27 @@ func (_m *TChanMetadataService) ReadServiceConfig(ctx thrift.Context, request *m
 	var r1 error
 	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ReadServiceConfigRequest) error); ok {
 		r1 = rf(ctx, request)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// UUIDToHostAddr provides a mock function with given fields: ctx, hostUUID
+func (_m *TChanMetadataService) UUIDToHostAddr(ctx thrift.Context, hostUUID string) (string, error) {
+	ret := _m.Called(ctx, hostUUID)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(thrift.Context, string) string); ok {
+		r0 = rf(ctx, hostUUID)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, string) error); ok {
+		r1 = rf(ctx, hostUUID)
 	} else {
 		r1 = ret.Error(1)
 	}


### PR DESCRIPTION
This patch provides an implementation of APIs previously added to the interface as part of this https://github.com/uber/cherami-thrift/pull/7 - the goal is to expose light weight listExtents api that fetches only the interesting columns for controller. This patch also does a glide up to pick up the thrift changes. Other packages are also updated as part of the glide up. Manually inspected the commits for gorocksdb/cherami-client-go/gocql and confirmed they are safe.