### PR TITLE
Controller: Migrate to the light-weight listExtents API

### DIFF
--- a/services/controllerhost/api_handlers.go
+++ b/services/controllerhost/api_handlers.go
@@ -80,7 +80,7 @@ func isUUIDLengthValid(uuid string) bool {
 	return len(uuid) == common.UUIDStringLength
 }
 
-func isInputHealthy(context *Context, extent *shared.Extent) bool {
+func isInputHealthy(context *Context, extent *m.DestinationExtent) bool {
 	return context.rpm.IsHostHealthy(common.InputServiceName, extent.GetInputHostUUID())
 }
 
@@ -104,7 +104,7 @@ func isAnyStoreHealthy(context *Context, storeIDs []string) bool {
 	return false
 }
 
-func areExtentStoresHealthy(context *Context, extent *shared.Extent) bool {
+func areExtentStoresHealthy(context *Context, extent *m.DestinationExtent) bool {
 	for _, h := range extent.GetStoreUUIDs() {
 		if !context.rpm.IsHostHealthy(common.StoreServiceName, h) {
 			context.log.WithFields(bark.Fields{
@@ -196,14 +196,14 @@ func readDestination(context *Context, dstID string, m3Scope int) (*shared.Desti
 	return dstDesc, err
 }
 
-func findOpenExtents(context *Context, dstID string, m3Scope int) ([]*shared.ExtentStats, error) {
+func findOpenExtents(context *Context, dstID string, m3Scope int) ([]*m.DestinationExtent, error) {
 	filterBy := []shared.ExtentStatus{shared.ExtentStatus_OPEN}
-	extentStats, err := context.mm.ListExtentsByDstIDStatus(dstID, filterBy)
+	extents, err := context.mm.ListDestinationExtentsByStatus(dstID, filterBy)
 	if err != nil {
 		context.m3Client.IncCounter(m3Scope, metrics.ControllerErrMetadataReadCounter)
 		return nil, err
 	}
-	return extentStats, err
+	return extents, err
 }
 
 func getDstType(desc *shared.DestinationDescription) dstType {
@@ -247,7 +247,7 @@ func minOpenExtentsForDst(context *Context, dstPath string, dstType dstType) int
 	return int(common.OverrideValueByPrefix(logFn, dstPath, cfg.NumPublisherExtentsByPath, defaultMinOpenPublishExtents, `NumPublisherExtentsByPath`))
 }
 
-func getInputAddrIfExtentIsWritable(context *Context, extent *shared.Extent, m3Scope int) (string, error) {
+func getInputAddrIfExtentIsWritable(context *Context, extent *m.DestinationExtent, m3Scope int) (string, error) {
 	inputhost, err := context.rpm.ResolveUUID(common.InputServiceName, extent.GetInputHostUUID())
 	if err != nil {
 		context.log.
@@ -356,7 +356,7 @@ func refreshInputHostsForDst(context *Context, dstUUID string, now int64) ([]str
 	var minOpenExtents = minOpenExtentsForDst(context, dstDesc.GetPath(), dstType)
 	var isMultiZoneDest = dstDesc.GetIsMultiZone()
 
-	openExtentStats, err := findOpenExtents(context, dstUUID, m3Scope)
+	openExtents, err := findOpenExtents(context, dstUUID, m3Scope)
 	if err != nil {
 		// we can't get the metadata, let's
 		// continue to use the cached result
@@ -368,10 +368,9 @@ func refreshInputHostsForDst(context *Context, dstUUID string, now int64) ([]str
 	}
 
 	var nHealthy = 0
-	var inputHosts = make(map[string]*common.HostInfo, len(openExtentStats))
+	var inputHosts = make(map[string]*common.HostInfo, len(openExtents))
 
-	for _, stat := range openExtentStats {
-		ext := stat.GetExtent()
+	for _, ext := range openExtents {
 
 		// skip remote zone extent(read only)
 		if common.IsRemoteZoneExtent(ext.GetOriginZone(), context.localZone) {

--- a/services/controllerhost/api_handlers.go
+++ b/services/controllerhost/api_handlers.go
@@ -165,8 +165,8 @@ func validateDstStatus(dstDesc *shared.DestinationDescription) error {
 	}
 }
 
-func listConsumerGroupExtents(context *Context, dstUUID string, cgUUID string, m3Scope int, filterByStatus []m.ConsumerGroupExtentStatus) ([]*m.ConsumerGroupExtent, error) {
-	cgExtents, err := context.mm.ListExtentsByConsumerGroup(dstUUID, cgUUID, filterByStatus)
+func listConsumerGroupExtents(context *Context, dstUUID string, cgUUID string, m3Scope int, filterByStatus []m.ConsumerGroupExtentStatus) ([]*m.ConsumerGroupExtentLite, error) {
+	cgExtents, err := context.mm.ListExtentsByConsumerGroupLite(dstUUID, cgUUID, filterByStatus)
 	if err != nil {
 		context.m3Client.IncCounter(m3Scope, metrics.ControllerErrMetadataReadCounter)
 	}

--- a/services/controllerhost/event_handlers.go
+++ b/services/controllerhost/event_handlers.go
@@ -274,10 +274,10 @@ func (event *ExtentCreatedEvent) Handle(context *Context) error {
 	inHostIDs[event.inHostID] = true
 	// Notify all in hosts handling open extents for this destination
 	filterBy := []shared.ExtentStatus{shared.ExtentStatus_OPEN}
-	stats, err := mm.ListExtentsByDstIDStatus(event.dstID, filterBy)
+	extents, err := mm.ListDestinationExtentsByStatus(event.dstID, filterBy)
 	if err == nil {
-		for _, stat := range stats {
-			inHostIDs[stat.GetExtent().GetInputHostUUID()] = true
+		for _, ext := range extents {
+			inHostIDs[ext.GetInputHostUUID()] = true
 		}
 	} else {
 		context.m3Client.IncCounter(metrics.ExtentCreatedEventScope, metrics.ControllerErrMetadataReadCounter)

--- a/services/controllerhost/event_handlers.go
+++ b/services/controllerhost/event_handlers.go
@@ -328,7 +328,7 @@ func (event *ConsGroupUpdatedEvent) Handle(context *Context) error {
 	outHostIDs[event.outputHostID] = true
 
 	filterBy := []m.ConsumerGroupExtentStatus{m.ConsumerGroupExtentStatus_OPEN}
-	cgExtents, err := mm.ListExtentsByConsumerGroup(event.dstID, event.consGroupID, filterBy)
+	cgExtents, err := mm.ListExtentsByConsumerGroupLite(event.dstID, event.consGroupID, filterBy)
 	if err == nil {
 		for _, cge := range cgExtents {
 			outHostIDs[cge.GetOutputHostUUID()] = true
@@ -1003,7 +1003,7 @@ func reconfigureAllConsumers(context *Context, dstID, extentID, reason, reasonCo
 		}
 
 		filterBy := []m.ConsumerGroupExtentStatus{m.ConsumerGroupExtentStatus_OPEN}
-		extents, err := context.mm.ListExtentsByConsumerGroup(dstID, cgd.GetConsumerGroupUUID(), filterBy)
+		extents, err := context.mm.ListExtentsByConsumerGroupLite(dstID, cgd.GetConsumerGroupUUID(), filterBy)
 		if err != nil {
 			continue
 		}

--- a/services/controllerhost/extentmon.go
+++ b/services/controllerhost/extentmon.go
@@ -243,7 +243,7 @@ func (monitor *extentStateMonitor) processDestination(dstDesc *shared.Destinatio
 
 	var err error
 	var context = monitor.context
-	var stats []*shared.ExtentStats
+	var extents []*metadata.DestinationExtent
 
 	monitor.mi.publishEvent(eExtentIterStart, nil)
 
@@ -258,20 +258,20 @@ extentIter:
 		shared.ExtentStatus_DELETED,
 	} {
 		filterBy := []shared.ExtentStatus{status}
-		stats, err = context.mm.ListExtentsByDstIDStatus(dstDesc.GetDestinationUUID(), filterBy)
+		extents, err = context.mm.ListDestinationExtentsByStatus(dstDesc.GetDestinationUUID(), filterBy)
 		if err != nil {
 			monitor.ll.WithFields(bark.Fields{
 				common.TagDst:  dstDesc.GetDestinationUUID(),
 				common.TagErr:  err,
 				`filterStatus`: status}).
-				Error(`ListExtentsByDstIDStatus failed`)
+				Error(`ListDestinationExtentsByStatus failed`)
 			if monitor.sleep(intervalBtwnRetries) {
 				break extentIter
 			}
 			continue extentIter
 		}
 
-		monitor.processExtents(dstDesc, stats)
+		monitor.processExtents(dstDesc, extents)
 	}
 
 	monitor.mi.publishEvent(eExtentIterEnd, nil)
@@ -292,15 +292,13 @@ extentIter:
 	monitor.publishConsumerGroups(dstDesc)
 }
 
-func (monitor *extentStateMonitor) processExtents(dstDesc *shared.DestinationDescription, stats []*shared.ExtentStats) {
+func (monitor *extentStateMonitor) processExtents(dstDesc *shared.DestinationDescription, extents []*metadata.DestinationExtent) {
 
-	for _, stat := range stats {
+	for _, extent := range extents {
 
-		extent := stat.GetExtent()
+		monitor.mi.publishEvent(eExtent, extent)
 
-		monitor.mi.publishEvent(eExtent, stat)
-
-		switch stat.GetStatus() {
+		switch extent.GetStatus() {
 		case shared.ExtentStatus_OPEN:
 			if !common.IsRemoteZoneExtent(extent.GetOriginZone(), monitor.context.localZone) && (dstDesc.GetStatus() == shared.DestinationStatus_DELETING || !monitor.isExtentHealthy(dstDesc, extent)) {
 				// rate limit extent seals to limit the
@@ -309,7 +307,7 @@ func (monitor *extentStateMonitor) processExtents(dstDesc *shared.DestinationDes
 				if !monitor.rateLimiter.Consume(1, 2*time.Second) {
 					continue
 				}
-				addExtentDownEvent(monitor.context, 0, extent.GetDestinationUUID(), extent.GetExtentUUID())
+				addExtentDownEvent(monitor.context, 0, dstDesc.GetDestinationUUID(), extent.GetExtentUUID())
 			}
 		default:
 			// from a store perspective, an extent is either sealed or
@@ -318,7 +316,7 @@ func (monitor *extentStateMonitor) processExtents(dstDesc *shared.DestinationDes
 			// if not, fix the out of sync ones. Do this check only
 			// after some minimum time since the last status update
 			// to allow for everything to catch up.
-			lastUpdateTime := time.Unix(0, stat.GetStatusUpdatedTimeMillis()*int64(time.Millisecond))
+			lastUpdateTime := time.Unix(0, extent.GetStatusUpdatedTimeMillis()*int64(time.Millisecond))
 			if time.Since(lastUpdateTime) > 2*extentCacheTTL {
 				monitor.fixOutOfSyncStoreExtents(dstDesc.GetDestinationUUID(), extent)
 			}
@@ -332,7 +330,7 @@ func (monitor *extentStateMonitor) processExtents(dstDesc *shared.DestinationDes
 // For a remote zone extent, store will mark a store extent as sealed
 // only after it gets the sealed marker from replication
 // So we don't need to sync the status for remote zone extent
-func (monitor *extentStateMonitor) fixOutOfSyncStoreExtents(dstID string, extent *shared.Extent) {
+func (monitor *extentStateMonitor) fixOutOfSyncStoreExtents(dstID string, extent *metadata.DestinationExtent) {
 	if common.IsRemoteZoneExtent(extent.GetOriginZone(), monitor.context.localZone) {
 		return
 	}
@@ -608,7 +606,7 @@ func (monitor *extentStateMonitor) listConsumerGroups(dstID string) ([]*shared.C
 	return cgdSlice, err
 }
 
-func (monitor *extentStateMonitor) isExtentHealthy(dstDesc *shared.DestinationDescription, extent *shared.Extent) bool {
+func (monitor *extentStateMonitor) isExtentHealthy(dstDesc *shared.DestinationDescription, extent *metadata.DestinationExtent) bool {
 
 	context := monitor.context
 	dstID := dstDesc.GetDestinationUUID()

--- a/services/controllerhost/extentmon_test.go
+++ b/services/controllerhost/extentmon_test.go
@@ -144,15 +144,12 @@ func (s *ExtentStateMonitorSuite) TestStoreExtentStatusOutOfSync() {
 	s.mcp.context.extentMonitor.mi.publishEvent(eIterStart, nil)
 	s.mcp.context.extentMonitor.mi.publishEvent(eDestStart, desc)
 	s.mcp.context.extentMonitor.mi.publishEvent(eExtentIterStart, nil)
-	s.mcp.context.extentMonitor.processExtents(desc, []*shared.ExtentStats{
+	s.mcp.context.extentMonitor.processExtents(desc, []*m.DestinationExtent{
 		{
-			Status: common.MetadataExtentStatusPtr(shared.ExtentStatus_SEALED),
-			Extent: &shared.Extent{
-				DestinationUUID: common.StringPtr(desc.GetDestinationUUID()),
-				ExtentUUID:      common.StringPtr(extentID),
-				InputHostUUID:   common.StringPtr(inHostID),
-				StoreUUIDs:      storeIDs,
-			},
+			Status:        common.MetadataExtentStatusPtr(shared.ExtentStatus_SEALED),
+			ExtentUUID:    common.StringPtr(extentID),
+			InputHostUUID: common.StringPtr(inHostID),
+			StoreUUIDs:    storeIDs,
 		},
 	})
 	s.mcp.context.extentMonitor.mi.publishEvent(eExtentIterEnd, nil)

--- a/services/controllerhost/mIterator.go
+++ b/services/controllerhost/mIterator.go
@@ -76,7 +76,7 @@ type mIterator struct {
 type mIteratorEvent struct {
 	t          mIteratorEventType
 	dest       *shared.DestinationDescription
-	extent     *shared.ExtentStats
+	extent     *metadata.DestinationExtent
 	cnsm       *shared.ConsumerGroupDescription
 	cnsmExtent *metadata.ConsumerGroupExtent
 }
@@ -206,7 +206,7 @@ func (i *mIterator) publishEvent(t mIteratorEventType, obj interface{}) {
 	case eDestStart:
 		i.current.dest = obj.(*shared.DestinationDescription)
 	case eExtent:
-		i.current.extent = obj.(*shared.ExtentStats)
+		i.current.extent = obj.(*metadata.DestinationExtent)
 	case eCnsmStart:
 		i.current.cnsm = obj.(*shared.ConsumerGroupDescription)
 	case eCnsmExtent:

--- a/services/controllerhost/mIterator.go
+++ b/services/controllerhost/mIterator.go
@@ -78,7 +78,7 @@ type mIteratorEvent struct {
 	dest       *shared.DestinationDescription
 	extent     *metadata.DestinationExtent
 	cnsm       *shared.ConsumerGroupDescription
-	cnsmExtent *metadata.ConsumerGroupExtent
+	cnsmExtent *metadata.ConsumerGroupExtentLite
 }
 
 type mIteratorHandler interface {
@@ -210,7 +210,7 @@ func (i *mIterator) publishEvent(t mIteratorEventType, obj interface{}) {
 	case eCnsmStart:
 		i.current.cnsm = obj.(*shared.ConsumerGroupDescription)
 	case eCnsmExtent:
-		i.current.cnsmExtent = obj.(*metadata.ConsumerGroupExtent)
+		i.current.cnsmExtent = obj.(*metadata.ConsumerGroupExtentLite)
 	case eIterStart:
 	case eIterEnd:
 	case eDestEnd:

--- a/services/controllerhost/metadataMgr.go
+++ b/services/controllerhost/metadataMgr.go
@@ -357,7 +357,7 @@ func (mm *metadataMgrImpl) ListExtentsByReplicationStatus(storeID string, status
 
 func (mm *metadataMgrImpl) ListExtentsByConsumerGroupLite(dstID string, cgID string, filterByStatus []m.ConsumerGroupExtentStatus) ([]*m.ConsumerGroupExtentLite, error) {
 
-	mReq := &m.ReadConsumerGroupExtentsRequest{
+	mReq := &m.ReadConsumerGroupExtentsLiteRequest{
 		DestinationUUID:   common.StringPtr(dstID),
 		ConsumerGroupUUID: common.StringPtr(cgID),
 		MaxResults:        common.Int32Ptr(defaultPageSize),

--- a/services/controllerhost/sort.go
+++ b/services/controllerhost/sort.go
@@ -23,39 +23,39 @@ package controllerhost
 import (
 	"sort"
 
-	"github.com/uber/cherami-thrift/.generated/go/shared"
+	"github.com/uber/cherami-thrift/.generated/go/metadata"
 )
 
 type extentStatsSorter struct {
-	stats   []*shared.ExtentStats
-	cmpFunc func(a, b *shared.ExtentStats) bool
+	extents []*metadata.DestinationExtent
+	cmpFunc func(a, b *metadata.DestinationExtent) bool
 }
 
 // Len implements sort.Interace
 func (s *extentStatsSorter) Len() int {
-	return len(s.stats)
+	return len(s.extents)
 }
 
 // Swap implements sort.Interface.
 func (s *extentStatsSorter) Swap(i, j int) {
-	s.stats[i], s.stats[j] = s.stats[j], s.stats[i]
+	s.extents[i], s.extents[j] = s.extents[j], s.extents[i]
 }
 
 // Less implements sort.Interface
 func (s *extentStatsSorter) Less(i, j int) bool {
-	return s.cmpFunc(s.stats[i], s.stats[j])
+	return s.cmpFunc(s.extents[i], s.extents[j])
 }
 
 // cmpExtentStatsByTime compares two extent stats
 // by createdTime and returns true, if a is less
 // than by
-func cmpExtentStatsByTime(a, b *shared.ExtentStats) bool {
+func cmpExtentStatsByTime(a, b *metadata.DestinationExtent) bool {
 	return a.GetCreatedTimeMillis() < b.GetCreatedTimeMillis()
 }
 
-func sortExtentStatsByTime(stats []*shared.ExtentStats) {
+func sortExtentStatsByTime(extents []*metadata.DestinationExtent) {
 	sorter := &extentStatsSorter{
-		stats:   stats,
+		extents: extents,
 		cmpFunc: cmpExtentStatsByTime,
 	}
 	sort.Sort(sorter)


### PR DESCRIPTION
This patch migrates the controller to use the new light weight list APIs. Almost everything within controller except parts of queueDepth are switched to the new implementation. This change is transparent to the unit tests, which can still continue to use the old apis.