### PR TITLE
Output admin commands

### DIFF
--- a/clients/outputhost/client.go
+++ b/clients/outputhost/client.go
@@ -67,3 +67,19 @@ func (s *OutClientImpl) UnloadConsumerGroups(req *admin.UnloadConsumerGroupsRequ
 
 	return s.client.UnloadConsumerGroups(ctx, req)
 }
+
+// ListLoadedConsumerGroups lists all the loaded cgs from the outputhost
+func (s *OutClientImpl) ListLoadedConsumerGroups() (*admin.ListConsumerGroupsResult_, error) {
+	ctx, cancel := tcthrift.NewContext(15 * time.Second)
+	defer cancel()
+
+	return s.client.ListLoadedConsumerGroups(ctx)
+}
+
+// ReadCgState
+func (s *OutClientImpl) ReadCgState(req *admin.ReadConsumerGroupStateRequest) (*admin.ReadConsumerGroupStateResult_, error) {
+	ctx, cancel := tcthrift.NewContext(15 * time.Second)
+	defer cancel()
+
+	return s.client.ReadCgState(ctx, req)
+}

--- a/cmd/tools/admin/main.go
+++ b/cmd/tools/admin/main.go
@@ -619,7 +619,7 @@ func main() {
 						cli.StringFlag{
 							Name:  "cg_uuid, cg",
 							Value: "",
-							Usage: "The consumergroup UUID whose in-memory state to dump",
+							Usage: "The UUID of the consumer group whose state will be dumped",
 						},
 					},
 					Action: func(c *cli.Context) {
@@ -649,8 +649,9 @@ func main() {
 						admin.UnloadConsumerGroup(c)
 					},
 				},
-      },
-      {
+			},
+		},
+		{
 			Name:    "seal-check",
 			Aliases: []string{"sc"},
 			Usage:   "seal-check <dest> [--seal]",

--- a/cmd/tools/admin/main.go
+++ b/cmd/tools/admin/main.go
@@ -569,28 +569,6 @@ func main() {
 			},
 		},
 		{
-			Name:    "unload",
-			Aliases: []string{"ul"},
-			Usage:   "unload (consumergroup)",
-			Subcommands: []cli.Command{
-				{
-					Name:    "consumergroup",
-					Aliases: []string{"c", "cg"},
-					Usage:   "unload consumergroup <hostport> [options]",
-					Flags: []cli.Flag{
-						cli.StringFlag{
-							Name:  "cg_uuid, u",
-							Value: "",
-							Usage: "The consumergroup UUID which should be unloaded",
-						},
-					},
-					Action: func(c *cli.Context) {
-						admin.UnloadConsumerGroup(c)
-					},
-				},
-			},
-		},
-		{
 			Name:    "serviceconfig",
 			Aliases: []string{"cfg"},
 			Usage:   "serviceconfig (get|set|delete)",
@@ -624,6 +602,51 @@ func main() {
 					Usage:   "serviceconfig delete <service-name.version.sku.hostname.config-key>",
 					Action: func(c *cli.Context) {
 						admin.DeleteServiceConfig(c)
+					},
+				},
+			},
+		},
+		{
+			Name:    "outputhost",
+			Aliases: []string{"oh"},
+			Usage:   "outputhost (cgstate|listAllCgs|unloadcg)",
+			Subcommands: []cli.Command{
+				{
+					Name:    "cgstate",
+					Aliases: []string{"cgs"},
+					Usage:   "outputhost cgstate <hostport> [options]",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "cg_uuid, cg",
+							Value: "",
+							Usage: "The consumergroup UUID whose in-memory state to dump",
+						},
+					},
+					Action: func(c *cli.Context) {
+						admin.GetCgState(c)
+					},
+				},
+				{
+					Name:    "listAllCgs",
+					Aliases: []string{"ls"},
+					Usage:   "outputhost listAllCgs <hostport>",
+					Action: func(c *cli.Context) {
+						admin.ListAllCgs(c)
+					},
+				},
+				{
+					Name:    "unloadcg",
+					Aliases: []string{"uc"},
+					Usage:   "outputhost unloadcg <hostport> [options]",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "cg_uuid, cg",
+							Value: "",
+							Usage: "The consumergroup UUID which should be unloaded",
+						},
+					},
+					Action: func(c *cli.Context) {
+						admin.UnloadConsumerGroup(c)
 					},
 				},
 			},

--- a/common/convert.go
+++ b/common/convert.go
@@ -46,6 +46,11 @@ func TSPtr(v time.Time) *time.Time {
 	return &v
 }
 
