### PR TITLE
Fix metrics crash in frontend::getQueueDepthInfo

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -352,6 +352,8 @@ const (
 	PurgeDLQForConsumerGroupScope
 	// MergeDLQForConsumerGroupScope represents MergeDLQForConsumerGroup API in frontend
 	MergeDLQForConsumerGroupScope
+	// GetQueueDepthInfoScope
+	GetQueueDepthInfoScope
 
 	// -- Operation scopes for StoreHost --
 
@@ -479,6 +481,7 @@ var scopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		CompleteMessageBatchScope:     {operation: "CompleteMessageBatch"},
 		PurgeDLQForConsumerGroupScope: {operation: "PurgeDLQForConsumerGroup"},
 		MergeDLQForConsumerGroupScope: {operation: "MergeDLQForConsumerGroup"},
+		GetQueueDepthInfoScope:        {operation: "GetQueueDepthInfo"},
 	},
 
 	// Inputhost operation tag values as seen by the Metrics backend

--- a/services/frontendhost/frontend.go
+++ b/services/frontendhost/frontend.go
@@ -1296,7 +1296,8 @@ func (h *Frontend) MergeDLQForConsumerGroup(ctx thrift.Context, mergeRequest *c.
 
 // GetQueueDepthInfo return queue depth info based on the key provided
 func (h *Frontend) GetQueueDepthInfo(ctx thrift.Context, queueRequest *c.GetQueueDepthInfoRequest) (result *c.GetQueueDepthInfoResult_, err error) {
-	defer func() { h.epilog(-1, result, &err) }()
+	sw := h.m3Client.StartTimer(metrics.GetQueueDepthInfoScope, metrics.FrontendLatencyTimer)
+	defer func() { sw.Stop(); h.epilog(metrics.GetQueueDepthInfoScope, result, &err) }()
 	if _, err = h.prolog(ctx, queueRequest); err != nil {
 		return
 	}


### PR DESCRIPTION
getQueueDepthInfo wasn't working because a metrics crash was introduced by epilog changes, and it went undiscovered because there was no unit test for this supposedly internal API.

I considered 'fixing' the metrics crash by modifying metrics.go, but such metrics crashes would not be an issue with even basic unit test coverage, which is a requirement for any metricated API.

`panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x6cf3e8]
goroutine 2541545 [running]:
panic(0xcac280, 0xc42000c0f0)
        /usr/lib/go-1.7/src/runtime/panic.go:500 +0x1a1
code.uber.internal/odp/cherami/vendor/github.com/uber/cherami-server/common/metrics.(*ClientImpl).IncCounter(0xc420422880, 0xffffffffffffffff, 0x46)
        code.uber.internal/odp/cherami/vendor/github.com/uber/cherami-server/common/metrics/metrics.go:165 +0x58
code.uber.internal/odp/cherami/vendor/github.com/uber/cherami-server/services/frontendhost.(*Frontend).epilogErr(0xc4203d40e0, 0x146b560, 0xc42047cae0, 0xffffffffffff
        code.uber.internal/odp/cherami/vendor/github.com/uber/cherami-server/services/frontendhost/frontend.go:1512 +0x51
code.uber.internal/odp/cherami/vendor/github.com/uber/cherami-server/services/frontendhost.(*Frontend).epilog(0xc4203d40e0, 0xffffffffffffffff, 0xd18240, 0x0, 0xc42d4
        code.uber.internal/odp/cherami/vendor/github.com/uber/cherami-server/services/frontendhost/frontend.go:1506 +0x69
code.uber.internal/odp/cherami/vendor/github.com/uber/cherami-server/services/frontendhost.(*Frontend).GetQueueDepthInfo.func1(0xc4203d40e0, 0xc42d4a0aa0, 0xc42d4a0aa
        code.uber.internal/odp/cherami/vendor/github.com/uber/cherami-server/services/frontendhost/frontend.go:1289 +0x59
code.uber.internal/odp/cherami/vendor/github.com/uber/cherami-server/services/frontendhost.(*Frontend).GetQueueDepthInfo(0xc4203d40e0, 0x7fa6917204f8, 0xc42c5cbec0, 0
        code.uber.internal/odp/cherami/vendor/github.com/uber/cherami-server/services/frontendhost/frontend.go:1291 +0x7b9
code.uber.internal/odp/cherami/vendor/github.com/uber/cherami-thrift/.generated/go/cherami.(*tchanBFrontendServer).handleGetQueueDepthInfo(0xc420568670, 0x7fa6917204f
        code.uber.internal/odp/cherami/vendor/github.com/uber/cherami-thrift/.generated/go/cherami/tchan-cherami.go:607 +0x100
code.uber.internal/odp/cherami/vendor/github.com/uber/cherami-thrift/.generated/go/cherami.(*tchanBFrontendServer).Handle(0xc420568670, 0x7fa6917204f8, 0xc42c5cbec0, 
        code.uber.internal/odp/cherami/vendor/github.com/uber/cherami-thrift/.generated/go/cherami/tchan-cherami.go:419 +0x814
code.uber.internal/odp/cherami/vendor/github.com/uber/tchannel-go/thrift.(*Server).handle(0xc42026e050, 0x7fa69175f550, 0xc42c5cbdb0, 0x1464040, 0xc420568670, 0x0, 0x
        code.uber.internal/odp/cherami/vendor/github.com/uber/tchannel-go/thrift/server.go:133 +0x2a8
code.uber.internal/odp/cherami/vendor/github.com/uber/tchannel-go/thrift.(*Server).Handle(0xc42026e050, 0x7fa69175f550, 0xc42c5cbdb0, 0xc42c886180)
        code.uber.internal/odp/cherami/vendor/github.com/uber/tchannel-go/thrift/server.go:203 +0x1b8
code.uber.internal/odp/cherami/vendor/github.com/uber/tchannel-go.(*handlerMap).Handle(0xc4204266e0, 0x7fa69175f550, 0xc42c5cbdb0, 0xc42c886180)
        code.uber.internal/odp/cherami/vendor/github.com/uber/tchannel-go/handlers.go:118 +0xf2
code.uber.internal/odp/cherami/vendor/github.com/uber/tchannel-go.channelHandler.Handle(0xc4200b0000, 0x7fa69175f550, 0xc42c5cbdb0, 0xc42c886180)
        code.uber.internal/odp/cherami/vendor/github.com/uber/tchannel-go/handlers.go:126 +0x96
code.uber.internal/odp/cherami/vendor/github.com/uber/tchannel-go.(*Connection).dispatchInbound(0xc42843e000, 0x200000721, 0xc42c886180, 0xc42b7f47e0)
        code.uber.internal/odp/cherami/vendor/github.com/uber/tchannel-go/inbound.go:195 +0x3a8
created by code.uber.internal/odp/cherami/vendor/github.com/uber/tchannel-go.(*Connection).handleCallReq
        code.uber.internal/odp/cherami/vendor/github.com/uber/tchannel-go/inbound.go:135 +0x1e08
`