### PR TITLE
report first/last addr/timestamp in replica-stats

### DIFF
--- a/config/base.yaml
+++ b/config/base.yaml
@@ -91,7 +91,7 @@ ReplicatorConfig:
 # Logging configuration
 logging:
   level: error
-  stdout: false
+  stdout: true
 
 # DefaultDestinationConfig right now configures how many replicas you want
 DefaultDestinationConfig:

--- a/services/controllerhost/queueDepthCache.go
+++ b/services/controllerhost/queueDepthCache.go
@@ -116,7 +116,7 @@ func (cache *storeExtentMetadataCache) fetchStoreExtentMetadata(extID string, st
 	rs := stats.GetReplicaStats()[0]
 	// store apparently reports illegal values
 	// fix them if needed
-	cache.fixReplicaStatsIfBroken(rs)
+	// cache.fixReplicaStatsIfBroken(rs)
 
 	// fmt.Printf("storeExtentMetadata.fetchStoreExtentMetadata: extReplStats: ext=%v firstEnq=%x lastEnq=%x\n",
 	// 	extID, rs.GetBeginEnqueueTimeUtc(), rs.GetLastEnqueueTimeUtc())

--- a/services/controllerhost/queueDepthCache.go
+++ b/services/controllerhost/queueDepthCache.go
@@ -86,7 +86,7 @@ func (cache *storeExtentMetadataCache) get(store storeID, extID extentID) *store
 	result := findStoreMetadata(entry, string(store))
 
 	if result != nil {
-		fmt.Printf("storeExtentMetadata.get (cached): extent=%v result={%v}\n", extID, result)
+		// fmt.Printf("storeExtentMetadata.get (cached): extent=%v result={%v}\n", extID, result)
 		return result
 	}
 	// cache miss, lets fetch the data from source
@@ -95,15 +95,15 @@ func (cache *storeExtentMetadataCache) get(store storeID, extID extentID) *store
 		entry = append(entry, result)
 		cache.entries[extID] = entry
 	}
