### PR TITLE
Fix code coverage: make integ tests count

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ install:
   - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
-  - go get github.com/wadey/gocovmerge
   - ccm create test -v 2.2.8 -n 1 -s
   - sudo ln -sf /home/travis/.local/bin/cqlsh /usr/local/bin/cqlsh
   - glide install && touch vendor/glide.updated

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ install:
   - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
+  - go get github.com/wadey/gocovmerge
   - ccm create test -v 2.2.8 -n 1 -s
   - sudo ln -sf /home/travis/.local/bin/cqlsh /usr/local/bin/cqlsh
   - glide install && touch vendor/glide.updated

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ cover_profile: bins
 	done
 
 	# merge the package cover files into one single cover
-	gocovmerge `find $(BUILD) -name "coverage.out"` > $(BUILD)/cover.out
+	gocovmerge `find $(BUILD) -name "coverage.out" | grep -v "$(BUILD)/tools"` > $(BUILD)/cover.out
 
 cover: cover_profile
 	go tool cover -html=$(BUILD)/cover.out

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 SHELL = /bin/bash
 
 PROJECT_ROOT=github.com/uber/cherami-server
+INTEG_TEST_ROOT=./test
 export GO15VENDOREXPERIMENT=1
 NOVENDOR = $(shell GO15VENDOREXPERIMENT=1 glide novendor)
 TEST_ARG ?= -race -v -timeout 5m
@@ -32,15 +33,28 @@ ALL_SRC := $(shell find . -name "*.go" | grep -v -e Godeps -e vendor \
 	-e ".*/mocks.*")
 
 # all directories with *_test.go files in them
-TEST_DIRS := $(sort $(dir $(filter %_test.go,$(ALL_SRC))))
+ALL_TEST_DIRS := $(sort $(dir $(filter %_test.go,$(ALL_SRC))))
+# all tests other than integration test fall into the pkg_test category
+PKG_TEST_DIRS := $(filter-out $(INTEG_TEST_ROOT)%,$(ALL_TEST_DIRS))
+# dirs that contain integration tests, these need to be treated
+# differently to get correct code coverage
+INTEG_TEST_DIRS := $(filter $(INTEG_TEST_ROOT)%,$(ALL_TEST_DIRS))
+
+# Need the following option to have integration tests
+# count towards coverage. godoc below:
+# -coverpkg pkg1,pkg2,pkg3
+#   Apply coverage analysis in each test to the given list of packages.
+#   The default is for each test to analyze only the package being tested.
+#   Packages are specified as import paths.
+GOCOVERPKG_ARG := -coverpkg="$(PROJECT_ROOT)/common/...,$(PROJECT_ROOT)/services/...,$(PROJECT_ROOT)/clients/..."
 
 test: bins
-	@for dir in $(TEST_DIRS); do \
+	@for dir in $(ALL_TEST_DIRS); do \
 		go test $(EMBED) "$$dir" $(TEST_NO_RACE_ARG) $(shell glide nv); \
 	done;
 
 test-race: $(ALL_SRC)
-	@for dir in $(TEST_DIRS); do \
+	@for dir in $(ALL_TEST_DIRS); do \
 		go test $(EMBED) "$$dir" $(TEST_ARG) | tee -a "$$dir"_test.log; \
 	done;	       
 
@@ -79,15 +93,22 @@ cherami-store-tool: $(DEPS)
 
 bins: cherami-server cherami-replicator-server cherami-cli cherami-admin cherami-replicator-tool cherami-cassandra-tool cherami-store-tool
 
-cover_profile: bins
-	@echo Testing packages:
+cover_profile: bins 
+	@echo Running tests:
 	@mkdir -p $(BUILD)
-	@echo "mode: atomic" > $(BUILD)/cover.out
-	@for dir in $(TEST_DIRS); do \
+	@for dir in $(PKG_TEST_DIRS); do \
 		mkdir -p $(BUILD)/"$$dir"; \
 		go test $(EMBED) "$$dir" $(TEST_ARG) -coverprofile=$(BUILD)/"$$dir"/coverage.out || exit 1; \
-		cat $(BUILD)/"$$dir"/coverage.out | grep -v "mode: atomic" >> $(BUILD)/cover.out; \
 	done
+	
+	@echo Running integration tests:
+	@for dir in $(INTEG_TEST_DIRS); do \
+		mkdir -p $(BUILD)/"$$dir"; \
+		go test $(EMBED) "$$dir" $(TEST_ARG) $(GOCOVERPKG_ARG) -coverprofile=$(BUILD)/"$$dir"/coverage.out || exit 1; \
+	done
+
+	# merge the package cover files into one single cover
+	gocovmerge `find $(BUILD) -name "coverage.out" | grep -v $(BUILD)/test` > $(BUILD)/cover.out
 
 cover: cover_profile
 	go tool cover -html=$(BUILD)/cover.out

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ cover_profile: bins
 	done
 
 	# merge the package cover files into one single cover
-	gocovmerge `find $(BUILD) -name "coverage.out" | grep -v $(BUILD)/test` > $(BUILD)/cover.out
+	gocovmerge `find $(BUILD) -name "coverage.out"` > $(BUILD)/cover.out
 
 cover: cover_profile
 	go tool cover -html=$(BUILD)/cover.out

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ bins: cherami-server cherami-replicator-server cherami-cli cherami-admin cherami
 cover_profile: bins 
 	@echo Running tests:
 	@mkdir -p $(BUILD)
