### PR TITLE
Add support for admin command on inputhost

### DIFF
--- a/clients/inputhost/client.go
+++ b/clients/inputhost/client.go
@@ -31,13 +31,18 @@ import (
 	tcthrift "github.com/uber/tchannel-go/thrift"
 )
 
-// InClientImpl is a inputhost cherami tchannel client
+const (
+	// defaultThriftTimeout for all the tchannel-thrift calls
+	defaultThriftTimeout = 10 * time.Second
+)
+
+// InClientImpl is a inputhost tchannel client
 type InClientImpl struct {
 	connection *tchannel.Channel
 	client     admin.TChanInputHostAdmin
 }
 
-// NewClient returns a new instance of cherami tchannel client
+// NewClient returns a new instance of tchannel client
 func NewClient(instanceID int, hostAddr string) (*InClientImpl, error) {
 	ch, err := tchannel.NewChannel(fmt.Sprintf("inputhost-client-%v", instanceID), nil)
 	if err != nil {
@@ -62,7 +67,7 @@ func (s *InClientImpl) Close() {
 
 // UnloadDestinations unloads the destination from the inputhost
 func (s *InClientImpl) UnloadDestinations(req *admin.UnloadDestinationsRequest) error {
-	ctx, cancel := tcthrift.NewContext(2 * time.Second)
+	ctx, cancel := tcthrift.NewContext(defaultThriftTimeout)
 	defer cancel()
 
 	return s.client.UnloadDestinations(ctx, req)
@@ -70,15 +75,15 @@ func (s *InClientImpl) UnloadDestinations(req *admin.UnloadDestinationsRequest) 
 
 // ListLoadedDestinations lists all the loaded destinations from the inputhost
 func (s *InClientImpl) ListLoadedDestinations() (*admin.ListDestinationsResult_, error) {
-	ctx, cancel := tcthrift.NewContext(15 * time.Second)
+	ctx, cancel := tcthrift.NewContext(defaultThriftTimeout)
 	defer cancel()
 
 	return s.client.ListLoadedDestinations(ctx)
 }
 
-// ReadDestState
+// ReadDestState reads the given destination's state from the inputhost
 func (s *InClientImpl) ReadDestState(req *admin.ReadDestinationStateRequest) (*admin.ReadDestinationStateResult_, error) {
-	ctx, cancel := tcthrift.NewContext(15 * time.Second)
+	ctx, cancel := tcthrift.NewContext(defaultThriftTimeout)
 	defer cancel()
 
 	return s.client.ReadDestState(ctx, req)

--- a/clients/inputhost/client.go
+++ b/clients/inputhost/client.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package inputhost
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/uber/cherami-server/common"
+	"github.com/uber/cherami-thrift/.generated/go/admin"
+
+	tchannel "github.com/uber/tchannel-go"
+	tcthrift "github.com/uber/tchannel-go/thrift"
+)
+
+// InClientImpl is a inputhost cherami tchannel client
+type InClientImpl struct {
+	connection *tchannel.Channel
+	client     admin.TChanInputHostAdmin
+}
+
+// NewClient returns a new instance of cherami tchannel client
+func NewClient(instanceID int, hostAddr string) (*InClientImpl, error) {
+	ch, err := tchannel.NewChannel(fmt.Sprintf("inputhost-client-%v", instanceID), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	tClient := tcthrift.NewClient(ch, common.InputServiceName, &tcthrift.ClientOptions{
+		HostPort: hostAddr,
+	})
+	client := admin.NewTChanInputHostAdminClient(tClient)
+
+	return &InClientImpl{
+		connection: ch,
+		client:     client,
+	}, nil
+}
+
+// Close closes the client
+func (s *InClientImpl) Close() {
+	s.connection.Close()
+}
+
+// UnloadDestinations unloads the destination from the inputhost
+func (s *InClientImpl) UnloadDestinations(req *admin.UnloadDestinationsRequest) error {
+	ctx, cancel := tcthrift.NewContext(2 * time.Second)
+	defer cancel()
+
+	return s.client.UnloadDestinations(ctx, req)
+}
+
+// ListLoadedDestinations lists all the loaded destinations from the inputhost
+func (s *InClientImpl) ListLoadedDestinations() (*admin.ListDestinationsResult_, error) {
+	ctx, cancel := tcthrift.NewContext(15 * time.Second)
+	defer cancel()
+
+	return s.client.ListLoadedDestinations(ctx)
+}
+
+// ReadDestState
+func (s *InClientImpl) ReadDestState(req *admin.ReadDestinationStateRequest) (*admin.ReadDestinationStateResult_, error) {
+	ctx, cancel := tcthrift.NewContext(15 * time.Second)
+	defer cancel()
+
+	return s.client.ReadDestState(ctx, req)
+}

--- a/cmd/tools/admin/main.go
+++ b/cmd/tools/admin/main.go
@@ -652,6 +652,51 @@ func main() {
 			},
 		},
 		{
+			Name:    "inputhost",
+			Aliases: []string{"ih"},
+			Usage:   "inputhost (deststate|listAllDests|unloaddest)",
+			Subcommands: []cli.Command{
+				{
+					Name:    "deststate",
+					Aliases: []string{"dests"},
+					Usage:   "inputhost deststate <hostport> [options]",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "dest_uuid, dest",
+							Value: "",
+							Usage: "The UUID of the destination whose state will be dumped",
+						},
+					},
+					Action: func(c *cli.Context) {
+						admin.GetDestinationState(c)
+					},
+				},
+				{
+					Name:    "listAllDests",
+					Aliases: []string{"ls"},
+					Usage:   "inputhost listAllDests <hostport>",
+					Action: func(c *cli.Context) {
+						admin.ListAllLoadedDestinations(c)
+					},
+				},
+				{
+					Name:    "unloaddest",
+					Aliases: []string{"ud"},
+					Usage:   "inputhost unloaddest <hostport> [options]",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "dest_uuid, dest",
+							Value: "",
+							Usage: "The destination UUID which should be unloaded",
+						},
+					},
+					Action: func(c *cli.Context) {
+						admin.UnloadDestination(c)
+					},
+				},
+			},
+		},
+		{
 			Name:    "seal-check",
 			Aliases: []string{"sc"},
 			Usage:   "seal-check <dest> [--seal]",

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -224,6 +224,12 @@ const (
 	PubConnectionScope
 	//PutMessageBatchInputHostDestScope represent API PutMessageBatch for per destination
 	PutMessageBatchInputHostDestScope
+	// UnloadDestinationsScope represents UnloadDestinations API
+	UnloadDestinationsScope
+	// ListLoadedDestinationsScope represents ListLoadedDestinations API
+	ListLoadedDestinationsScope
+	// ReadDestStateScope represents ReadDestState API
+	ReadDestStateScope
 
 	// -- Operation scopes for OutputHost --
 
@@ -492,6 +498,9 @@ var scopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		DestinationsUpdatedScope:      {operation: "DestinationsUpdated"},
 		PubConnectionStreamScope:      {operation: "PubConnection"},
 		PutMessageBatchInputHostScope: {operation: "PutMessageBatchInputHost"},
+		UnloadDestinationsScope:       {operation: "UnloadDestinations"},
+		ListLoadedDestinationsScope:   {operation: "ListLoadedDestinations"},
+		ReadDestStateScope:            {operation: "ReadDestState"},
 	},
 
 	// Outputhost operation tag values as seen by the Metrics backend

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 95f30a537dc5b2841e061722d66e26c58126e82c19e9ba29bb6b0f44cf1741d0
-updated: 2017-02-14T08:55:45.490984145-08:00
+hash: 455d014dba66a9246f74391ada335e48ddfe5a119aebb4671de58865ac011d9f
+updated: 2017-03-07T12:54:07.57993842-08:00
 imports:
 - name: github.com/apache/thrift
   version: 2d6060d882069ed3e3d6302aa63ea7eb4bb155ad
@@ -91,7 +91,7 @@ imports:
 - name: github.com/stretchr/objx
   version: 1a9d0bb9f541897e62256577b352fdbc1fb4fd94
 - name: github.com/stretchr/testify
-  version: 4d4bfba8f1d1027c4fdbe371823030df51419987
+  version: 2402e8e7a02fc811447d11f881aa9746cdc57983
   subpackages:
   - assert
   - mock
@@ -104,7 +104,7 @@ imports:
 - name: github.com/uber-go/atomic
   version: 3b8db5e93c4c02efbc313e17b2e796b0914a01fb
 - name: github.com/uber/cherami-client-go
-  version: 1cdcfc4a204fe42013f4cf7196fab208d3b98085 
+  version: 1cdcfc4a204fe42013f4cf7196fab208d3b98085
   subpackages:
   - client/cherami
   - common
@@ -113,7 +113,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: ac828452c87c2aabd8f10ba8d95c4731201a99de
+  version: 07e768fb690bae4b98d73b18eeb9b931a03de7ef
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami
@@ -148,7 +148,7 @@ imports:
   - trand
   - typed
 - name: golang.org/x/net
-  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
+  version: 60c41d1de8da134c05b7b40154a9a82bf5b7edb9
   subpackages:
   - context
 - name: golang.org/x/sys

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 455d014dba66a9246f74391ada335e48ddfe5a119aebb4671de58865ac011d9f
-updated: 2017-03-07T12:54:07.57993842-08:00
+hash: 95f30a537dc5b2841e061722d66e26c58126e82c19e9ba29bb6b0f44cf1741d0
+updated: 2017-03-09T08:28:59.876988661-08:00
 imports:
 - name: github.com/apache/thrift
   version: 2d6060d882069ed3e3d6302aa63ea7eb4bb155ad
@@ -113,7 +113,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: 07e768fb690bae4b98d73b18eeb9b931a03de7ef
+  version: 09ed2ceaeab9e52820a81caece0dee9914c31f5d
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/glide.yaml
+++ b/glide.yaml
@@ -34,6 +34,7 @@ import:
   - common/websocket
   - stream
 - package: github.com/uber/cherami-thrift
+  version: input_admin
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/glide.yaml
+++ b/glide.yaml
@@ -34,7 +34,6 @@ import:
   - common/websocket
   - stream
 - package: github.com/uber/cherami-thrift
-  version: input_admin
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/services/controllerhost/event_pipeline_test.go
+++ b/services/controllerhost/event_pipeline_test.go
@@ -727,3 +727,15 @@ func (service *MockInputOutputService) ListLoadedConsumerGroups(ctx thrift.Conte
 func (service *MockInputOutputService) ReadCgState(ctx thrift.Context, req *admin.ReadConsumerGroupStateRequest) (*admin.ReadConsumerGroupStateResult_, error) {
 	return nil, fmt.Errorf("mock not implemented")
 }
+
+func (service *MockInputOutputService) UnloadDestinations(ctx thrift.Context, request *admin.UnloadDestinationsRequest) error {
+	return fmt.Errorf("mock not implemented")
+}
+
+func (service *MockInputOutputService) ListLoadedDestinations(ctx thrift.Context) (*admin.ListDestinationsResult_, error) {
+	return nil, fmt.Errorf("mock not implemented")
+}
+
+func (service *MockInputOutputService) ReadDestState(ctx thrift.Context, req *admin.ReadDestinationStateRequest) (*admin.ReadDestinationStateResult_, error) {
+	return nil, fmt.Errorf("mock not implemented")
+}

--- a/services/inputhost/inputhost.go
+++ b/services/inputhost/inputhost.go
@@ -585,6 +585,12 @@ ACKDRAIN:
 	pathCache.destM3Client.AddCounter(metrics.PutMessageBatchInputHostDestScope, metrics.InputhostDestMessageUserFailures, userErrs)
 	h.m3Client.AddCounter(metrics.PutMessageBatchInputHostScope, metrics.InputhostMessageInternalFailures, internalErrs)
 	pathCache.destM3Client.AddCounter(metrics.PutMessageBatchInputHostDestScope, metrics.InputhostDestMessageInternalFailures, internalErrs)
+
+	// Increment the overall incoming messages, failed messages and acks
+	pathCache.dstMetrics.Add(load.DstMetricOverallNumMsgs, int64(len(messages)))
+	pathCache.dstMetrics.Add(load.DstMetricNumFailed, (internalErrs + userErrs))
+	pathCache.dstMetrics.Add(load.DstMetricNumAcks, int64(len(result.SuccessMessages)))
+
 	return result, nil
 }
 

--- a/services/inputhost/inputhost.go
+++ b/services/inputhost/inputhost.go
@@ -641,6 +641,105 @@ func (h *InputHost) DestinationsUpdated(ctx thrift.Context, request *admin.Desti
 	return
 }
 
+// UnloadDestinations is the API used to unload consumer groups to clear the cache
+func (h *InputHost) UnloadDestinations(ctx thrift.Context, request *admin.UnloadDestinationsRequest) (err error) {
+	defer atomic.AddInt32(&h.loadShutdownRef, -1)
+	sw := h.m3Client.StartTimer(metrics.UnloadDestinationsScope, metrics.InputhostLatencyTimer)
+	defer sw.Stop()
+	h.m3Client.IncCounter(metrics.UnloadDestinationsScope, metrics.InputhostRequests)
+	// If we are already shutting down, no need to do anything here
+	if atomic.AddInt32(&h.loadShutdownRef, 1) <= 0 {
+		h.logger.Error("not unloading the path cache; inputHost already shutdown")
+		h.m3Client.IncCounter(metrics.UnloadDestinationsScope, metrics.InputhostFailures)
+		return ErrHostShutdown
+	}
+
+	for _, destUUID := range request.DestUUIDs {
+		h.pathMutex.RLock()
+		pathCache, ok := h.pathCache[destUUID]
+		if ok {
+			pathCache.Lock()
+			pathCache.prepareForUnload()
+			go pathCache.unload()
+			pathCache.Unlock()
+		} else {
+			h.logger.WithField(common.TagDst, common.FmtDst(destUUID)).
+				Error("destination is not cached at all")
+			err = ErrDstNotLoaded
+			h.m3Client.IncCounter(metrics.UnloadDestinationsScope, metrics.InputhostFailures)
+		}
+		h.pathMutex.RUnlock()
+	}
+
+	return err
+}
+
+// ListLoadedDestinations is the API used to list all the loaded destinations in memory
+func (h *InputHost) ListLoadedDestinations(ctx thrift.Context) (result *admin.ListDestinationsResult_, err error) {
+	defer atomic.AddInt32(&h.loadShutdownRef, -1)
+	sw := h.m3Client.StartTimer(metrics.ListLoadedDestinationsScope, metrics.InputhostLatencyTimer)
+	defer sw.Stop()
+	h.m3Client.IncCounter(metrics.ListLoadedDestinationsScope, metrics.InputhostRequests)
+	// If we are already shutting down, no need to do anything here
+	if atomic.AddInt32(&h.loadShutdownRef, 1) <= 0 {
+		h.logger.Error("inputHost already shutdown")
+		h.m3Client.IncCounter(metrics.ListLoadedDestinationsScope, metrics.InputhostFailures)
+		return nil, ErrHostShutdown
+	}
+
+	result = admin.NewListDestinationsResult_()
+	result.Dests = make([]*admin.Destinations, 0)
+	h.pathMutex.RLock()
+	for destUUID, pathCache := range h.pathCache {
+		destRes := admin.NewDestinations()
+		destRes.DestUUID = common.StringPtr(destUUID)
+		destRes.DestPath = common.StringPtr(pathCache.destinationPath)
+
+		result.Dests = append(result.Dests, destRes)
+	}
+	h.pathMutex.RUnlock()
+
+	return result, err
+}
+
+// ReadDestState is the API used to read the state of the destination which is loaded on thi inputhost
+func (h *InputHost) ReadDestState(ctx thrift.Context, request *admin.ReadDestinationStateRequest) (result *admin.ReadDestinationStateResult_, err error) {
+	defer atomic.AddInt32(&h.loadShutdownRef, -1)
+	sw := h.m3Client.StartTimer(metrics.ReadDestStateScope, metrics.InputhostLatencyTimer)
+	defer sw.Stop()
+	h.m3Client.IncCounter(metrics.ReadDestStateScope, metrics.InputhostRequests)
+	// If we are already shutting down, no need to do anything here
+	if atomic.AddInt32(&h.loadShutdownRef, 1) <= 0 {
+		h.logger.Error("inputHost already shutdown")
+		h.m3Client.IncCounter(metrics.ReadDestStateScope, metrics.InputhostFailures)
+		return nil, ErrHostShutdown
+	}
+
+	result = admin.NewReadDestinationStateResult_()
+
+	result.InputHostUUID = common.StringPtr(h.GetHostUUID())
+	result.DestState = make([]*admin.DestinationState, 0)
+
+	// Now populate all destination state
+	h.pathMutex.RLock()
+	for _, destUUID := range request.DestUUIDs {
+		pathCache, ok := h.pathCache[destUUID]
+		if ok {
+			destState := pathCache.getState()
+			result.DestState = append(result.DestState, destState)
+		} else {
+			h.logger.WithField(common.TagDst, common.FmtDst(destUUID)).
+				Error("destination is not cached at all")
+			err = ErrDstNotLoaded
+			h.m3Client.IncCounter(metrics.ReadDestStateScope, metrics.InputhostFailures)
+		}
+	}
+	h.pathMutex.RUnlock()
+
+	return result, err
+
+}
+
 // Report is the implementation for reporting host specific load to controller
 func (h *InputHost) Report(reporter common.LoadReporter) {
 

--- a/services/inputhost/load/metrics.go
+++ b/services/inputhost/load/metrics.go
@@ -61,6 +61,14 @@ const (
 	DstMetricMsgsIn
 	// DstMetricBytesIn represents count of incoming bytes per dst
 	DstMetricBytesIn
+	// DstMetricsNumAcks represents count of number of acked messages per dst
+	DstMetricNumAcks
+	// DstMetricsNumNacks represents count of number of nacked messages per dst
+	DstMetricNumNacks
+	// DstMetricsNumThrottled represents count of number of throttled messages per dst
+	DstMetricNumThrottled
+	// DstMetricsNumFailed represents count of number of failed messages per dst
+	DstMetricNumFailed
 	// numDstMetrics gives the number of inpust host dst level metrics
 	numDstMetrics
 )

--- a/services/inputhost/load/metrics.go
+++ b/services/inputhost/load/metrics.go
@@ -69,6 +69,9 @@ const (
 	DstMetricNumThrottled
 	// DstMetricsNumFailed represents count of number of failed messages per dst
 	DstMetricNumFailed
+	// DstMetricOverallNumMsgs represents count of the overall number of messages per dst
+	// Note: this is different than the MsgsIn above since that maintains the per second msgs
+	DstMetricOverallNumMsgs
 	// numDstMetrics gives the number of inpust host dst level metrics
 	numDstMetrics
 )

--- a/services/inputhost/pathCache.go
+++ b/services/inputhost/pathCache.go
@@ -483,18 +483,10 @@ func (pathCache *inPathCache) Report(reporter common.LoadReporter) {
 func (pathCache *inPathCache) getState() *admin.DestinationState {
 	pathCache.RLock()
 	defer pathCache.RUnlock()
-	now := time.Now().UnixNano()
-	diffSecs := (now - pathCache.lastDstLoadReportedTime) / int64(time.Second)
-	if diffSecs < 1 {
-		// just use the counter as is
-		diffSecs = 1
-	}
-
-	msgsInPerSec := pathCache.dstMetrics.GetAndReset(load.DstMetricMsgsIn) / diffSecs
 	destState := admin.NewDestinationState()
 	destState.DestUUID = common.StringPtr(pathCache.destUUID)
 	destState.MsgsChSize = common.Int64Ptr(int64(len(pathCache.putMsgCh)))
-	destState.NumMsgsIn = common.Int64Ptr(msgsInPerSec)
+	destState.NumMsgsIn = common.Int64Ptr(pathCache.dstMetrics.Get(load.DstMetricOverallNumMsgs))
 	destState.NumConnections = common.Int64Ptr(pathCache.dstMetrics.Get(load.DstMetricNumOpenConns))
 	destState.NumSentAcks = common.Int64Ptr(pathCache.dstMetrics.Get(load.DstMetricNumAcks))
 	destState.NumSentNacks = common.Int64Ptr(pathCache.dstMetrics.Get(load.DstMetricNumNacks))

--- a/services/inputhost/pathCache.go
+++ b/services/inputhost/pathCache.go
@@ -479,3 +479,34 @@ func (pathCache *inPathCache) Report(reporter common.LoadReporter) {
 	// Also update the metrics reporter to make sure the connection gauge is updated
 	pathCache.destM3Client.UpdateGauge(metrics.PubConnectionScope, metrics.InputhostDestPubConnection, numConnections)
 }
+
+func (pathCache *inPathCache) getState() *admin.DestinationState {
+	pathCache.RLock()
+	defer pathCache.RUnlock()
+	now := time.Now().UnixNano()
+	diffSecs := (now - pathCache.lastDstLoadReportedTime) / int64(time.Second)
+	if diffSecs < 1 {
+		// just use the counter as is
+		diffSecs = 1
+	}
+
+	msgsInPerSec := pathCache.dstMetrics.GetAndReset(load.DstMetricMsgsIn) / diffSecs
+	destState := admin.NewDestinationState()
+	destState.DestUUID = common.StringPtr(pathCache.destUUID)
+	destState.MsgsChSize = common.Int64Ptr(int64(len(pathCache.putMsgCh)))
+	destState.NumMsgsIn = common.Int64Ptr(msgsInPerSec)
+	destState.NumConnections = common.Int64Ptr(pathCache.dstMetrics.Get(load.DstMetricNumOpenConns))
+	destState.NumSentAcks = common.Int64Ptr(pathCache.dstMetrics.Get(load.DstMetricNumAcks))
+	destState.NumSentNacks = common.Int64Ptr(pathCache.dstMetrics.Get(load.DstMetricNumNacks))
+	destState.NumFailed = common.Int64Ptr(pathCache.dstMetrics.Get(load.DstMetricNumFailed))
+	destState.NumThrottled = common.Int64Ptr(pathCache.dstMetrics.Get(load.DstMetricNumThrottled))
+
+	destState.DestExtents = make([]*admin.InputDestExtent, 0)
+	// get all extent state now
+	for _, extCache := range pathCache.extentCache {
+		extState := extCache.connection.getState()
+		destState.DestExtents = append(destState.DestExtents, extState)
+	}
+
+	return destState
+}

--- a/services/inputhost/pathCache.go
+++ b/services/inputhost/pathCache.go
@@ -493,11 +493,13 @@ func (pathCache *inPathCache) getState() *admin.DestinationState {
 	destState.NumFailed = common.Int64Ptr(pathCache.dstMetrics.Get(load.DstMetricNumFailed))
 	destState.NumThrottled = common.Int64Ptr(pathCache.dstMetrics.Get(load.DstMetricNumThrottled))
 
-	destState.DestExtents = make([]*admin.InputDestExtent, 0)
+	destState.DestExtents = make([]*admin.InputDestExtent, len(pathCache.extentCache))
+	count := 0
 	// get all extent state now
 	for _, extCache := range pathCache.extentCache {
 		extState := extCache.connection.getState()
-		destState.DestExtents = append(destState.DestExtents, extState)
+		destState.DestExtents[count] = extState
+		count++
 	}
 
 	return destState

--- a/services/inputhost/pubconnection.go
+++ b/services/inputhost/pubconnection.go
@@ -26,9 +26,9 @@ import (
 	"time"
 
 	"github.com/uber-common/bark"
-
 	"github.com/uber/cherami-server/common"
 	"github.com/uber/cherami-server/common/metrics"
+	"github.com/uber/cherami-server/services/inputhost/load"
 	serverStream "github.com/uber/cherami-server/stream"
 	"github.com/uber/cherami-thrift/.generated/go/cherami"
 )
@@ -477,6 +477,7 @@ func (conn *pubConnection) failInflightMessages(inflightMessages map[string]resp
 			conn.pathCache.m3Client.IncCounter(metrics.PubConnectionStreamScope, metrics.InputhostMessageFailures)
 			conn.pathCache.destM3Client.IncCounter(metrics.PubConnectionScope, metrics.InputhostDestMessageFailures)
 			conn.failedMsgs++
+			conn.pathCache.dstMetrics.Increment(load.DstMetricNumFailed)
 		}
 	}
 
@@ -522,10 +523,13 @@ func (conn *pubConnection) writeAckToClient(inflightMessages map[string]response
 		switch ack.GetStatus() {
 		case cherami.Status_OK:
 			conn.sentAcks++
+			conn.pathCache.dstMetrics.Increment(load.DstMetricNumAcks)
 		case cherami.Status_FAILED:
 			conn.sentNacks++
+			conn.pathCache.dstMetrics.Increment(load.DstMetricNumNacks)
 		case cherami.Status_THROTTLED:
 			conn.sentThrottled++
+			conn.pathCache.dstMetrics.Increment(load.DstMetricNumThrottled)
 		}
 	}
 

--- a/services/inputhost/pubconnection.go
+++ b/services/inputhost/pubconnection.go
@@ -216,6 +216,7 @@ func (conn *pubConnection) readRequestStream() {
 			// record the counter metric
 			conn.pathCache.m3Client.IncCounter(metrics.PubConnectionStreamScope, metrics.InputhostMessageReceived)
 			conn.pathCache.destM3Client.IncCounter(metrics.PubConnectionScope, metrics.InputhostDestMessageReceived)
+			conn.pathCache.dstMetrics.Increment(load.DstMetricOverallNumMsgs)
 
 			conn.recvMsgs++
 

--- a/tools/admin/lib.go
+++ b/tools/admin/lib.go
@@ -178,6 +178,22 @@ func ReadCgAckID(c *cli.Context) {
 	fmt.Fprintln(os.Stdout, string(outputStr))
 }
 
+// UnloadDestination unloads the destination on the given inputhost
+func UnloadDestination(c *cli.Context) {
+	mClient := toolscommon.GetMClient(c, adminToolService)
+	toolscommon.UnloadDestination(c, mClient)
+}
+
+// ListAllLoadedDestinations unloads the destination on the given inputhost
+func ListAllLoadedDestinations(c *cli.Context) {
+	toolscommon.ListAllLoadedDestinations(c)
+}
+
+// GetDestinationState gets the destination state on the given inputhost
+func GetDestinationState(c *cli.Context) {
+	toolscommon.GetDestinationState(c)
+}
+
 type storeExtJSONOutputFields struct {
 	StoreAddr      string `json:"storehost_addr"`
 	StoreUUID      string `json:"storehost_uuid"`


### PR DESCRIPTION
This patch does a couple of things:
(1) implements all the relevant admin APIs on inputhost to do the following:
       - Unload a loaded destination
       - Get a list of all the destinations currently loaded in-memory
       - Get the state of a specific destination loaded in-memory
(2) Wire the admin command to perform all of the aforementioned tasks on the inputhost

Some of the things that was needed for this support:
(1) Inputhost client for the CLI to talk directly to inputhost
(2) We needed to keep track of overall number of messages (without resetting every time we report to controller), number of acks, nacks and failed messages.

Tested manually in my laptop and will look something like this:
For example, something like 
`
$ ./cherami-admin --hostport=127.0.0.1:4922 inputhost listAllDests 127.0.0.1:4240
    {"destUUID":"87e2f8b2-bdfd-478e-98df-2aef481a40e0","destPath":"/test/admin"}
    {"destUUID":"5bbe76ad-b6b3-4af1-abe0-d7854a8d8e83","destPath":"/test/cherami2"}


$ ./cherami-admin --hostport=127.0.0.1:4922 inputhost deststate 127.0.0.1:4240 --dest_uuid=5bbe76ad-b6b3-4af1-abe0-d7854a8d8e83
    inputhostUUID: 5baccb55-8ec3-4055-a94f-f06e75cbb4c5
    {"DestUUID":"5bbe76ad-b6b3-4af1-abe0-d7854a8d8e83","msgsChSize":0,"numConnections":1,"numMsgsIn":24,"numSentAcks":24,"numSentNacks":0,"numThrottled":0,"numFailed":0}
            {"extentUUID":"4695174f-1f3d-4e5a-ae12-1f54bb73128e","maxSeqNo":10817752,"maxSizeBytes":11077378048,"currSeqNo":16,"currSizeBytes":80,"replicas":[11,1,"127.0.0.1:4253"]}
            {"extentUUID":"9eb0cbf2-b5eb-420c-a580-89d920e5363f","maxSeqNo":16418725,"maxSizeBytes":16812774400,"currSeqNo":3,"currSizeBytes":7,"replicas":[11,1,"127.0.0.1:4253"]}
            {"extentUUID":"b37b023f-efb6-4bc3-808d-059c9d8b3025","maxSeqNo":19140325,"maxSizeBytes":19599692800,"currSeqNo":3,"currSizeBytes":6,"replicas":[11,1,"127.0.0.1:4253"]}
            {"extentUUID":"f1e66518-9fb7-4034-9180-3a1ed602f81b","maxSeqNo":13806070,"maxSizeBytes":14137415680,"currSeqNo":2,"currSizeBytes":4,"replicas":[11,1,"127.0.0.1:4253"]}
`