-	fmt.Printf("storeExtentMetadata.get (miss): extent=%v result={%v}\n", extID, result)
+	// fmt.Printf("storeExtentMetadata.get (miss): extent=%v result={%v}\n", extID, result)
 	return result
 }
 
 func (cache *storeExtentMetadataCache) fetchStoreExtentMetadata(extID string, store string) (result *storeExtentMetadata) {
 
-	defer func() {
-		fmt.Printf("storeExtentMetadata.fetchStoreExtentMetadata: extent=%v result={%v}\n", extID, result)
-	}()
+	// defer func() {
+	// 	fmt.Printf("storeExtentMetadata.fetchStoreExtentMetadata: extent=%v result={%v}\n", extID, result)
+	// }()
 
 	stats, err := cache.datasource.ReadStoreExtentStats(extID, store)
 	if err != nil {
@@ -118,8 +118,8 @@ func (cache *storeExtentMetadataCache) fetchStoreExtentMetadata(extID string, st
 	// fix them if needed
 	cache.fixReplicaStatsIfBroken(rs)
 
-	fmt.Printf("storeExtentMetadata.fetchStoreExtentMetadata: extReplStats: ext=%v firstEnq=%x lastEnq=%x\n",
-		extID, rs.GetBeginEnqueueTimeUtc(), rs.GetLastEnqueueTimeUtc())
+	// fmt.Printf("storeExtentMetadata.fetchStoreExtentMetadata: extReplStats: ext=%v firstEnq=%x lastEnq=%x\n",
+	// 	extID, rs.GetBeginEnqueueTimeUtc(), rs.GetLastEnqueueTimeUtc())
 
 	return &storeExtentMetadata{
 		storeID:               store,

--- a/services/storehost/extStats.go
+++ b/services/storehost/extStats.go
@@ -68,8 +68,10 @@ type (
 		extentID  uuid.UUID
 		timestamp int64
 
-		firstSeqNum, lastSeqNum int64
-		sealed                  bool
+		firstSeqNum, lastSeqNum       int64
+		firstAddress, lastAddress     int64
+		firstTimestamp, lastTimestamp int64
+		sealed                        bool
 	}
 )
 
@@ -158,7 +160,8 @@ func (t *ExtStatsReporter) trySendReport(extentID uuid.UUID, ext *extentContext,
 	r.timestamp = time.Now().UnixNano()
 
 	// get a snapshot of various extent stats
-	r.firstSeqNum, r.lastSeqNum = ext.getBeginSeqNum(), ext.getLastSeqNum()
+	r.firstAddress, r.firstSeqNum, r.firstTimestamp = ext.getFirstMsg()
+	r.lastAddress, r.lastSeqNum, r.lastTimestamp = ext.getLastMsg()
 	r.sealed, _ = ext.isSealed()
 
 	// create and send report non-blockingly
@@ -293,15 +296,15 @@ pump:
 			}
 
 			extReplStats := &shared.ExtentReplicaStats{
-				StoreUUID:  common.StringPtr(t.hostID),
-				ExtentUUID: common.StringPtr(extentID.String()),
-				// BeginAddress:  common.Int64Ptr(report.firstAddress),
-				// LastAddress: common.Int64Ptr(report.lastAddress),
-				BeginSequence:     common.Int64Ptr(report.firstSeqNum),
-				LastSequence:      common.Int64Ptr(report.lastSeqNum),
-				AvailableSequence: common.Int64Ptr(report.lastSeqNum),
-				// BeginEnqueueTimeUtc: common.Int64Ptr(report.firstTimestamp),
-				// LastEnqueueTimeUtc: common.Int64Ptr(report.lastTimestamp),
+				StoreUUID:           common.StringPtr(t.hostID),
+				ExtentUUID:          common.StringPtr(extentID.String()),
+				BeginAddress:        common.Int64Ptr(report.firstAddress),
+				LastAddress:         common.Int64Ptr(report.lastAddress),
+				BeginSequence:       common.Int64Ptr(report.firstSeqNum),
+				LastSequence:        common.Int64Ptr(report.lastSeqNum),
+				AvailableSequence:   common.Int64Ptr(report.lastSeqNum),
+				BeginEnqueueTimeUtc: common.Int64Ptr(report.firstTimestamp),
+				LastEnqueueTimeUtc:  common.Int64Ptr(report.lastTimestamp),
 				// SizeInBytes: common.Int64Ptr(report.size),
 				Status:                shared.ExtentReplicaStatusPtr(extReplStatus),
 				AvailableSequenceRate: common.Float64Ptr(lastSeqRate),

--- a/services/storehost/extStats.go
+++ b/services/storehost/extStats.go
@@ -302,23 +302,23 @@ pump:
 			}
 
 			extReplStats := &shared.ExtentReplicaStats{
-				StoreUUID:           common.StringPtr(t.hostID),
-				ExtentUUID:          common.StringPtr(extentID.String()),
-				BeginAddress:        common.Int64Ptr(report.firstAddress),
-				LastAddress:         common.Int64Ptr(report.lastAddress),
-				BeginSequence:       common.Int64Ptr(report.firstSeqNum),
-				LastSequence:        common.Int64Ptr(report.lastSeqNum),
-				AvailableSequence:   common.Int64Ptr(report.lastSeqNum),
-				BeginEnqueueTimeUtc: common.Int64Ptr(report.firstTimestamp),
-				LastEnqueueTimeUtc:  common.Int64Ptr(0x123456789ABCDEF), //report.lastTimestamp),
-				// SizeInBytes: common.Int64Ptr(report.size),
-				Status:                shared.ExtentReplicaStatusPtr(extReplStatus),
-				AvailableSequenceRate: common.Float64Ptr(lastSeqRate),
+				StoreUUID:             common.StringPtr(t.hostID),
+				ExtentUUID:            common.StringPtr(extentID.String()),
+				BeginAddress:          common.Int64Ptr(report.firstAddress),
+				LastAddress:           common.Int64Ptr(report.lastAddress),
+				AvailableAddress:      common.Int64Ptr(report.lastAddress),
+				BeginSequence:         common.Int64Ptr(report.firstSeqNum),
+				LastSequence:          common.Int64Ptr(report.lastSeqNum),
 				LastSequenceRate:      common.Float64Ptr(lastSeqRate),
-				// AvailableAddress
+				AvailableSequence:     common.Int64Ptr(report.lastSeqNum),
+				AvailableSequenceRate: common.Float64Ptr(lastSeqRate),
+				BeginEnqueueTimeUtc:   common.Int64Ptr(report.firstTimestamp),
+				LastEnqueueTimeUtc:    common.Int64Ptr(report.lastTimestamp),
+				Status:                shared.ExtentReplicaStatusPtr(extReplStatus),
+				// BeginTime:             common.Int64Ptr(report.firstTimestamp), // only for timer-queue
+				// EndTime:               common.Int64Ptr(report.lastTimestamp),
+				// SizeInBytes: common.Int64Ptr(report.size),
 				// SizeInBytesRate
-				// BeginTime
-				// EndTime
 				// WriteTime
 			}
 

--- a/services/storehost/extent.go
+++ b/services/storehost/extent.go
@@ -89,13 +89,19 @@ func (x *ExtentObj) extentRUnlock() {
 	x.ext.RUnlock()
 }
 
-// wrappers that modify the {begin,last,seal}SeqNum
-func (x *ExtentObj) getBeginSeqNum() int64 {
-	return atomic.LoadInt64(&x.ext.beginSeqNum)
+// wrappers that modify the {first,last,seal}SeqNum
+func (x *ExtentObj) getFirstSeqNum() int64 {
+	return atomic.LoadInt64(&x.ext.firstSeqNum)
 }
 
-func (x *ExtentObj) setBeginSeqNum(beginSeqNum int64) {
-	atomic.StoreInt64(&x.ext.beginSeqNum, beginSeqNum)
+func (x *ExtentObj) setFirstSeqNum(firstSeqNum int64) {
+	atomic.StoreInt64(&x.ext.firstSeqNum, firstSeqNum)
+}
+
+func (x *ExtentObj) setFirstMsg(firstAddr, firstSeqNum, firstTimestamp int64) {
+	atomic.StoreInt64(&x.ext.firstAddr, firstAddr)
+	atomic.StoreInt64(&x.ext.firstSeqNum, firstSeqNum)
+	atomic.StoreInt64(&x.ext.firstTimestamp, firstTimestamp)
 }
 
 func (x *ExtentObj) getLastSeqNum() int64 {
@@ -104,6 +110,14 @@ func (x *ExtentObj) getLastSeqNum() int64 {
 
 func (x *ExtentObj) setLastSeqNum(lastSeqNum int64) {
 	x.ext.lastSeqNum = lastSeqNum // should be called with extentLock held
+}
+
+// setLastMsg sets the addr, seqnum, timestamp of the last message;
+// should be called with the extentLock held.
+func (x *ExtentObj) setLastMsg(lastAddr, lastSeqNum, lastTimestamp int64) {
+	x.ext.lastAddr = lastAddr
+	x.ext.lastSeqNum = lastSeqNum
+	x.ext.lastTimestamp = lastTimestamp
 }
 
 func (x *ExtentObj) getSealSeqNum() int64 {


### PR DESCRIPTION
The diff adds support in storehost to report first/last timestamps and address (along with seqnum) with replica-stats.

This is more of a preview of the changes and is work-in-progress, since some queue-depth tests are failing against this change, that I am yet to root-cause/fix.