+	@echo "mode: atomic" > $(BUILD)/cover.out
 	@for dir in $(PKG_TEST_DIRS); do \
 		mkdir -p $(BUILD)/"$$dir"; \
 		go test $(EMBED) "$$dir" $(TEST_ARG) -coverprofile=$(BUILD)/"$$dir"/coverage.out || exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ cover_profile: bins
 	@for dir in $(PKG_TEST_DIRS); do \
 		mkdir -p $(BUILD)/"$$dir"; \
 		go test $(EMBED) "$$dir" $(TEST_ARG) -coverprofile=$(BUILD)/"$$dir"/coverage.out || exit 1; \
-		cat $(BUILD)/"$$dir"/coverage.out | grep -v "mode: atomic" >> $(BUILD)/cover.out; \
+		cat $(BUILD)/"$$dir"/coverage.out | grep -v "mode: atomic" | grep -v "$(PROJECT_ROOT)/tools" >> $(BUILD)/cover.out; \
 	done
 	
 	@echo Running integration tests:

--- a/Makefile
+++ b/Makefile
@@ -99,16 +99,15 @@ cover_profile: bins
 	@for dir in $(PKG_TEST_DIRS); do \
 		mkdir -p $(BUILD)/"$$dir"; \
 		go test $(EMBED) "$$dir" $(TEST_ARG) -coverprofile=$(BUILD)/"$$dir"/coverage.out || exit 1; \
+		cat $(BUILD)/"$$dir"/coverage.out | grep -v "mode: atomic" >> $(BUILD)/cover.out; \
 	done
 	
 	@echo Running integration tests:
 	@for dir in $(INTEG_TEST_DIRS); do \
 		mkdir -p $(BUILD)/"$$dir"; \
 		go test $(EMBED) "$$dir" $(TEST_ARG) $(GOCOVERPKG_ARG) -coverprofile=$(BUILD)/"$$dir"/coverage.out || exit 1; \
+		cat $(BUILD)/"$$dir"/coverage.out | grep -v "mode: atomic" >> $(BUILD)/cover.out; \
 	done
-
-	# merge the package cover files into one single cover
-	gocovmerge `find $(BUILD) -name "coverage.out" | grep -v "$(BUILD)/tools"` > $(BUILD)/cover.out
 
 cover: cover_profile
 	go tool cover -html=$(BUILD)/cover.out

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SHELL = /bin/bash
 
 PROJECT_ROOT=github.com/uber/cherami-server
 INTEG_TEST_ROOT=./test
+TOOLS_ROOT=./tools
 export GO15VENDOREXPERIMENT=1
 NOVENDOR = $(shell GO15VENDOREXPERIMENT=1 glide novendor)
 TEST_ARG ?= -race -v -timeout 5m
@@ -36,6 +37,7 @@ ALL_SRC := $(shell find . -name "*.go" | grep -v -e Godeps -e vendor \
 ALL_TEST_DIRS := $(sort $(dir $(filter %_test.go,$(ALL_SRC))))
 # all tests other than integration test fall into the pkg_test category
 PKG_TEST_DIRS := $(filter-out $(INTEG_TEST_ROOT)%,$(ALL_TEST_DIRS))
+PKG_TEST_DIRS := $(filter-out $(TOOLS_ROOT)%,$(PKG_TEST_DIRS))
 # dirs that contain integration tests, these need to be treated
 # differently to get correct code coverage
 INTEG_TEST_DIRS := $(filter $(INTEG_TEST_ROOT)%,$(ALL_TEST_DIRS))
@@ -100,7 +102,7 @@ cover_profile: bins
 	@for dir in $(PKG_TEST_DIRS); do \
 		mkdir -p $(BUILD)/"$$dir"; \
 		go test $(EMBED) "$$dir" $(TEST_ARG) -coverprofile=$(BUILD)/"$$dir"/coverage.out || exit 1; \
-		cat $(BUILD)/"$$dir"/coverage.out | grep -v "mode: atomic" | grep -v "$(PROJECT_ROOT)/tools" >> $(BUILD)/cover.out; \
+		cat $(BUILD)/"$$dir"/coverage.out | grep -v "mode: atomic" >> $(BUILD)/cover.out; \
 	done
 	
 	@echo Running integration tests:

--- a/clients/controller/client.go
+++ b/clients/controller/client.go
@@ -28,7 +28,7 @@ import (
 )
 
 // NewClient returns a new instance of cherami controller client
-func NewClient(ch *tchannel.Channel, hostAddr string) controller.TChanControllerClient {
+func NewClient(ch *tchannel.Channel, hostAddr string) controller.TChanController {
 	tClient := thrift.NewClient(ch, common.ControllerServiceName, &thrift.ClientOptions{
 		HostPort: hostAddr,
 	})


### PR DESCRIPTION
Currently, our integration tests don't count towards code coverage. There are a couple of problems:

* go test needs a special argument if the test lives outside of the package
* correct merging of cover files matters

This patch addresses both of the above above problems and updates the makefiles. 

After the change, running the integration test discovered an unexercised code path referencing a non-existent symbol. That's also fixed (clients/controller/client.go).