+// Int16Ptr makes a copy and returns the pointer to an int16.
+func Int16Ptr(v int16) *int16 {
+	return &v
+}
+
 // Int32Ptr makes a copy and returns the pointer to an int32.
 func Int32Ptr(v int32) *int32 {
 	return &v

--- a/glide.lock
+++ b/glide.lock
@@ -98,7 +98,7 @@ imports:
   - require
   - suite
 - name: github.com/tecbot/gorocksdb
-  version: f2a0b10f7228cff360e2d9efa081a15a8cbd68b7
+  version: 17991d3138a879b166adebf86f7c84da3c1517a7
 - name: github.com/uber-common/bark
   version: 8841a0f8e7ca869284ccb29c08a14cf3f4310f46
 - name: github.com/uber-go/atomic

--- a/glide.lock
+++ b/glide.lock
@@ -98,7 +98,7 @@ imports:
   - require
   - suite
 - name: github.com/tecbot/gorocksdb
-  version: 17991d3138a879b166adebf86f7c84da3c1517a7
+  version: f2a0b10f7228cff360e2d9efa081a15a8cbd68b7
 - name: github.com/uber-common/bark
   version: 8841a0f8e7ca869284ccb29c08a14cf3f4310f46
 - name: github.com/uber-go/atomic
@@ -113,7 +113,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: 0f0585c53937209f08a57c6ae51d8a7fd281e100
+  version: 0c533e4976e642ddf87456203395fdb45456e00e
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 95f30a537dc5b2841e061722d66e26c58126e82c19e9ba29bb6b0f44cf1741d0
-updated: 2017-01-31T14:55:02.42070453-08:00
+updated: 2017-02-14T08:55:45.490984145-08:00
 imports:
 - name: github.com/apache/thrift
   version: 2d6060d882069ed3e3d6302aa63ea7eb4bb155ad
@@ -98,7 +98,7 @@ imports:
   - require
   - suite
 - name: github.com/tecbot/gorocksdb
-  version: 17991d3138a879b166adebf86f7c84da3c1517a7 
+  version: 17991d3138a879b166adebf86f7c84da3c1517a7
 - name: github.com/uber-common/bark
   version: 8841a0f8e7ca869284ccb29c08a14cf3f4310f46
 - name: github.com/uber-go/atomic
@@ -113,7 +113,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: a80cedb0790594d2f09211c99842205b1474a32d 
+  version: 2e84419711eb57a3be7412c18de80f9fe7a0cc60
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/glide.yaml
+++ b/glide.yaml
@@ -34,6 +34,7 @@ import:
   - common/websocket
   - stream
 - package: github.com/uber/cherami-thrift
+  version: output_admin
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/glide.yaml
+++ b/glide.yaml
@@ -34,7 +34,6 @@ import:
   - common/websocket
   - stream
 - package: github.com/uber/cherami-thrift
-  version: output_admin
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/services/controllerhost/event_pipeline_test.go
+++ b/services/controllerhost/event_pipeline_test.go
@@ -715,3 +715,11 @@ func (service *MockInputOutputService) GetUpdatedCount(key string) int {
 func (service *MockInputOutputService) UnloadConsumerGroups(ctx thrift.Context, request *admin.UnloadConsumerGroupsRequest) error {
 	return fmt.Errorf("mock not implemented")
 }
+
+func (service *MockInputOutputService) ListLoadedConsumerGroups(ctx thrift.Context) (*admin.ListConsumerGroupsResult_, error) {
+	return nil, fmt.Errorf("mock not implemented")
+}
+
+func (service *MockInputOutputService) ReadCgState(ctx thrift.Context, req *admin.ReadConsumerGroupStateRequest) (*admin.ReadConsumerGroupStateResult_, error) {
+	return nil, fmt.Errorf("mock not implemented")
+}

--- a/services/outputhost/extcache.go
+++ b/services/outputhost/extcache.go
@@ -37,6 +37,7 @@ import (
 	"github.com/uber/cherami-server/common"
 	"github.com/uber/cherami-server/services/outputhost/load"
 	serverStream "github.com/uber/cherami-server/stream"
+	"github.com/uber/cherami-thrift/.generated/go/admin"
 	"github.com/uber/cherami-thrift/.generated/go/cherami"
 	"github.com/uber/cherami-thrift/.generated/go/controller"
 	"github.com/uber/cherami-thrift/.generated/go/metadata"
@@ -413,4 +414,16 @@ func (extCache *extentCache) unload() {
 	extCache.cacheMutex.Lock()
 	close(extCache.closeChannel)
 	extCache.cacheMutex.Unlock()
+}
+
+func (extCache *extentCache) getState() *admin.OutputCgExtent {
+	cge := admin.NewOutputCgExtent()
+	cge.ExtentUUID = common.StringPtr(extCache.extUUID)
+	cge.ConnectedStoreUUID = common.StringPtr(extCache.connectedStoreUUID)
+	cge.NumCreditsSentToStore = common.Int32Ptr(int32(extCache.connection.sentCreds))
+	cge.NumMsgsReadFromStore = common.Int32Ptr(int32(extCache.connection.recvMsgs))
+	cge.StartSequence = common.Int64Ptr(int64(extCache.connection.startingSequence))
+	cge.AckMgrState = extCache.ackMgr.getAckMgrState()
+
+	return cge
 }

--- a/tools/admin/lib.go
+++ b/tools/admin/lib.go
@@ -134,6 +134,16 @@ func UnloadConsumerGroup(c *cli.Context) {
 	toolscommon.UnloadConsumerGroup(c, mClient)
 }
 
+// ListAllCgs unloads the CG on the given outputhost
+func ListAllCgs(c *cli.Context) {
+	toolscommon.ListAllConsumerGroups(c)
+}
+
+// GetCgState gets the cg state on the given outputhost
+func GetCgState(c *cli.Context) {
+	toolscommon.GetConsumerGroupState(c)
+}
+
 // ReadCgBacklog reads cg backlog
 func ReadCgBacklog(c *cli.Context) {
 	cClient := toolscommon.GetCClient(c, adminToolService)

--- a/tools/common/lib.go
+++ b/tools/common/lib.go
@@ -427,6 +427,85 @@ func UnloadConsumerGroup(c *cli.Context, mClient mcli.Client) {
 	ExitIfError(err)
 }
 
+// ListAllConsumerGroups lists all loaded CGs in memory of the outputhost
+func ListAllConsumerGroups(c *cli.Context) {
+	if len(c.Args()) < 1 {
+		ExitIfError(errors.New(strNotEnoughArgs))
+	}
+
+	hostPort := c.Args()[0]
+
+	// generate a random instance id to be used to create a client tchannel
+	instanceID := rand.Intn(50000)
+	outputClient, err := outputhost.NewClient(instanceID, hostPort)
+	ExitIfError(err)
+	defer outputClient.Close()
+
+	listCgResult, err := outputClient.ListLoadedConsumerGroups()
+	ExitIfError(err)
+
+	if listCgResult != nil {
+		for _, cg := range listCgResult.Cgs {
+			fmt.Printf("%v\n", Jsonify(cg))
+		}
+	}
+}
+
+// GetConsumerGroupState unloads the CG based on cli.Context
+func GetConsumerGroupState(c *cli.Context) {
+	if len(c.Args()) < 1 {
+		ExitIfError(errors.New(strNotEnoughArgs))
+	}
+
+	hostPort := c.Args()[0]
+	cgUUID := c.String("cg_uuid")
+
+	if !uuidRegex.MatchString(cgUUID) {
+		ExitIfError(errors.New("specify a valid cg UUID"))
+	}
+
+	// generate a random instance id to be used to create a client tchannel
+	instanceID := rand.Intn(50000)
+	outputClient, err := outputhost.NewClient(instanceID, hostPort)
+	ExitIfError(err)
+	defer outputClient.Close()
+
+	cgStateReq := admin.NewReadConsumerGroupStateRequest()
+	cgStateReq.CgUUIDs = []string{cgUUID}
+
+	readcgStateRes, err1 := outputClient.ReadCgState(cgStateReq)
+	ExitIfError(err1)
+
+	fmt.Printf("sessionID: %v\n", readcgStateRes.GetSessionID())
+
+	for _, cg := range readcgStateRes.CgState {
+		printCgState(cg)
+		for _, ext := range cg.CgExtents {
+			fmt.Printf("\t%v\n", Jsonify(ext))
+		}
+	}
+}
+
+type cgStateJSONOutput struct {
+	CgUUID             string `json""cgUUID"`
+	NumOutstandingMsgs int32  `json:"numOutstandingMsgs"`
+	MsgChSize          int64  `json:"msgChSize"`
+	MsgCacheChSize     int64  `json:"msgCacheChSize"`
+	NumConnections     int64  `json:"numConnections"`
+}
+
+func printCgState(cgState *admin.ConsumerGroupState) {
+	output := &cgStateJSONOutput{
+		CgUUID:             cgState.GetCgUUID(),
+		NumOutstandingMsgs: cgState.GetNumOutstandingMsgs(),
+		MsgChSize:          cgState.GetMsgChSize(),
+		MsgCacheChSize:     cgState.GetMsgCacheChSize(),
+		NumConnections:     cgState.GetNumConnections(),
+	}
+	outputStr, _ := json.Marshal(output)
+	fmt.Fprintln(os.Stdout, string(outputStr))
+}
+
 type destDescJSONOutputFields struct {
 	Path                        string                          `json:"path"`
 	UUID                        string                          `json:"uuid"`


### PR DESCRIPTION
This patch adds a couple of admin commands on outputhost to inspect the
in-memory cg and ack manager states.

(1) The first command is to list all loaded consumer groups on a
specific outputhost
(2) The second command is to read the cg state on an outputhost given
the cgUUID. The cg state includes all in-memory info about this cg and
also the AckManager for all the extents within this CG. This will be
helpful in finding "how many holes are present in the ack manager since
the last ack level".