### PR TITLE
Replicator fix deadlock

### DIFF
--- a/services/replicator/metadataReconciler.go
+++ b/services/replicator/metadataReconciler.go
@@ -621,7 +621,7 @@ func (r *metadataReconciler) sealExtentInStore(destUUID string, extentUUID strin
 
 	var errorOccured bool
 	for _, store := range readExtentResult.GetExtentStats().GetExtent().GetStoreUUIDs() {
-		storeClient, _, err := r.replicator.clientFactory.GetThriftStoreClientUUID(store, destUUID)
+		storeClient, _, err := r.replicator.GetClientFactory().GetThriftStoreClientUUID(store, destUUID)
 		if err != nil {
 			lclLg.WithFields(bark.Fields{
 				common.TagErr:  err,

--- a/services/replicator/metadataReconciler.go
+++ b/services/replicator/metadataReconciler.go
@@ -71,7 +71,7 @@ const (
 	runInterval                    = time.Duration(10 * time.Minute)
 	metadataListRequestPageSize    = 50
 	storeCallTimeout               = 10 * time.Second
-	extentMissingDurationThreshold = time.Duration(24 * time.Hour)
+	extentMissingDurationThreshold = time.Duration(1 * time.Hour)
 )
 
 // NewMetadataReconciler returns an instance of MetadataReconciler

--- a/services/replicator/replicator.go
+++ b/services/replicator/replicator.go
@@ -123,7 +123,6 @@ func NewReplicator(serviceName string, sVice common.SCommon, metadataClient meta
 		defaultAuthoritativeZone: config.GetReplicatorConfig().GetDefaultAuthoritativeZone(),
 		tenancy:                  tenancy,
 		replicatorclientFactory:  replicatorClientFactory,
-		clientFactory:            sVice.GetClientFactory(),
 		remoteReplicatorConn:     make(map[string]*outConnection),
 		storehostConn:            make(map[string]*outConnection),
 	}
@@ -142,6 +141,7 @@ func (r *Replicator) Start(thriftService []thrift.TChanServer) {
 	r.hostIDHeartbeater = common.NewHostIDHeartbeater(r.metaClient, r.GetHostUUID(), r.GetHostPort(), r.GetHostName(), r.logger)
 	r.hostIDHeartbeater.Start()
 	r.replicatorclientFactory.SetTChannel(r.GetTChannel())
+	r.clientFactory = r.GetClientFactory()
 
 	r.metadataReconciler = NewMetadataReconciler(r.metaClient, r, r.localZone, r.logger, r.m3Client)
 	r.metadataReconciler.Start()

--- a/services/replicator/replicator.go
+++ b/services/replicator/replicator.go
@@ -61,7 +61,6 @@ type (
 		tenancy                   string
 		defaultAuthoritativeZone  string
 		replicatorclientFactory   ClientFactory
-		clientFactory             common.ClientFactory
 		remoteReplicatorConn      map[string]*outConnection
 		remoteReplicatorConnMutex sync.RWMutex
 		storehostConn             map[string]*outConnection
@@ -141,7 +140,6 @@ func (r *Replicator) Start(thriftService []thrift.TChanServer) {
 	r.hostIDHeartbeater = common.NewHostIDHeartbeater(r.metaClient, r.GetHostUUID(), r.GetHostPort(), r.GetHostName(), r.logger)
 	r.hostIDHeartbeater.Start()
 	r.replicatorclientFactory.SetTChannel(r.GetTChannel())
-	r.clientFactory = r.GetClientFactory()
 
 	r.metadataReconciler = NewMetadataReconciler(r.metaClient, r, r.localZone, r.logger, r.m3Client)
 	r.metadataReconciler.Start()


### PR DESCRIPTION
the way replicator uses GetClientFactory causes a deadlock because we try to get it before starting service. Simple fix is to remove the variable.