### PR TITLE
ConfigMgr: Make the rule evaluator honor hierarchy

### DIFF
--- a/clients/metadata/metadata_cassandra.go
+++ b/clients/metadata/metadata_cassandra.go
@@ -69,16 +69,20 @@ const (
 	tableDestinationsByPath     = "destinations_by_path"
 	tableHostAddrToUUID         = "host_addr_to_uuid"
 	tableInputHostExtents       = "input_host_extents"
-	tableStoreExtents           = "store_extents"
-	tableUUIDToHostAddr         = "uuid_to_host_addr"
 	tableOperationsByEntityName = "user_operations_by_entity_name"
 	tableOperationsByEntityUUID = "user_operations_by_entity_uuid"
+	tableStoreExtents           = "store_extents"
+	tableUUIDToHostAddr         = "uuid_to_host_addr"
 )
 
 const (
 	columnAckLevelOffset                 = "ack_level_offset"
 	columnAckLevelSequence               = "ack_level_sequence"
 	columnAckLevelSequenceRate           = "ack_level_sequence_rate"
+	columnActiveZone                     = "active_zone"
+	columnAllowConsume                   = "allow_consume"
+	columnAllowPublish                   = "allow_publish"
+	columnAlwaysReplicatedTo             = "always_replicate_to"
 	columnArchivalLocation               = "archival_location"
 	columnAvailableAddress               = "available_address"
 	columnAvailableEnqueueTime           = "available_enqueue_time"
@@ -88,6 +92,9 @@ const (
 	columnBeginEnqueueTime               = "begin_enqueue_time"
 	columnBeginSequence                  = "begin_sequence"
 	columnBeginTime                      = "begin_time"
+	columnCallerHostName                 = "caller_host_name"
+	columnCallerServiceName              = "caller_service_name"
+	columnChecksumOption                 = "checksum_option"
 	columnConnectedStore                 = "connected_store"
 	columnConsumedMessagesRetention      = "consumed_messages_retention"
 	columnConsumerGroup                  = "consumer_group"
@@ -95,35 +102,46 @@ const (
 	columnConsumerGroupVisibility        = "consumer_group_visibility"
 	columnCreatedTime                    = "created_time"
 	columnDLQConsumerGroup               = "dlq_consumer_group"
+	columnDLQMergeBefore                 = "dlq_merge_before"
+	columnDLQPurgeBefore                 = "dlq_purge_before"
 	columnDeadLetterQueueDestinationUUID = "dead_letter_queue_destination_uuid"
 	columnDestination                    = "destination"
 	columnDestinationUUID                = "destination_uuid"
 	columnDirectoryUUID                  = "directory_uuid"
 	columnEndTime                        = "end_time"
+	columnEntityName                     = "entity_name"
+	columnEntityType                     = "entity_type"
+	columnEntityUUID                     = "entity_uuid"
 	columnExtent                         = "extent"
 	columnExtentUUID                     = "extent_uuid"
 	columnHostAddr                       = "hostaddr"
 	columnHostName                       = "hostname"
+	columnInitiatorInfo                  = "initiator"
 	columnInputHostUUID                  = "input_host_uuid"
-	columnOriginZone                     = "origin_zone"
-	columnRemoteExtentPrimaryStore       = "remote_extent_primary_store"
+	columnIsMultiZone                    = "is_multi_zone"
+	columnKafkaCluster                   = "kafka_cluster"
+	columnKafkaTopics                    = "kafka_topics"
 	columnLastAddress                    = "last_address"
 	columnLastEnqueueTime                = "last_enqueue_time"
 	columnLastSequence                   = "last_sequence"
 	columnLastSequenceRate               = "last_sequence_rate"
 	columnLockTimeoutSeconds             = "lock_timeout_seconds"
 	columnMaxDeliveryCount               = "max_delivery_count"
-	columnDLQMergeBefore                 = "dlq_merge_before"
 	columnName                           = "name"
+	columnOpsContent                     = "operation_content"
+	columnOpsTime                        = "operation_time"
+	columnOpsType                        = "operation_type"
+	columnOriginZone                     = "origin_zone"
 	columnOutputHostUUID                 = "output_host_uuid"
 	columnOwnerEmail                     = "owner_email"
-	columnChecksumOption                 = "checksum_option"
 	columnPath                           = "path"
-	columnDLQPurgeBefore                 = "dlq_purge_before"
 	columnReceivedLevelOffset            = "received_level_offset"
 	columnReceivedLevelSequence          = "received_level_sequence"
 	columnReceivedLevelSequenceRate      = "received_level_sequence_rate"
+	columnRemoteExtentPrimaryStore       = "remote_extent_primary_store"
+	columnRemoteExtentReplicaNum         = "remote_extent_replica_num"
 	columnReplicaStats                   = "replica_stats"
+	columnReplicationStatus              = "replication_status"
 	columnSizeInBytes                    = "size_in_bytes"
 	columnSizeInBytesRate                = "size_in_bytes_rate"
 	columnSkipOlderMessagesSeconds       = "skip_older_messages_seconds"
@@ -137,27 +155,11 @@ const (
 	columnType                           = "type"
 	columnUUID                           = "uuid"
 	columnUnconsumedMessagesRetention    = "unconsumed_messages_retention"
-	columnEntityName                     = "entity_name"
-	columnEntityUUID                     = "entity_uuid"
-	columnEntityType                     = "entity_type"
-	columnInitiatorInfo                  = "initiator"
-	columnOpsType                        = "operation_type"
-	columnOpsTime                        = "operation_time"
-	columnOpsContent                     = "operation_content"
-	columnUserName                       = "user_name"
 	columnUserEmail                      = "user_email"
-	columnIsMultiZone                    = "is_multi_zone"
-	columnZoneConfigs                    = "zone_configs"
-	columnZone                           = "zone"
-	columnAllowPublish                   = "allow_publish"
-	columnAllowConsume                   = "allow_consume"
-	columnAlwaysReplicatedTo             = "always_replicate_to"
-	columnRemoteExtentReplicaNum         = "remote_extent_replica_num"
+	columnUserName                       = "user_name"
 	columnVisible                        = "visible"
-	columnActiveZone                     = "active_zone"
-	columnCallerServiceName              = "caller_service_name"
-	columnCallerHostName                 = "caller_host_name"
-	columnReplicationStatus              = "replication_status"
+	columnZone                           = "zone"
+	columnZoneConfigs                    = "zone_configs"
 )
 
 const userOperationTTL = "2592000" // 30 days
@@ -320,16 +322,18 @@ const (
 		columnZoneConfigs + `: ?}`
 
 	sqlInsertDstByUUID = `INSERT INTO ` + tableDestinations +
-		`(` + columnUUID + `, ` + columnIsMultiZone + `, ` + columnDestination + `, ` + columnDLQConsumerGroup + `) ` +
-		` VALUES (?, ?, ` + sqlDstType + `, ?)`
+		`(` + columnUUID + `, ` + columnIsMultiZone + `, ` + columnDestination + `, ` + columnKafkaCluster + `, ` + columnKafkaTopics + `, ` + columnDLQConsumerGroup + `) ` +
+		` VALUES (?, ?, ` + sqlDstType + `, ?, ?, ?)`
 
 	sqlInsertDstByPath = `INSERT INTO ` + tableDestinationsByPath +
 		`(` +
 		columnDirectoryUUID + `, ` +
 		columnPath + `, ` +
 		columnIsMultiZone + `, ` +
-		columnDestination +
-		`) VALUES (?, ?, ?, ` + sqlDstType + `) IF NOT EXISTS`
+		columnDestination + `, ` +
+		columnKafkaCluster + `, ` +
+		columnKafkaTopics +
+		`) VALUES (?, ?, ?, ` + sqlDstType + `, ?, ?) IF NOT EXISTS`
 
 	sqlGetDstByPath = `SELECT ` +
 		columnDestination + `.` + columnUUID + `, ` +
@@ -341,7 +345,9 @@ const (
 		columnDestination + `.` + columnOwnerEmail + `, ` +
 		columnDestination + `.` + columnChecksumOption + `, ` +
 		columnDestination + `.` + columnIsMultiZone + `, ` +
-		columnDestination + `.` + columnZoneConfigs +
+		columnDestination + `.` + columnZoneConfigs + `, ` +
+		columnKafkaCluster + `, ` +
+		columnKafkaTopics +
 		` FROM ` + tableDestinationsByPath +
 		` WHERE ` + columnDirectoryUUID + `=? and ` + columnPath + `=?`
 
@@ -358,7 +364,9 @@ const (
 		columnDestination + `.` + columnZoneConfigs + `, ` +
 		columnDLQConsumerGroup + `, ` +
 		columnDLQPurgeBefore + `, ` +
-		columnDLQMergeBefore +
+		columnDLQMergeBefore + `, ` +
+		columnKafkaCluster + `, ` +
+		columnKafkaTopics +
 		` FROM ` + tableDestinations
 
 	sqlUpdateDstByUUID = `UPDATE ` + tableDestinations + ` SET ` +
@@ -422,6 +430,8 @@ func (s *CassandraMetadataService) CreateDestinationUUID(ctx thrift.Context, uui
 		request.GetChecksumOption(),
 		request.GetIsMultiZone(),
 		marshalDstZoneConfigs(request.GetZoneConfigs()),
+		request.KafkaCluster,
+		request.KafkaTopics,
 		request.DLQConsumerGroupUUID, // may be nil
 	).Exec(); err != nil {
 		return nil, &shared.InternalServiceError{
@@ -447,7 +457,9 @@ func (s *CassandraMetadataService) CreateDestinationUUID(ctx thrift.Context, uui
 			request.GetOwnerEmail(),
 			request.GetChecksumOption(),
 			request.GetIsMultiZone(),
-			marshalDstZoneConfigs(request.GetZoneConfigs()))
+			marshalDstZoneConfigs(request.GetZoneConfigs()),
+			request.KafkaCluster,
+			request.KafkaTopics)
 		applied, err := query.MapScanCAS(previous)
 		if err != nil {
 			return nil, &shared.InternalServiceError{
@@ -495,6 +507,8 @@ func (s *CassandraMetadataService) CreateDestinationUUID(ctx thrift.Context, uui
 		IsMultiZone:                 common.BoolPtr(request.GetIsMultiZone()),
 		ZoneConfigs:                 request.GetZoneConfigs(),
 		DLQConsumerGroupUUID:        common.StringPtr(request.GetDLQConsumerGroupUUID()),
+		KafkaCluster:                common.StringPtr(request.GetKafkaCluster()),
+		KafkaTopics:                 request.KafkaTopics,
 	}, nil
 }
 
@@ -513,6 +527,8 @@ func getUtilDestinationDescription() *shared.DestinationDescription {
 	result.DLQMergeBefore = common.Int64Ptr(0)
 	result.IsMultiZone = common.BoolPtr(false)
 	result.ZoneConfigs = shared.DestinationDescription_ZoneConfigs_DEFAULT
+	result.KafkaCluster = common.StringPtr("")
+	result.KafkaTopics = make([]string, 0)
 
 	return result
 }
@@ -621,7 +637,10 @@ func (s *CassandraMetadataService) ReadDestination(ctx thrift.Context, getReques
 			result.OwnerEmail,
 			result.ChecksumOption,
 			result.IsMultiZone,
-			&zoneConfigsData)
+			&zoneConfigsData,
+			result.KafkaCluster,
+			&result.KafkaTopics,
+		)
 	} else {
 		sql = sqlListDestinationsByUUID + ` WHERE ` + columnUUID + `=?`
 		query = s.session.Query(sql).Consistency(s.lowConsLevel)
@@ -641,6 +660,8 @@ func (s *CassandraMetadataService) ReadDestination(ctx thrift.Context, getReques
 			result.DLQConsumerGroupUUID, //
 			result.DLQPurgeBefore,       // Only a UUID lookup can populate these values; this is OK since DLQ destinations can only be found by UUID anyway
 			result.DLQMergeBefore,       //
+			result.KafkaCluster,
+			&result.KafkaTopics,
 		)
 	}
 	result.ZoneConfigs = unmarshalDstZoneConfigs(zoneConfigsData)
@@ -994,7 +1015,9 @@ func (s *CassandraMetadataService) ListDestinationsByUUID(ctx thrift.Context, li
 		&zoneConfigsData,
 		d.DLQConsumerGroupUUID,
 		d.DLQPurgeBefore,
-		d.DLQMergeBefore) {
+		d.DLQMergeBefore,
+		d.KafkaCluster,
+		&d.KafkaTopics) {
 		d.ZoneConfigs = unmarshalDstZoneConfigs(zoneConfigsData)
 
 		// Get a new item within limit
@@ -1062,7 +1085,9 @@ func (s *CassandraMetadataService) ListAllDestinations(ctx thrift.Context, listR
 		&zoneConfigsData,
 		d.DLQConsumerGroupUUID,
 		d.DLQPurgeBefore,
-		d.DLQMergeBefore) && count < listRequest.GetLimit() {
+		d.DLQMergeBefore,
+		d.KafkaCluster,
+		&d.KafkaTopics) && count < listRequest.GetLimit() {
 		d.ZoneConfigs = unmarshalDstZoneConfigs(zoneConfigsData)
 		*d.DLQPurgeBefore = int64(cqlTimestampToUnixNano(*d.DLQPurgeBefore))
 		*d.DLQMergeBefore = int64(cqlTimestampToUnixNano(*d.DLQMergeBefore))

--- a/clients/metadata/schema/metadata.cql
+++ b/clients/metadata/schema/metadata.cql
@@ -93,7 +93,9 @@ CREATE TABLE destinations (
     -- DLQ Destination metadata; N.B.: DLQ destinations don't exist in the destinations_by_path table --
     dlq_purge_before timestamp, -- Indicates that retention should delete messages before this timestamp in this destination; consumer groups should not read before this
     dlq_merge_before timestamp, -- Indicates that extent controller should merge messages/extents created before this timestamp to the consumer group. consumer groups should not read before this
-    dlq_consumer_group uuid     -- If this is a DLQ destination, the consumer group uuid that corresponds to this DLQ destination
+    dlq_consumer_group uuid,    -- If this is a DLQ destination, the consumer group uuid that corresponds to this DLQ destination
+    kafka_cluster text,
+    kafka_topics set<text>
 );
 
 CREATE INDEX ON destinations (is_multi_zone);
@@ -103,6 +105,8 @@ CREATE TABLE destinations_by_path (
     path text,
     is_multi_zone boolean,
     destination frozen<destination>,
+    kafka_cluster text,
+    kafka_topics set<text>,
     PRIMARY KEY (directory_uuid, path)
 );
 

--- a/clients/metadata/schema/v14/201703240000_add_kafka.cql
+++ b/clients/metadata/schema/v14/201703240000_add_kafka.cql
@@ -1,0 +1,4 @@
+ALTER TABLE destinations ADD kafka_cluster text;
+ALTER TABLE destinations ADD kafka_topics set<text>;
+ALTER TABLE destinations_by_path ADD kafka_cluster text;
+ALTER TABLE destinations_by_path ADD kafka_topics set<text>;

--- a/clients/metadata/schema/v14/manifest.json
+++ b/clients/metadata/schema/v14/manifest.json
@@ -1,0 +1,8 @@
+{
+	"CurrVersion": 14,
+	"MinCompatibleVersion": 8,
+	"Description": "Add kafkaCluster and kafkaTopics",
+	"SchemaUpdateCqlFiles": [
+		"201703240000_add_kafka.cql"
+	]
+}

--- a/common/dconfig/configmgr.go
+++ b/common/dconfig/configmgr.go
@@ -511,13 +511,15 @@ func newKVTreeNode() *kvTreeNode {
 
 func addToKVTree(root *kvTreeNode, version, sku, host, cfgKey, cfgValue string) {
 
-	var maxDepth = 1 // max depth of tree to traverse
+	var maxDepth int // max depth of tree to traverse
 
-	if sku != wildcardToken || host != wildcardToken {
-		maxDepth++
-		if host != wildcardToken {
-			maxDepth++
-		}
+	switch {
+	case host != wildcardToken:
+		maxDepth = 3
+	case sku != wildcardToken:
+		maxDepth = 2
+	default:
+		maxDepth = 1
 	}
 
 	curr := root

--- a/common/dconfig/configmgr.go
+++ b/common/dconfig/configmgr.go
@@ -438,7 +438,6 @@ func (cfgMgr *CassandraConfigManager) mkKVTreeForSvc(service string, items []*m.
 	return root
 }
 
-
 // mkConfig constructs a config object of given type using the
 // values from the given set of key,value strings. If the given
 // map of (k,v) is missing a config key, then this method will

--- a/common/dconfig/configmgr.go
+++ b/common/dconfig/configmgr.go
@@ -351,8 +351,8 @@ func (cfgMgr *CassandraConfigManager) mkKVTreeForSvc(service string, items []*m.
 
 	allSkus := make(map[string]struct{})
 	allVersions := make(map[string]struct{})
-	wildcardVersionItems := make([]*m.ServiceConfigItem, 0, len(items)) // items with version as wildcard
-	wildcardVersionSkuItems := make([]*m.ServiceConfigItem, 0, len(items)) // items with version as wildcard and sku not a wildcard
+	wildcardVersionItems := make([]*m.ServiceConfigItem, 0, len(items))              // items with version as wildcard
+	wildcardVersionSkuItems := make([]*m.ServiceConfigItem, 0, len(items))           // items with version as wildcard and sku not a wildcard
 	versionToWildcardSkuItems := make(map[string][]*m.ServiceConfigItem, len(items)) // items with sku as wildcard
 
 	for i, item := range items {
@@ -370,7 +370,7 @@ func (cfgMgr *CassandraConfigManager) mkKVTreeForSvc(service string, items []*m.
 		}
 
 		if sku != wildcardToken && host != wildcardToken {
-			key := strings.Join([]string{service,version, sku, host,cfgKey}, ".")
+			key := strings.Join([]string{service, version, sku, host, cfgKey}, ".")
 			sku = wildcardToken
 			items[i].Sku = common.StringPtr(wildcardToken)
 			cfgMgr.logger.WithField(key, cfgValue).Warn("Forcing sku=*;host specific items MUST be sku agnostic")
@@ -427,7 +427,7 @@ func (cfgMgr *CassandraConfigManager) mkKVTreeForSvc(service string, items []*m.
 
 	// apply svc.*. items as default for every svc.ver.*
 	for _, item := range wildcardVersionItems {
- 		for ver := range allVersions {
+		for ver := range allVersions {
 			for sku := range allSkus {
 				addToKVTree(root, ver, sku, item.GetHostname(), item.GetConfigKey(), item.GetConfigValue())
 			}
@@ -436,7 +436,6 @@ func (cfgMgr *CassandraConfigManager) mkKVTreeForSvc(service string, items []*m.
 
 	return root
 }
-
 
 // mkConfig constructs a config object of given type using the
 // values from the given set of key,value strings. If the given

--- a/common/dconfig/configmgr.go
+++ b/common/dconfig/configmgr.go
@@ -129,8 +129,7 @@ var cfgRefreshInterval = time.Minute
 // default values that apply to a broad category, subject to
 // the following constraints:
 //
-//  (1) serviceName cannot be a wildcard
-//  (2) if sku is a wildcard, hostname MUST also be a wildcard
+//  (1) if hostname is specified, sku is always ignored (i.e. treated as wildcard)
 //
 // Config Evaluation:
 //   In general, the config evaluator ALWAYS returns the most specific config
@@ -146,8 +145,9 @@ var cfgRefreshInterval = time.Minute
 //  Example Queries:
 //       Get(inputhost, *, *, *)        = 111
 //       Get(inputhost, v1, *, *)       = 333
-//       Get(inputhost, v1, ec2m112, *) = 222 --> BEWARE, defaults applied
+//       Get(inputhost, v1, ec2m112, *) = 333
 //       Get(inputhost, v1, m1large, *) = 444
+//       Get(inputhost, v2, ec2m112, *) = 222 <-- SKU default applied
 //
 // The constructor to this class takes a configTypes param, which is a map
 // of serviceName to configObjects. The config object MUST be of struct type
@@ -226,6 +226,18 @@ func (cfgMgr *CassandraConfigManager) runLoop() {
 	cfgMgr.logger.Info("Config refresher stopped")
 }
 
+func printConfigTree(tree *configTreeNode, keys []string, idx int) {
+
+	key := strings.Join(keys, ".")
+	fmt.Printf("key=%v %+v\n", key, tree.value)
+
+	for k,v := range tree.children {
+		keys[idx] = k
+		printConfigTree(v, keys, idx+1)
+		keys[idx] = "*"
+	}
+}
+
 // Get returns the config value that best matches the given
 // input criteria. svc param cannot be empty.
 func (cfgMgr *CassandraConfigManager) Get(svc string, version string, sku string, host string) (interface{}, error) {
@@ -245,7 +257,14 @@ func (cfgMgr *CassandraConfigManager) Get(svc string, version string, sku string
 
 		next, hasNext := curr.children[k]
 		if !hasNext {
-			break
+			if k == wildcardToken {
+				break
+			}
+			// if we don't have this value, substitute wildcard & retry
+			next, hasNext = curr.children[wildcardToken]
+			if !hasNext {
+				break
+			}
 		}
 		curr = next
 	}
@@ -299,6 +318,7 @@ func (cfgMgr *CassandraConfigManager) mkConfigTree(inputKVTree *kvTree) *configT
 	for k, v := range cfgMgr.configTypes {
 		tree := inputKVTree.children[k]
 		result.children[k] = cfgMgr.mkConfigTreeForSvc(v, nil, tree)
+		printConfigTree(result.children[k], []string{k, "*", "*", "*"}, 1)
 	}
 
 	return result
@@ -318,14 +338,37 @@ func (cfgMgr *CassandraConfigManager) mkConfigTreeForSvc(cfgType interface{}, de
 	return result
 }
 
+// mkKVTreeForSvc builds a hierarchical tree of key values
+// for a speicific service. The tree hierarchy is from
+// svc -> version -> sku -> host. The key values at each
+// level serve as the default for its children nodes.
+//
+// The actual construction of the tree is a 3 step process:
+// (1) Take every config item of form svc.version.sku.host.key=value and add it to tree
+//        (a) If the version & sku are wildcard (i.e. *), then the config item
+//            MUST serve as a default for every version/ every sku, so keep track of
+//            these separately
+//        (b) If the version is a wildcard but sku is not, then this config item
+//			  MUST serve as a default for every version.sku, so trace this separately
+//        (c) If the version is not wildcard, but sku is wildcard, then the
+//            config item MUST serve as a default for every sku for that version
+//            so keep track of these separately
+// (2) Add the items tracked in 1(b) to the tree (for every sku)
+// (3) Add the items tracked in 1(a) for every version
+//
+// Its important to apply the config items in the order (1).(2).(3) to honor
+// the hierarchial structure
 func (cfgMgr *CassandraConfigManager) mkKVTreeForSvc(service string, items []*m.ServiceConfigItem) *kvTreeNode {
 
 	root := newKVTreeNode()
 
-	versions := make(map[string]struct{})
-	wildcardVersionItems := make([]*m.ServiceConfigItem, 0, len(items))
+	allSkus := make(map[string]struct{})
+	allVersions := make(map[string]struct{})
+	wildcardVersionItems := make([]*m.ServiceConfigItem, 0, len(items)) // items with version as wildcard
+	wildcardVersionSkuItems := make([]*m.ServiceConfigItem, 0, len(items)) // items with version as wildcard and sku not a wildcard
+	versionToWildcardSkuItems := make(map[string][]*m.ServiceConfigItem, len(items)) // items with sku as wildcard
 
-	for _, item := range items {
+	for i, item := range items {
 
 		cfgKey := strings.ToLower(item.GetConfigKey())
 		cfgValue := item.GetConfigValue()
@@ -339,45 +382,74 @@ func (cfgMgr *CassandraConfigManager) mkKVTreeForSvc(service string, items []*m.
 			continue
 		}
 
-		versions[version] = struct{}{}
+		if sku != wildcardToken && host != wildcardToken {
+			key := strings.Join([]string{service,version, sku, host,cfgKey}, ".")
+			sku = wildcardToken
+			items[i].Sku = common.StringPtr(wildcardToken)
+			cfgMgr.logger.WithField(key, cfgValue).Warn("Forcing sku=*;host specific items MUST be sku agnostic")
+		}
+
+		allSkus[sku] = struct{}{}
+		allVersions[version] = struct{}{}
 
 		if version == wildcardToken {
 			if sku == wildcardToken {
-				if host != wildcardToken {
-					// when hostname is present, we always expect the sku
-					// this is an invariant for the hierarchial config store
-					cfgMgr.logger.Errorf("Skipping illegal config item with wildcard sku, item=%v", item)
+				if host == wildcardToken {
+					// service.*.*.*.key, add it at the root level
+					root.keyValues[cfgKey] = cfgValue
 					continue
 				}
-				// service.*.*.*.key, add it at the root level
-				root.keyValues[cfgKey] = cfgValue
+				// 1(a) keep track of svc.* config items
+				wildcardVersionItems = append(wildcardVersionItems, item)
 				continue
 			}
-			// keep track of service.* wildcards separtely
-			// they are the defaults for all service.version.*
-			wildcardVersionItems = append(wildcardVersionItems, item)
+			// 1(b) Keep track of svc.*.sku config items
+			wildcardVersionSkuItems = append(wildcardVersionSkuItems, item)
+			continue
+		}
+
+		if sku == wildcardToken {
+			defaults, ok := versionToWildcardSkuItems[version]
+			if !ok {
+				defaults = make([]*m.ServiceConfigItem, 0, 4)
+				versionToWildcardSkuItems[version] = defaults
+			}
+			// 1(c) keep track of svc.ver.* items
+			versionToWildcardSkuItems[version] = append(defaults, item)
 			continue
 		}
 
 		addToKVTree(root, version, sku, host, cfgKey, cfgValue)
 	}
 
-	// now apply the wildcarded version items for every
-	// version that we know of, including the wildcard
+	// apply svc.ver.* items as default for every svc.ver.sku
+	for ver, items := range versionToWildcardSkuItems {
+		for _, item := range items {
+			for s := range allSkus {
+				addToKVTree(root, ver, s, item.GetHostname(), item.GetConfigKey(), item.GetConfigValue())
+			}
+		}
+	}
+
+	// apply svc.*.sku. items as default for every svc.ver.sku items
+	for _, item := range wildcardVersionSkuItems {
+		for ver := range allVersions {
+			addToKVTree(root, ver, item.GetSku(), item.GetHostname(), item.GetConfigKey(), item.GetConfigValue())
+		}
+	}
+
+	// apply svc.*. items as default for every svc.ver.*
 	for _, item := range wildcardVersionItems {
-
-		sku := item.GetSku()
-		host := item.GetHostname()
-		cfgKey := item.GetConfigKey()
-		cfgValue := item.GetConfigValue()
-
-		for ver := range versions {
-			addToKVTree(root, ver, sku, host, cfgKey, cfgValue)
+ 		for ver := range allVersions {
+			for sku := range allSkus {
+				addToKVTree(root, ver, sku, item.GetHostname(), item.GetConfigKey(), item.GetConfigValue())
+			}
 		}
 	}
 
 	return root
 }
+
 
 // mkConfig constructs a config object of given type using the
 // values from the given set of key,value strings. If the given
@@ -455,7 +527,7 @@ func addToKVTree(root *kvTreeNode, version, sku, host, cfgKey, cfgValue string) 
 
 	var maxDepth = 1 // max depth of tree to traverse
 
-	if sku != wildcardToken {
+	if sku != wildcardToken || host != wildcardToken {
 		maxDepth++
 		if host != wildcardToken {
 			maxDepth++
@@ -492,6 +564,7 @@ func setIntField(field reflect.Value, fieldName string, keyValues map[string]str
 			return
 		}
 	}
+	fmt.Printf("Using default value for fieldName=%v defaultStr=%v\n", fieldName, defaultStr)
 	if defaultVal.IsValid() {
 		field.Set(defaultVal)
 		return

--- a/common/dconfig/configmgr.go
+++ b/common/dconfig/configmgr.go
@@ -226,18 +226,6 @@ func (cfgMgr *CassandraConfigManager) runLoop() {
 	cfgMgr.logger.Info("Config refresher stopped")
 }
 
-func printConfigTree(tree *configTreeNode, keys []string, idx int) {
-
-	key := strings.Join(keys, ".")
-	fmt.Printf("key=%v %+v\n", key, tree.value)
-
-	for k,v := range tree.children {
-		keys[idx] = k
-		printConfigTree(v, keys, idx+1)
-		keys[idx] = "*"
-	}
-}
-
 // Get returns the config value that best matches the given
 // input criteria. svc param cannot be empty.
 func (cfgMgr *CassandraConfigManager) Get(svc string, version string, sku string, host string) (interface{}, error) {
@@ -318,7 +306,6 @@ func (cfgMgr *CassandraConfigManager) mkConfigTree(inputKVTree *kvTree) *configT
 	for k, v := range cfgMgr.configTypes {
 		tree := inputKVTree.children[k]
 		result.children[k] = cfgMgr.mkConfigTreeForSvc(v, nil, tree)
-		printConfigTree(result.children[k], []string{k, "*", "*", "*"}, 1)
 	}
 
 	return result

--- a/common/dconfig/configmgr_test.go
+++ b/common/dconfig/configmgr_test.go
@@ -122,6 +122,11 @@ func (s *ConfigManagerTestSuite) TestConfigOverrides() {
 		SliceItem   []string `name:"slice-set" default:"a,b,c"`
 	}
 
+	type testOutputConfig1 struct {
+		CacheSizeBytes int64 	`name:"cache-size-bytes" default:"1024"`
+		AdminStatus    string   `name:"admin-status" default:"enabled"`
+	}
+
 	cfgItems := []m.ServiceConfigItem{
 		{ServiceName: strp("input"), ServiceVersion: strp("*"), Sku: strp("*"), Hostname: strp("*"), ConfigKey: strp("max-extents"), ConfigValue: strp("100")},
 		{ServiceName: strp("input"), ServiceVersion: strp("*"), Sku: strp("*"), Hostname: strp("*"), ConfigKey: strp("max-conns"), ConfigValue: strp("1000")},
@@ -135,6 +140,11 @@ func (s *ConfigManagerTestSuite) TestConfigOverrides() {
 		{ServiceName: strp("store"), ServiceVersion: strp("*"), Sku: strp("*"), Hostname: strp("*"), ConfigKey: strp("max-outconns"), ConfigValue: strp("1000")},
 		{ServiceName: strp("store"), ServiceVersion: strp("*"), Sku: strp("*"), Hostname: strp("*"), ConfigKey: strp("camelcase"), ConfigValue: strp("normalize")}, // intentionally use a normalized key to set in cassandra
 		{ServiceName: strp("store"), ServiceVersion: strp("*"), Sku: strp("*"), Hostname: strp("*"), ConfigKey: strp("slice-set"), ConfigValue: strp("Z")},
+		{ServiceName: strp("output"), ServiceVersion: strp("*"), Sku: strp("*"), Hostname: strp("cherami22"), ConfigKey: strp("admin-status"), ConfigValue: strp("disabled")},
+		{ServiceName: strp("output"), ServiceVersion: strp("*"), Sku: strp("*"), Hostname: strp("*"), ConfigKey: strp("cache-size-bytes"), ConfigValue: strp("10000")},
+		{ServiceName: strp("output"), ServiceVersion: strp("*"), Sku: strp("haswell"), Hostname: strp("*"), ConfigKey: strp("cache-size-bytes"), ConfigValue: strp("20000")},
+		{ServiceName: strp("output"), ServiceVersion: strp("v2"), Sku: strp("*"), Hostname: strp("*"), ConfigKey: strp("cache-size-bytes"), ConfigValue: strp("15000")},
+		{ServiceName: strp("output"), ServiceVersion: strp("v2"), Sku: strp("skylake"), Hostname: strp("*"), ConfigKey: strp("cache-size-bytes"), ConfigValue: strp("12000")},
 	}
 
 	for i, item := range cfgItems {
@@ -153,22 +163,27 @@ func (s *ConfigManagerTestSuite) TestConfigOverrides() {
 		output testStoreConfig1
 	}
 
+	type outputTestCase1 struct {
+		input  configGetterTestInput
+		output testOutputConfig1
+	}
+
 	inputTestCases := []inputTestCase1{
 		{configGetterTestInput{svc: "input"}, testInputConfig1{MaxConns: 1000, MaxExtents: 100, AdminStatus: "enabled"}},
 		{configGetterTestInput{svc: "input", sku: "whitesnake"}, testInputConfig1{MaxConns: 1000, MaxExtents: 150, AdminStatus: "enabled"}},
 		{configGetterTestInput{svc: "input", sku: "whitesnake", host: "cherami14"}, testInputConfig1{MaxConns: 1000, MaxExtents: 0, AdminStatus: "enabled"}},
 		{configGetterTestInput{svc: "input", vers: "v1"}, testInputConfig1{MaxConns: 1000, MaxExtents: 50, AdminStatus: "enabled"}},
-		{configGetterTestInput{svc: "input", vers: "v1", sku: "whitesnake"}, testInputConfig1{MaxConns: 1000, MaxExtents: 150, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "input", vers: "v1", sku: "whitesnake"}, testInputConfig1{MaxConns: 1000, MaxExtents: 50, AdminStatus: "enabled"}},
 		{configGetterTestInput{svc: "input", vers: "v1", sku: "whitesnake", host: "cherami14"}, testInputConfig1{MaxConns: 1000, MaxExtents: 0, AdminStatus: "enabled"}},
-		{configGetterTestInput{svc: "input", vers: "v1", sku: "m1.b ", host: "cherami15"}, testInputConfig1{MaxConns: 1000, MaxExtents: 50, AdminStatus: "enabled"}},
-		{configGetterTestInput{svc: "input", vers: "v1", sku: "m1.12", host: "cherami14"}, testInputConfig1{MaxConns: 1000, MaxExtents: 50, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "input", vers: "v1", sku: "m1.b ", host: "cherami15"}, testInputConfig1{MaxConns: 1000, MaxExtents: 1, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "input", vers: "v1", sku: "m1.12", host: "cherami14"}, testInputConfig1{MaxConns: 1000, MaxExtents: 0, AdminStatus: "enabled"}},
 		{configGetterTestInput{svc: "input", vers: "v1", sku: "k1.12"}, testInputConfig1{MaxConns: 1000, MaxExtents: 50, AdminStatus: "enabled"}},
 		{configGetterTestInput{svc: "input", vers: "v2"}, testInputConfig1{MaxConns: 1000, MaxExtents: 100, AdminStatus: "enabled"}},
 		{configGetterTestInput{svc: "input", vers: "v2", sku: "blackeye"}, testInputConfig1{MaxConns: 1000, MaxExtents: 200, AdminStatus: "enabled"}},
 		{configGetterTestInput{svc: "input", vers: "v2", sku: "blackeye", host: "cherami20"}, testInputConfig1{MaxConns: 1000, MaxExtents: 200, AdminStatus: "enabled"}},
 		{configGetterTestInput{svc: "input", vers: "v2", sku: "whitesnake"}, testInputConfig1{MaxConns: 1000, MaxExtents: 170, AdminStatus: "enabled"}},
 		{configGetterTestInput{svc: "input", vers: "v2", sku: "whitesnake", host: "cherami60"}, testInputConfig1{MaxConns: 1000, MaxExtents: 170, AdminStatus: "enabled"}},
-		{configGetterTestInput{svc: "input", vers: "v3", sku: "whitesnake", host: "cherami55"}, testInputConfig1{MaxConns: 1000, MaxExtents: 100, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "input", vers: "v3", sku: "whitesnake", host: "cherami55"}, testInputConfig1{MaxConns: 1000, MaxExtents: 150, AdminStatus: "enabled"}},
 		{configGetterTestInput{svc: "input", vers: "v3"}, testInputConfig1{MaxConns: 1000, MaxExtents: 100, AdminStatus: "enabled"}},
 	}
 
@@ -180,9 +195,27 @@ func (s *ConfigManagerTestSuite) TestConfigOverrides() {
 		{configGetterTestInput{svc: "store", vers: "v1", sku: "sku1", host: "host1"}, testStoreConfig1{MaxInConns: 2000, MaxOutConns: 1000, AdminStatus: "enabled", CamelCase: "normalize", SliceItem: []string{"Z"}}},
 	}
 
+	outputTestCases := []outputTestCase1{
+		{configGetterTestInput{svc: "output"}, testOutputConfig1{CacheSizeBytes:10000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", sku: "haswell"}, testOutputConfig1{CacheSizeBytes:20000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", vers: "v2"}, testOutputConfig1{CacheSizeBytes:15000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", vers: "v2", sku: "haswell"}, testOutputConfig1{CacheSizeBytes:15000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", vers: "v2", sku: "skylake"}, testOutputConfig1{CacheSizeBytes:12000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", vers: "v2", sku: "ivy"}, testOutputConfig1{CacheSizeBytes:15000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", vers: "v1", sku: "haswell"}, testOutputConfig1{CacheSizeBytes:20000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", vers: "v1", sku: "ivy"}, testOutputConfig1{CacheSizeBytes:10000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", host: "cherami22"}, testOutputConfig1{CacheSizeBytes:10000, AdminStatus: "disabled"}},
+		{configGetterTestInput{svc: "output", host: "cherami44"}, testOutputConfig1{CacheSizeBytes:10000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", vers: "v2", sku: "haswell", host: "cherami22"}, testOutputConfig1{CacheSizeBytes:15000, AdminStatus: "disabled"}},
+		{configGetterTestInput{svc: "output", vers: "v1", sku: "ivy", host: "cherami22"}, testOutputConfig1{CacheSizeBytes:10000, AdminStatus: "disabled"}},
+		{configGetterTestInput{svc: "output", sku: "haswell", host: "cherami22"}, testOutputConfig1{CacheSizeBytes:20000, AdminStatus: "disabled"}},
+		{configGetterTestInput{svc: "output", host: "cherami22"}, testOutputConfig1{CacheSizeBytes:10000, AdminStatus: "disabled"}},
+	}
+
 	configTypes := make(map[string]interface{})
 	configTypes["input"] = testInputConfig1{}
 	configTypes["store"] = testStoreConfig1{}
+	configTypes["output"] = testOutputConfig1{}
 
 	cfgMgrIface := NewCassandraConfigManager(s.cdb.GetClient(), configTypes, s.logger)
 	cfgMgr := cfgMgrIface.(*CassandraConfigManager)
@@ -192,13 +225,20 @@ func (s *ConfigManagerTestSuite) TestConfigOverrides() {
 		cfg, err := cfgMgr.Get(tc.input.svc, tc.input.vers, tc.input.sku, tc.input.host)
 		s.Nil(err, "configStore.Get() failed for input %v", i)
 		value := cfg.(testInputConfig1)
-		s.True(reflect.DeepEqual(tc.output, value), "Wrong output for input %v", i)
+		s.True(reflect.DeepEqual(tc.output, value), "Wrong output for input %v, output=%+v", i, value)
 	}
 
 	for i, tc := range storeTestCases {
 		cfg, err := cfgMgr.Get(tc.input.svc, tc.input.vers, tc.input.sku, tc.input.host)
 		s.Nil(err, "configStore.Get() failed for input %v", i)
 		value := cfg.(testStoreConfig1)
-		s.True(reflect.DeepEqual(tc.output, value), "Wrong output for input %v", i)
+		s.True(reflect.DeepEqual(tc.output, value), "Wrong output for input %v, output=%+v", i, value)
+	}
+
+	for i, tc := range outputTestCases {
+		cfg, err := cfgMgr.Get(tc.input.svc, tc.input.vers, tc.input.sku, tc.input.host)
+		s.Nil(err, "configStore.Get() failed for input %v", i)
+		value := cfg.(testOutputConfig1)
+		s.True(reflect.DeepEqual(tc.output, value), "Wrong output for input %v, output=%+v", i, value)
 	}
 }

--- a/common/dconfig/configmgr_test.go
+++ b/common/dconfig/configmgr_test.go
@@ -123,8 +123,8 @@ func (s *ConfigManagerTestSuite) TestConfigOverrides() {
 	}
 
 	type testOutputConfig1 struct {
-		CacheSizeBytes int64 	`name:"cache-size-bytes" default:"1024"`
-		AdminStatus    string   `name:"admin-status" default:"enabled"`
+		CacheSizeBytes int64  `name:"cache-size-bytes" default:"1024"`
+		AdminStatus    string `name:"admin-status" default:"enabled"`
 	}
 
 	cfgItems := []m.ServiceConfigItem{
@@ -196,20 +196,20 @@ func (s *ConfigManagerTestSuite) TestConfigOverrides() {
 	}
 
 	outputTestCases := []outputTestCase1{
-		{configGetterTestInput{svc: "output"}, testOutputConfig1{CacheSizeBytes:10000, AdminStatus: "enabled"}},
-		{configGetterTestInput{svc: "output", sku: "haswell"}, testOutputConfig1{CacheSizeBytes:20000, AdminStatus: "enabled"}},
-		{configGetterTestInput{svc: "output", vers: "v2"}, testOutputConfig1{CacheSizeBytes:15000, AdminStatus: "enabled"}},
-		{configGetterTestInput{svc: "output", vers: "v2", sku: "haswell"}, testOutputConfig1{CacheSizeBytes:15000, AdminStatus: "enabled"}},
-		{configGetterTestInput{svc: "output", vers: "v2", sku: "skylake"}, testOutputConfig1{CacheSizeBytes:12000, AdminStatus: "enabled"}},
-		{configGetterTestInput{svc: "output", vers: "v2", sku: "ivy"}, testOutputConfig1{CacheSizeBytes:15000, AdminStatus: "enabled"}},
-		{configGetterTestInput{svc: "output", vers: "v1", sku: "haswell"}, testOutputConfig1{CacheSizeBytes:20000, AdminStatus: "enabled"}},
-		{configGetterTestInput{svc: "output", vers: "v1", sku: "ivy"}, testOutputConfig1{CacheSizeBytes:10000, AdminStatus: "enabled"}},
-		{configGetterTestInput{svc: "output", host: "cherami22"}, testOutputConfig1{CacheSizeBytes:10000, AdminStatus: "disabled"}},
-		{configGetterTestInput{svc: "output", host: "cherami44"}, testOutputConfig1{CacheSizeBytes:10000, AdminStatus: "enabled"}},
-		{configGetterTestInput{svc: "output", vers: "v2", sku: "haswell", host: "cherami22"}, testOutputConfig1{CacheSizeBytes:15000, AdminStatus: "disabled"}},
-		{configGetterTestInput{svc: "output", vers: "v1", sku: "ivy", host: "cherami22"}, testOutputConfig1{CacheSizeBytes:10000, AdminStatus: "disabled"}},
-		{configGetterTestInput{svc: "output", sku: "haswell", host: "cherami22"}, testOutputConfig1{CacheSizeBytes:20000, AdminStatus: "disabled"}},
-		{configGetterTestInput{svc: "output", host: "cherami22"}, testOutputConfig1{CacheSizeBytes:10000, AdminStatus: "disabled"}},
+		{configGetterTestInput{svc: "output"}, testOutputConfig1{CacheSizeBytes: 10000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", sku: "haswell"}, testOutputConfig1{CacheSizeBytes: 20000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", vers: "v2"}, testOutputConfig1{CacheSizeBytes: 15000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", vers: "v2", sku: "haswell"}, testOutputConfig1{CacheSizeBytes: 15000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", vers: "v2", sku: "skylake"}, testOutputConfig1{CacheSizeBytes: 12000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", vers: "v2", sku: "ivy"}, testOutputConfig1{CacheSizeBytes: 15000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", vers: "v1", sku: "haswell"}, testOutputConfig1{CacheSizeBytes: 20000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", vers: "v1", sku: "ivy"}, testOutputConfig1{CacheSizeBytes: 10000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", host: "cherami22"}, testOutputConfig1{CacheSizeBytes: 10000, AdminStatus: "disabled"}},
+		{configGetterTestInput{svc: "output", host: "cherami44"}, testOutputConfig1{CacheSizeBytes: 10000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", vers: "v2", sku: "haswell", host: "cherami22"}, testOutputConfig1{CacheSizeBytes: 15000, AdminStatus: "disabled"}},
+		{configGetterTestInput{svc: "output", vers: "v1", sku: "ivy", host: "cherami22"}, testOutputConfig1{CacheSizeBytes: 10000, AdminStatus: "disabled"}},
+		{configGetterTestInput{svc: "output", sku: "haswell", host: "cherami22"}, testOutputConfig1{CacheSizeBytes: 20000, AdminStatus: "disabled"}},
+		{configGetterTestInput{svc: "output", host: "cherami22"}, testOutputConfig1{CacheSizeBytes: 10000, AdminStatus: "disabled"}},
 	}
 
 	configTypes := make(map[string]interface{})

--- a/common/rpm.go
+++ b/common/rpm.go
@@ -507,7 +507,7 @@ func (rpm *ringpopMonitorImpl) refresh(service string, currInfo *membershipInfo)
 				continue
 			}
 
-			v.Name = names[0] // cache hostname to avoid dns reverse lookup
+			v.Name = strings.Split(names[0], ".")[0] // cache hostname to avoid dns reverse lookup
 
 			hwInfo, err := rpm.hwInfoReader.Read(names[0])
 			if err != nil {

--- a/common/util.go
+++ b/common/util.go
@@ -725,3 +725,38 @@ func FindNearestInt(target int64, nums ...int64) (nearest int64) {
 
 	return
 }
+
+// ContainsEmpty scans a string slice for an empty string, returning true if one is found
+func ContainsEmpty(a []string) bool {
+	return ContainsString(a, ``)
+}
+
+// ContainsString scans a string slice for a matching string, returning true if one is found
+func ContainsString(a []string, x string) bool {
+	for _, s := range a {
+		if s == x {
+			return true
+		}
+	}
+	return false
+}
+
+// StringSetEqual checks for set equality (i.e. non-ordered, discounting duplicates) for two string slices
+// StringSetEqual([]string{`a`,`a`,`b`,`b`}, []string{`a`,`a`,`b`}) == TRUE !!
+// DEVNOTE: This is O(N^2), so don't use it with large N; better if len(a) > len(b) if you have duplicates
+func StringSetEqual(a, b []string) bool {
+	if len(a) == 0 { // This handles all nil/[]string{} cases, which are considered equivalent empty sets
+		return len(b) == 0
+	}
+
+	for _, A := range a { // For each in a
+		if match := ContainsString(b, A); !match { // If A is not in b
+			return false
+		}
+	}
+
+	if len(a) >= len(b) { // Only recurse if a could be a proper subset of b
+		return true
+	}
+	return StringSetEqual(b, a) // Above we checked only that all A are in B; check all B in A
+}

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -179,3 +179,41 @@ func (s *UtilSuite) TestOverrideValueByPrefixConcurrency() {
 	startersPistol.Unlock() // bang!
 	wg.Wait()
 }
+
+// TestContainsString tests ContainsString
+func (s *UtilSuite) TestContainsString() {
+	s.False(ContainsString(nil, ``))
+	s.False(ContainsString(make([]string, 0), ``))
+	s.True(ContainsString(make([]string, 10), ``))
+	s.True(ContainsString([]string{``}, ``))
+	s.True(ContainsString([]string{`a`, ``, `c`}, ``))
+	s.True(ContainsString([]string{`a`, `b`, ``}, ``))
+	s.False(ContainsString([]string{`a`}, ``))
+	s.False(ContainsString([]string{`a`, `b`, `c`}, ``))
+	s.True(ContainsString([]string{`a`, `b`, `c`}, `a`))
+	s.True(ContainsString([]string{`a`, `b`, `c`}, `b`))
+	s.True(ContainsString([]string{`a`, `b`, `c`}, `c`))
+	s.False(ContainsString([]string{`a`, `b`, `c`}, `d`))
+}
+
+func (s *UtilSuite) TestStringSetEqual() {
+	s.False(StringSetEqual([]string{``, `a`}, []string{`a`}))
+	s.False(StringSetEqual([]string{``}, nil))
+	s.False(StringSetEqual([]string{`a`, `b`}, []string{`a`}))
+	s.False(StringSetEqual([]string{`a`}, []string{`a`, ``}))
+	s.False(StringSetEqual([]string{`a`}, []string{`a`, `b`}))
+	s.False(StringSetEqual([]string{`a`}, []string{`b`}))
+	s.False(StringSetEqual(nil, []string{``}))
+	s.False(StringSetEqual(nil, []string{`a`}))
+	s.True(StringSetEqual([]string{`a`, `a`, `c`}, []string{`a`, `c`, `a`}))
+	s.True(StringSetEqual([]string{`a`, `b`, `c`, `a`}, []string{`a`, `b`, `c`}))
+	s.True(StringSetEqual([]string{`a`, `b`, `c`}, []string{`a`, `b`, `c`, `a`}))
+	s.True(StringSetEqual([]string{`a`, `b`, `c`}, []string{`a`, `b`, `c`}))
+	s.True(StringSetEqual([]string{`a`, `b`, `c`}, []string{`b`, `a`, `c`}))
+	s.True(StringSetEqual([]string{`a`, `b`, `c`}, []string{`c`, `b`, `a`}))
+	s.True(StringSetEqual([]string{`a`, `c`, `c`}, []string{`a`, `a`, `c`}))
+	s.True(StringSetEqual([]string{`a`}, []string{`a`}))
+	s.True(StringSetEqual(nil, []string{}))
+	s.True(StringSetEqual(nil, nil))
+
+}

--- a/glide.lock
+++ b/glide.lock
@@ -113,7 +113,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: 959013313a26bbb974e23286ef4b9991fde4947b
+  version: 3fecab6f4e017bf30308fb4104e8c944f2a2bb81
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami


### PR DESCRIPTION
Currently, the cassandra backed dynamic config manager has some assumptions about how wildcards are processed. Every config item handled by the configMgr is of the form:

serviceName.serviceVersion.sku.host.key=value

And as you go towards the right, the rules get more specific and the longest matching rule wins. However, with the current code, wildcards are *not* really fully supported. The configMgr assumes it will always be dealing with all the params i.e. {name,version,sku,host}.  

This patch does the following

* Makes the configMgr support wildcards fully
* Modifies rpm to truncate hostnames after the first period