### PR TITLE
RetMgr should potentially run on non-primary controller

### DIFF
--- a/common/rpm.go
+++ b/common/rpm.go
@@ -260,12 +260,19 @@ func (rpm *ringpopMonitorImpl) FindHostForKey(service string, key string) (*Host
 
 	// get list of hosts that for the given service
 	members, err := rpm.GetHosts(service)
-	if err != nil || members == nil || len(members) == 0 {
+	if err != nil {
+		return nil, err
+	}
+
+	if members == nil || len(members) == 0 {
 		return nil, ErrUnknownService
 	}
 
-	// pick the host corresponding to the hash
-	return members[hash%len(members)], nil
+	// pick the host corresponding to the hash and get a pointer to
+	// a copy of the HostInfo, since it is treated as immutable.
+	var host = *members[hash%len(members)]
+
+	return &host, nil
 }
 
 // IsHostHealthy returns true if the given host is healthy and false otherwise


### PR DESCRIPTION
Retention Manager uses 'FindHostForKey' to determine the controller host that it should run on. It uses a different key from what controller uses (to determine the primary controller), but it seems like the ret-mgr seems to always pick the primary controller as the host to run on.

I found that the root-cause is that 'FindHostForKey' (in common/rpm.go) ignore the "key" in picking the host. This change addresses that by using a hash of the given key to pick the host.
