### PR TITLE
Avoid sealing at a specific seq# on an ExtentUnreachable notification

### DIFF
--- a/services/controllerhost/event_handlers.go
+++ b/services/controllerhost/event_handlers.go
@@ -1049,11 +1049,12 @@ func sealExtentOnStore(context *Context, storeUUID string, storeAddr string, ext
 
 	defer context.clientFactory.ReleaseThriftStoreClient(storeUUID)
 
+	// Avoid specifying a seal sequence
+	// number for now. Input host can issue
+	// a seal-request asynchronously while its
+	// still accepting new messages.
 	req := store.NewSealExtentRequest()
 	req.ExtentUUID = common.StringPtr(extentID)
-	if seq > 0 {
-		req.SequenceNumber = common.Int64Ptr(seq)
-	}
 
 	var timeout = sealExtentInitialCallTimeout
 	var retryPolicy = sealExtentInitialRetryPolicy()


### PR DESCRIPTION
This patch contains the change in controller to exclude seal seq# on a SealExtentRequest to store. Currently, controller can issue a seal to the store for a few reasons and one of them is inputHost requesting for a SEAL (extentSizeLimit). When this happens, inputhost will issue the sealRequest to controller asynchronously while still accepting new messages. To avoid a race, its best to avoid sealing at a specific sequence number from controller (as a short term fix). 