### PR TITLE
multi zone consumer group: cg metadata propagation(fast and slow path)

### DIFF
--- a/clients/metadata/client.go
+++ b/clients/metadata/client.go
@@ -116,7 +116,7 @@ func (c *clientImpl) ReadExtentStats(request *m.ReadExtentStatsRequest) (*m.Read
 	return c.client.ReadExtentStats(ctx, request)
 }
 
-func (c *clientImpl) ReadDestination(request *m.ReadDestinationRequest) (*shared.DestinationDescription, error) {
+func (c *clientImpl) ReadDestination(request *shared.ReadDestinationRequest) (*shared.DestinationDescription, error) {
 	ctx, cancel := c.createContext()
 	defer cancel()
 

--- a/clients/metadata/client.go
+++ b/clients/metadata/client.go
@@ -158,7 +158,7 @@ func (c *clientImpl) ListHosts(request *m.ListHostsRequest) (*m.ListHostsResult_
 	return c.client.ListHosts(ctx, request)
 }
 
-func (c *clientImpl) ListAllConsumerGroups(request *m.ListConsumerGroupRequest) (*m.ListConsumerGroupResult_, error) {
+func (c *clientImpl) ListAllConsumerGroups(request *shared.ListConsumerGroupRequest) (*shared.ListConsumerGroupResult_, error) {
 	ctx, cancel := c.createContext()
 	defer cancel()
 
@@ -172,7 +172,7 @@ func (c *clientImpl) ListEntityOps(request *m.ListEntityOpsRequest) (*m.ListEnti
 	return c.client.ListEntityOps(ctx, request)
 }
 
-func (c *clientImpl) ListConsumerGroups(request *m.ListConsumerGroupRequest) (*m.ListConsumerGroupResult_, error) {
+func (c *clientImpl) ListConsumerGroups(request *shared.ListConsumerGroupRequest) (*shared.ListConsumerGroupResult_, error) {
 	ctx, cancel := c.createContext()
 	defer cancel()
 

--- a/clients/metadata/interface.go
+++ b/clients/metadata/interface.go
@@ -42,8 +42,8 @@ type (
 		ReadConsumerGroupByUUID(request *m.ReadConsumerGroupRequest) (*shared.ConsumerGroupDescription, error)
 		ReadConsumerGroup(request *m.ReadConsumerGroupRequest) (*shared.ConsumerGroupDescription, error)
 		ListHosts(request *m.ListHostsRequest) (*m.ListHostsResult_, error)
-		ListConsumerGroups(request *m.ListConsumerGroupRequest) (*m.ListConsumerGroupResult_, error)
-		ListAllConsumerGroups(request *m.ListConsumerGroupRequest) (*m.ListConsumerGroupResult_, error)
+		ListConsumerGroups(request *shared.ListConsumerGroupRequest) (*shared.ListConsumerGroupResult_, error)
+		ListAllConsumerGroups(request *shared.ListConsumerGroupRequest) (*shared.ListConsumerGroupResult_, error)
 		ReadServiceConfig(request *m.ReadServiceConfigRequest) (*m.ReadServiceConfigResult_, error)
 		UpdateServiceConfig(request *m.UpdateServiceConfigRequest) error
 		DeleteServiceConfig(request *m.DeleteServiceConfigRequest) error

--- a/clients/metadata/interface.go
+++ b/clients/metadata/interface.go
@@ -33,7 +33,7 @@ type (
 		ReadExtentStats(request *m.ReadExtentStatsRequest) (*m.ReadExtentStatsResult_, error)
 		ListExtentsStats(request *shared.ListExtentsStatsRequest) (*shared.ListExtentsStatsResult_, error)
 		ListStoreExtentsStats(request *m.ListStoreExtentsStatsRequest) (*m.ListStoreExtentsStatsResult_, error)
-		ReadDestination(request *m.ReadDestinationRequest) (*shared.DestinationDescription, error)
+		ReadDestination(request *shared.ReadDestinationRequest) (*shared.DestinationDescription, error)
 		ListDestinations(request *shared.ListDestinationsRequest) (*shared.ListDestinationsResult_, error)
 		ListDestinationsByUUID(request *shared.ListDestinationsByUUIDRequest) (*shared.ListDestinationsResult_, error)
 		ReadConsumerGroupExtents(request *m.ReadConsumerGroupExtentsRequest) (*m.ReadConsumerGroupExtentsResult_, error)

--- a/clients/metadata/metadata_cassandra.go
+++ b/clients/metadata/metadata_cassandra.go
@@ -43,7 +43,12 @@ const directoryUUID string = "CC3B477C-E6F2-4465-9A98-7FE71B68CD1F"
 
 var uuidRegex, _ = regexp.Compile(`^[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}$`)
 
-const defaultSessionTimeout = 10 * time.Second
+const (
+	defaultSessionTimeout = 10 * time.Second
+	defaultDLQConsumedRetention        = 7 * 24 * 3600 // One Week
+	defaultDLQUnconsumedRetention      = 7 * 24 * 3600 // One Week
+	defaultDLQOwnerEmail               = "default@uber"
+)
 
 const (
 	opsCreate = "create"
@@ -1181,19 +1186,73 @@ const (
 		` WHERE ` + columnDestinationUUID + `=? and ` + columnName + `=?`
 )
 
-// CreateConsumerGroup creates a ConsumerGroup for the given destination, if it doesn't already exist
+func (s *CassandraMetadataService) CreateConsumerGroup(ctx thrift.Context, request *shared.CreateConsumerGroupRequest) (*shared.ConsumerGroupDescription, error) {
+	uuidRequest := shared.NewCreateConsumerGroupUUIDRequest()
+	uuidRequest.Request = request
+	uuidRequest.ConsumerGroupUUID = common.StringPtr(uuid.New())
+	return s.CreateConsumerGroupUUID(ctx, uuidRequest)
+}
+
+// CreateConsumerGroupUUID creates a ConsumerGroup for the given destination, if it doesn't already exist
 // ConsumerGroups are tied to a destination path, so the same ConsumerGroupName can be used across
 // multiple destination paths. If the requested [destinationPath, consumerGroupName] already exists,
 // this method will return an EntityAlreadyExistsError.
-func (s *CassandraMetadataService) CreateConsumerGroup(ctx thrift.Context, request *shared.CreateConsumerGroupRequest) (*shared.ConsumerGroupDescription, error) {
+func (s *CassandraMetadataService) CreateConsumerGroupUUID(ctx thrift.Context, request *shared.CreateConsumerGroupUUIDRequest) (*shared.ConsumerGroupDescription, error) {
+	createRequest := request.GetRequest()
+	cgUUID := request.GetConsumerGroupUUID()
 
-	dstInfo, err := s.ReadDestination(nil, &m.ReadDestinationRequest{Path: common.StringPtr(request.GetDestinationPath())})
+	// Dead Letter Queue destination creation
+
+	// Only non-UUID (non-DLQ) destinations get a DLQ for the corresponding consumer groups
+	// We may create a consumer group consume a DLQ destination and no DLQ destination creation needed in this case
+	var dlqUUID *string
+	if common.PathRegex.MatchString(createRequest.GetDestinationPath()) {
+		dlqCreateRequest := shared.NewCreateDestinationRequest()
+		dlqCreateRequest.ConsumedMessagesRetention = common.Int32Ptr(defaultDLQConsumedRetention)
+		dlqCreateRequest.UnconsumedMessagesRetention = common.Int32Ptr(defaultDLQUnconsumedRetention)
+		dlqCreateRequest.OwnerEmail = common.StringPtr(defaultDLQOwnerEmail)
+		dlqCreateRequest.Type = common.InternalDestinationTypePtr(shared.DestinationType_PLAIN)
+		dlqCreateRequest.DLQConsumerGroupUUID = common.StringPtr(cgUUID)
+		dlqPath, _ := common.GetDLQPathNameFromCGName(createRequest.GetConsumerGroupName())
+		dlqCreateRequest.Path = common.StringPtr(dlqPath)
+
+		var dlqDestDesc *shared.DestinationDescription
+		dlqDestDesc, err := s.CreateDestination(nil, dlqCreateRequest)
+
+		if err != nil || dlqDestDesc == nil {
+			switch err.(type) {
+			case *shared.EntityAlreadyExistsError:
+				log.WithFields(log.Fields{common.TagCnsm: common.FmtCnsm(cgUUID)}).Info("DeadLetterQueue destination already existed")
+				mDLQReadRequest := m.ReadDestinationRequest{
+					Path: dlqCreateRequest.Path,
+				}
+
+				dlqDestDesc, err = s.ReadDestination(nil, &mDLQReadRequest)
+				if err != nil || dlqDestDesc == nil {
+					log.WithFields(log.Fields{common.TagCnsm: common.FmtCnsm(cgUUID), common.TagErr: err}).Error(`Can't read existing DeadLetterQueue destination`)
+					return nil, err
+				}
+
+				// We continue to consumer group creation if err == nil and dlqDestDesc != nil after the read
+			default:
+				log.WithFields(log.Fields{common.TagCnsm: common.FmtCnsm(cgUUID), common.TagErr: err}).Error(`Can't create DeadLetterQueue destination`)
+				return nil, err
+			}
+		}
+
+		dlqUUID = common.StringPtr(dlqDestDesc.GetDestinationUUID())
+	} else {
+		log.WithFields(log.Fields{common.TagCnsm: common.FmtCnsm(cgUUID)}).Info("DeadLetterQueue destination not being created")
+	}
+
+	dstInfo, err := s.ReadDestination(nil, &m.ReadDestinationRequest{Path: common.StringPtr(createRequest.GetDestinationPath())})
 	if err != nil {
 		return nil, err
 	}
+	dstUUID := dstInfo.GetDestinationUUID()
 
 	/*
-		   Every ConsumerGroup is assigned a UUID, which identifes the group uniquely. We need to
+		   Every ConsumerGroup is assigned a UUID, which identifies the group uniquely. We need to
 			 be able to retrieve a ConsumerGroup given either a UUID or a (destinationPath, groupName)
 			 tuple. To enable this, we maintain the ConsumerGroup information across two tables, one
 			 indexed by the UUID and the other indexed by the (destinationUUID, groupName) tuple. Creation
@@ -1207,70 +1266,48 @@ func (s *CassandraMetadataService) CreateConsumerGroup(ctx thrift.Context, reque
 			A batch query cannot be used here, because CassandraDB requires all the queries in a batch
 			to be from the same partition.
 	*/
-	cgUUID := uuid.New()
-	dstUUID := dstInfo.GetDestinationUUID()
-	var dlqUUID *string
-	if request.DeadLetterQueueDestinationUUID != nil {
-		var destDesc *shared.DestinationDescription
-		dlqUUID = common.StringPtr(request.GetDeadLetterQueueDestinationUUID())
-
-		// We need to create the consumer group with UUID matching the random UUID already populated in the DLQ destination
-
-		readDestReq := m.NewReadDestinationRequest()
-		readDestReq.DestinationUUID = common.StringPtr(request.GetDeadLetterQueueDestinationUUID())
-
-		destDesc, err = s.ReadDestination(ctx, readDestReq)
-		if err != nil || destDesc == nil || len(destDesc.GetDLQConsumerGroupUUID()) == 0 {
-			return nil, &shared.InternalServiceError{
-				Message: fmt.Sprintf("CreateConsumerGroup - lookup of DLQ destination failed dst=%v, cg=%v, dlqDst=%v err=%v",
-					request.GetDestinationPath(), request.GetConsumerGroupName(), request.GetDeadLetterQueueDestinationUUID(), err),
-			}
-		}
-
-		cgUUID = destDesc.GetDLQConsumerGroupUUID()
-	}
 
 	err = s.session.Query(sqlInsertCGByUUID,
 		cgUUID,
-		request.GetIsMultiZone(),
+		createRequest.GetIsMultiZone(),
 		cgUUID,
 		dstUUID,
-		request.GetConsumerGroupName(),
-		request.GetStartFrom(),
+		createRequest.GetConsumerGroupName(),
+		createRequest.GetStartFrom(),
 		shared.ConsumerGroupStatus_ENABLED,
-		request.GetLockTimeoutSeconds(),
-		request.GetMaxDeliveryCount(),
-		request.GetSkipOlderMessagesSeconds(),
+		createRequest.GetLockTimeoutSeconds(),
+		createRequest.GetMaxDeliveryCount(),
+		createRequest.GetSkipOlderMessagesSeconds(),
 		dlqUUID,
-		request.GetOwnerEmail(),
-		request.GetIsMultiZone(),
-		request.GetActiveZone(),
-		marshalCgZoneConfigs(request.GetZoneConfigs())).Exec()
+		createRequest.GetOwnerEmail(),
+		createRequest.GetIsMultiZone(),
+		createRequest.GetActiveZone(),
+		marshalCgZoneConfigs(createRequest.GetZoneConfigs())).Exec()
 
 	if err != nil {
 		return nil, &shared.InternalServiceError{
 			Message: fmt.Sprintf("CreateConsumerGroup - insert into consumer_groups table failed, dst=%v, cg=%v, err=%v",
-				request.GetDestinationPath(), request.GetConsumerGroupName(), err),
+				createRequest.GetDestinationPath(), createRequest.GetConsumerGroupName(), err),
 		}
 	}
 
 	query := s.session.Query(sqlInsertCGByName,
 		dstUUID,
-		request.GetConsumerGroupName(),
-		request.GetIsMultiZone(),
+		createRequest.GetConsumerGroupName(),
+		createRequest.GetIsMultiZone(),
 		cgUUID,
 		dstUUID,
-		request.GetConsumerGroupName(),
-		request.GetStartFrom(),
+		createRequest.GetConsumerGroupName(),
+		createRequest.GetStartFrom(),
 		shared.ConsumerGroupStatus_ENABLED,
-		request.GetLockTimeoutSeconds(),
-		request.GetMaxDeliveryCount(),
-		request.GetSkipOlderMessagesSeconds(),
+		createRequest.GetLockTimeoutSeconds(),
+		createRequest.GetMaxDeliveryCount(),
+		createRequest.GetSkipOlderMessagesSeconds(),
 		dlqUUID,
-		request.GetOwnerEmail(),
-		request.GetIsMultiZone(),
-		request.GetActiveZone(),
-		marshalCgZoneConfigs(request.GetZoneConfigs()))
+		createRequest.GetOwnerEmail(),
+		createRequest.GetIsMultiZone(),
+		createRequest.GetActiveZone(),
+		marshalCgZoneConfigs(createRequest.GetZoneConfigs()))
 
 	previous := make(map[string]interface{}) // We actually throw away the old values below, but passing nil causes a panic
 
@@ -1280,7 +1317,7 @@ func (s *CassandraMetadataService) CreateConsumerGroup(ctx thrift.Context, reque
 			log.WithFields(log.Fields{common.TagCnsm: common.FmtCnsm(cgUUID), common.TagErr: err}).Warn(`CreateConsumerGroup - failed to delete orphan record after a failed CAS attempt, ,`)
 		}
 		return nil, &shared.EntityAlreadyExistsError{
-			Message: fmt.Sprintf("CreateConsumerGroup - Group exists, dst=%v cg=%v err=%v", request.GetDestinationPath(), request.GetConsumerGroupName(), err),
+			Message: fmt.Sprintf("CreateConsumerGroup - Group exists, dst=%v cg=%v err=%v", createRequest.GetDestinationPath(), createRequest.GetConsumerGroupName(), err),
 		}
 	}
 
@@ -1289,7 +1326,7 @@ func (s *CassandraMetadataService) CreateConsumerGroup(ctx thrift.Context, reque
 	callerServiceName := getThriftContextValue(ctx, common.CallerServiceName)
 
 	s.recordUserOperation(
-		request.GetConsumerGroupName(),
+		createRequest.GetConsumerGroupName(),
 		cgUUID,
 		entityTypeCG,
 		callerUserName,
@@ -1298,22 +1335,22 @@ func (s *CassandraMetadataService) CreateConsumerGroup(ctx thrift.Context, reque
 		callerHostName,
 		opsCreate,
 		time.Now(),
-		marshalRequest(request))
+		marshalRequest(createRequest))
 
 	return &shared.ConsumerGroupDescription{
 		ConsumerGroupUUID:              common.StringPtr(cgUUID),
 		DestinationUUID:                common.StringPtr(dstUUID),
-		ConsumerGroupName:              common.StringPtr(request.GetConsumerGroupName()),
-		StartFrom:                      common.Int64Ptr(request.GetStartFrom()),
+		ConsumerGroupName:              common.StringPtr(createRequest.GetConsumerGroupName()),
+		StartFrom:                      common.Int64Ptr(createRequest.GetStartFrom()),
 		Status:                         common.InternalConsumerGroupStatusPtr(shared.ConsumerGroupStatus_ENABLED),
-		LockTimeoutSeconds:             common.Int32Ptr(request.GetLockTimeoutSeconds()),
-		MaxDeliveryCount:               common.Int32Ptr(request.GetMaxDeliveryCount()),
-		SkipOlderMessagesSeconds:       common.Int32Ptr(request.GetSkipOlderMessagesSeconds()),
-		DeadLetterQueueDestinationUUID: common.StringPtr(request.GetDeadLetterQueueDestinationUUID()),
-		OwnerEmail:                     common.StringPtr(request.GetOwnerEmail()),
-		IsMultiZone:                    common.BoolPtr(request.GetIsMultiZone()),
-		ActiveZone:                     common.StringPtr(request.GetActiveZone()),
-		ZoneConfigs:                    request.GetZoneConfigs(),
+		LockTimeoutSeconds:             common.Int32Ptr(createRequest.GetLockTimeoutSeconds()),
+		MaxDeliveryCount:               common.Int32Ptr(createRequest.GetMaxDeliveryCount()),
+		SkipOlderMessagesSeconds:       common.Int32Ptr(createRequest.GetSkipOlderMessagesSeconds()),
+		DeadLetterQueueDestinationUUID: dlqUUID,
+		OwnerEmail:                     common.StringPtr(createRequest.GetOwnerEmail()),
+		IsMultiZone:                    common.BoolPtr(createRequest.GetIsMultiZone()),
+		ActiveZone:                     common.StringPtr(createRequest.GetActiveZone()),
+		ZoneConfigs:                    createRequest.GetZoneConfigs(),
 	}, nil
 }
 
@@ -1349,7 +1386,7 @@ func (s *CassandraMetadataService) readConsumerGroupByDstUUID(dstUUID string, cg
 	return result, nil
 }
 
-// ReadConsumerGroup returns the ConsumerGroupDescription for the [destinatinPath, groupName].
+// ReadConsumerGroup returns the ConsumerGroupDescription for the [destinationPath, groupName].
 // When destination path is specified as input, this method only returns result, if the
 // destination has not been DELETED. When destination UUID is specified as input, this
 // method will always return result, if the consumer group exist.
@@ -1586,6 +1623,7 @@ func (s *CassandraMetadataService) DeleteConsumerGroup(ctx thrift.Context, reque
 	// DELETED. The following code adds the DLQ destination delete
 	// to the batch operation, if there is one.
 	dlqDstID := existingCG.GetDeadLetterQueueDestinationUUID()
+	log.Info(fmt.Sprintf("dlq dst id: %v", dlqDstID))
 	// Not all CGs have a DLQ, only do this if there is a DLQ
 	if len(dlqDstID) > 0 {
 		var dlqDstDesc *shared.DestinationDescription

--- a/clients/metadata/metadata_cassandra.go
+++ b/clients/metadata/metadata_cassandra.go
@@ -1705,7 +1705,7 @@ func (s *CassandraMetadataService) DeleteConsumerGroup(ctx thrift.Context, reque
 // If the ConsumerGroupName parameter is empty, this method will return all ConsumerGroups for the given
 // destination path/uuid. The returned value is an implementation of MetadataServiceListConsumerGroupsOutCall interface.
 // Callers must repeatedly invoke the Read() operation on the returned type until either an EOF or error is returned.
-func (s *CassandraMetadataService) ListConsumerGroups(ctx thrift.Context, request *m.ListConsumerGroupRequest) (*m.ListConsumerGroupResult_, error) {
+func (s *CassandraMetadataService) ListConsumerGroups(ctx thrift.Context, request *shared.ListConsumerGroupRequest) (*shared.ListConsumerGroupResult_, error) {
 
 	if request.DestinationPath == nil && request.DestinationUUID == nil {
 		return nil, &shared.BadRequestError{
@@ -1751,7 +1751,7 @@ func (s *CassandraMetadataService) ListConsumerGroups(ctx thrift.Context, reques
 		}
 	}
 
-	result := &m.ListConsumerGroupResult_{
+	result := &shared.ListConsumerGroupResult_{
 		ConsumerGroups: []*shared.ConsumerGroupDescription{},
 		NextPageToken:  request.PageToken,
 	}
@@ -1797,7 +1797,7 @@ func (s *CassandraMetadataService) ListConsumerGroups(ctx thrift.Context, reques
 }
 
 // ListAllConsumerGroups returns all ConsumerGroups in ConsumerGroups Table. This API is only used for debuging tool
-func (s *CassandraMetadataService) ListAllConsumerGroups(ctx thrift.Context, request *m.ListConsumerGroupRequest) (*m.ListConsumerGroupResult_, error) {
+func (s *CassandraMetadataService) ListAllConsumerGroups(ctx thrift.Context, request *shared.ListConsumerGroupRequest) (*shared.ListConsumerGroupResult_, error) {
 
 	if request.GetLimit() <= 0 {
 		return nil, &shared.BadRequestError{
@@ -1813,7 +1813,7 @@ func (s *CassandraMetadataService) ListAllConsumerGroups(ctx thrift.Context, req
 		}
 	}
 
-	result := &m.ListConsumerGroupResult_{
+	result := &shared.ListConsumerGroupResult_{
 		ConsumerGroups: []*shared.ConsumerGroupDescription{},
 		NextPageToken:  request.PageToken,
 	}

--- a/clients/metadata/metadata_cassandra.go
+++ b/clients/metadata/metadata_cassandra.go
@@ -44,10 +44,10 @@ const directoryUUID string = "CC3B477C-E6F2-4465-9A98-7FE71B68CD1F"
 var uuidRegex, _ = regexp.Compile(`^[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}$`)
 
 const (
-	defaultSessionTimeout = 10 * time.Second
-	defaultDLQConsumedRetention        = 7 * 24 * 3600 // One Week
-	defaultDLQUnconsumedRetention      = 7 * 24 * 3600 // One Week
-	defaultDLQOwnerEmail               = "default@uber"
+	defaultSessionTimeout         = 10 * time.Second
+	defaultDLQConsumedRetention   = 7 * 24 * 3600 // One Week
+	defaultDLQUnconsumedRetention = 7 * 24 * 3600 // One Week
+	defaultDLQOwnerEmail          = "default@uber"
 )
 
 const (

--- a/clients/metadata/metadata_cassandra_test.go
+++ b/clients/metadata/metadata_cassandra_test.go
@@ -1772,7 +1772,7 @@ func (s *CassandraSuite) TestListConsumerGroups() {
 
 	dstUUID := dstInfo.GetDestinationUUID()
 
-	listReq := &m.ListConsumerGroupRequest{
+	listReq := &shared.ListConsumerGroupRequest{
 		DestinationPath: common.StringPtr(dstPath),
 		Limit:           common.Int64Ptr(testPageSize),
 	}
@@ -1781,7 +1781,7 @@ func (s *CassandraSuite) TestListConsumerGroups() {
 	assert.Nil(err, "ListConsumerGroups failed")
 	assert.Equal(0, len(listRes.GetConsumerGroups()), "Result should be empty when there are no matching groups")
 
-	listRes, err = s.client.ListConsumerGroups(nil, &m.ListConsumerGroupRequest{
+	listRes, err = s.client.ListConsumerGroups(nil, &shared.ListConsumerGroupRequest{
 		DestinationUUID: common.StringPtr(dstUUID),
 		Limit:           common.Int64Ptr(testPageSize),
 	})
@@ -1823,12 +1823,12 @@ func (s *CassandraSuite) TestListConsumerGroups() {
 	assert.Equal(1, len(listRes.GetConsumerGroups()), "ListConsumerGroups failed to return correct number of result")
 	assert.Equal(testName, listRes.GetConsumerGroups()[0].GetConsumerGroupName(), "Wrong consumer group returned")
 
-	inputs := make([]*m.ListConsumerGroupRequest, 0, 2)
-	inputs = append(inputs, &m.ListConsumerGroupRequest{
+	inputs := make([]*shared.ListConsumerGroupRequest, 0, 2)
+	inputs = append(inputs, &shared.ListConsumerGroupRequest{
 		DestinationPath: common.StringPtr(dstPath),
 		Limit:           common.Int64Ptr(testPageSize),
 	})
-	inputs = append(inputs, &m.ListConsumerGroupRequest{
+	inputs = append(inputs, &shared.ListConsumerGroupRequest{
 		DestinationUUID: common.StringPtr(dstUUID),
 		Limit:           common.Int64Ptr(testPageSize),
 	})
@@ -1896,7 +1896,7 @@ func (s *CassandraSuite) TestListAllConsumerGroups() {
 		}
 	}
 
-	listReq := &m.ListConsumerGroupRequest{
+	listReq := &shared.ListConsumerGroupRequest{
 		Limit: common.Int64Ptr(testPageSize),
 	}
 

--- a/clients/metadata/metadata_cassandra_test.go
+++ b/clients/metadata/metadata_cassandra_test.go
@@ -1736,6 +1736,13 @@ func (s *CassandraSuite) TestConsumerGroupCRUD() {
 	dlqDest, err := s.client.ReadDestination(nil, dlqDestReq)
 	assert.Nil(err, "Read Dlq destination failed")
 	assert.Equal(dlqDest.GetDLQConsumerGroupUUID(), gotCG.GetConsumerGroupUUID())
+	assert.Equal(dlqDest.GetConsumedMessagesRetention(), int32(defaultDLQConsumedRetention))
+	assert.Equal(dlqDest.GetUnconsumedMessagesRetention(), int32(defaultDLQUnconsumedRetention))
+	assert.Equal(dlqDest.GetIsMultiZone(), false)
+	assert.Equal(dlqDest.GetOwnerEmail(), createReq.GetOwnerEmail())
+	dlqName, err := common.GetDLQPathNameFromCGName(createReq.GetConsumerGroupName())
+	assert.Nil(err, "GetDLQPathNameFromCGName failed")
+	assert.Equal(dlqDest.GetPath(), dlqName)
 
 	for pass := 0; pass < 3; pass++ {
 		readReq := &m.ReadConsumerGroupRequest{

--- a/clients/metadata/metadata_cassandra_test.go
+++ b/clients/metadata/metadata_cassandra_test.go
@@ -230,7 +230,7 @@ func (s *CassandraSuite) TestDestinationCRUD() {
 
 		// Read
 		// By UUID
-		getDestination := &m.ReadDestinationRequest{
+		getDestination := &shared.ReadDestinationRequest{
 			DestinationUUID: common.StringPtr(destination.GetDestinationUUID()),
 		}
 		loadedDestination, err := s.client.ReadDestination(nil, getDestination)
@@ -255,7 +255,7 @@ func (s *CassandraSuite) TestDestinationCRUD() {
 		s.Equal(destination.GetDLQMergeBefore(), loadedDestination.GetDLQMergeBefore())
 
 		// By Path
-		getDestination = &m.ReadDestinationRequest{
+		getDestination = &shared.ReadDestinationRequest{
 			Path: common.StringPtr(destination.GetPath()),
 		}
 		loadedDestination, err = s.client.ReadDestination(nil, getDestination)
@@ -296,7 +296,7 @@ func (s *CassandraSuite) TestDestinationCRUD() {
 		s.Equal(updateDestination.GetOwnerEmail(), updatedDestination.GetOwnerEmail())
 		s.Equal(updateDestination.GetChecksumOption(), updatedDestination.GetChecksumOption())
 
-		getDestination = &m.ReadDestinationRequest{
+		getDestination = &shared.ReadDestinationRequest{
 			DestinationUUID: common.StringPtr(destination.GetDestinationUUID()),
 		}
 		loadedDestination, err = s.client.ReadDestination(nil, getDestination)
@@ -342,7 +342,7 @@ func (s *CassandraSuite) TestDestinationCRUD() {
 				s.Equal(updateDestinationDLQCursors.GetDLQMergeBefore(), updatedDestination.GetDLQMergeBefore())
 			}
 
-			getDestination = &m.ReadDestinationRequest{
+			getDestination = &shared.ReadDestinationRequest{
 				DestinationUUID: common.StringPtr(destination.GetDestinationUUID()),
 			}
 			loadedDestination, err = s.client.ReadDestination(nil, getDestination)
@@ -387,14 +387,14 @@ func (s *CassandraSuite) TestDestinationCRUD() {
 		err := s.client.DeleteDestination(nil, deleteDestination)
 		s.Nil(err)
 		// Read by UUID might return deleted destination with DELETED status
-		getDestination := &m.ReadDestinationRequest{
+		getDestination := &shared.ReadDestinationRequest{
 			DestinationUUID: common.StringPtr(dest.GetDestinationUUID()),
 		}
 		deletedDestination, err := s.client.ReadDestination(nil, getDestination)
 		s.Nil(err)
 		s.True(deletedDestination.GetStatus() == shared.DestinationStatus_DELETING, fmt.Sprintf("%v", deletedDestination))
 		// Read by path shouldn't return deleted destination
-		getDestination = &m.ReadDestinationRequest{
+		getDestination = &shared.ReadDestinationRequest{
 			Path: common.StringPtr(dest.GetPath()),
 		}
 		deletedDestination, err = s.client.ReadDestination(nil, getDestination)
@@ -407,7 +407,7 @@ func (s *CassandraSuite) TestDestinationCRUD() {
 		s.Nil(err)
 
 		// Read by UUID might return deleted destination with DELETED status
-		getDestination = &m.ReadDestinationRequest{
+		getDestination = &shared.ReadDestinationRequest{
 			DestinationUUID: common.StringPtr(dest.GetDestinationUUID()),
 		}
 		deletedDestination, err = s.client.ReadDestination(nil, getDestination)
@@ -1508,7 +1508,7 @@ func (s *CassandraSuite) TestDeleteConsumerGroupDeletesDLQ() {
 	assert.Equal(shared.ConsumerGroupStatus_ENABLED, gotCG.GetStatus(), "Wrong CG status")
 
 	dlqUUID := gotCG.GetDeadLetterQueueDestinationUUID()
-	readDstReq := &m.ReadDestinationRequest{
+	readDstReq := &shared.ReadDestinationRequest{
 		Path: common.StringPtr(dlqUUID),
 	}
 	dlqDst, err := s.client.ReadDestination(nil, readDstReq)
@@ -1536,7 +1536,7 @@ func (s *CassandraSuite) TestDeleteConsumerGroupDeletesDLQ() {
 		dlqDst.GetStatus() == shared.DestinationStatus_DELETED,
 		`DLQ should be deleted`)
 
-	readDstReq = &m.ReadDestinationRequest{
+	readDstReq = &shared.ReadDestinationRequest{
 		DestinationUUID: common.StringPtr(dlqUUID),
 	}
 	dlqDst, err = s.client.ReadDestination(nil, readDstReq)

--- a/common/metadata/metaMetrics.go
+++ b/common/metadata/metaMetrics.go
@@ -301,7 +301,7 @@ func (m *metadataMetricsMgr) ReadConsumerGroupExtentsByExtUUID(ctx thrift.Contex
 	return result, err
 }
 
-func (m *metadataMetricsMgr) ReadDestination(ctx thrift.Context, request *m.ReadDestinationRequest) (result *shared.DestinationDescription, err error) {
+func (m *metadataMetricsMgr) ReadDestination(ctx thrift.Context, request *shared.ReadDestinationRequest) (result *shared.DestinationDescription, err error) {
 
 	m.m3.IncCounter(metrics.MetadataReadDestinationScope, metrics.MetadataRequests)
 	sw := m.m3.StartTimer(metrics.MetadataReadDestinationScope, metrics.MetadataLatency)
@@ -373,6 +373,21 @@ func (m *metadataMetricsMgr) CreateConsumerGroup(ctx thrift.Context, request *sh
 
 	if err != nil {
 		m.m3.IncCounter(metrics.MetadataCreateConsumerGroupScope, metrics.MetadataFailures)
+	}
+
+	return result, err
+}
+
+func (m *metadataMetricsMgr) CreateConsumerGroupUUID(ctx thrift.Context, request *shared.CreateConsumerGroupUUIDRequest) (result *shared.ConsumerGroupDescription, err error) {
+
+	m.m3.IncCounter(metrics.MetadataCreateConsumerGroupUUIDScope, metrics.MetadataRequests)
+	sw := m.m3.StartTimer(metrics.MetadataCreateConsumerGroupUUIDScope, metrics.MetadataLatency)
+	defer sw.Stop()
+
+	result, err = m.meta.CreateConsumerGroupUUID(ctx, request)
+
+	if err != nil {
+		m.m3.IncCounter(metrics.MetadataCreateConsumerGroupUUIDScope, metrics.MetadataFailures)
 	}
 
 	return result, err

--- a/common/metadata/metaMetrics.go
+++ b/common/metadata/metaMetrics.go
@@ -76,7 +76,7 @@ func (m *metadataMetricsMgr) HostAddrToUUID(ctx thrift.Context, request string) 
 	return result, err
 }
 
-func (m *metadataMetricsMgr) ListAllConsumerGroups(ctx thrift.Context, request *m.ListConsumerGroupRequest) (result *m.ListConsumerGroupResult_, err error) {
+func (m *metadataMetricsMgr) ListAllConsumerGroups(ctx thrift.Context, request *shared.ListConsumerGroupRequest) (result *shared.ListConsumerGroupResult_, err error) {
 
 	m.m3.IncCounter(metrics.MetadataListAllConsumerGroupsScope, metrics.MetadataRequests)
 	sw := m.m3.StartTimer(metrics.MetadataListAllConsumerGroupsScope, metrics.MetadataLatency)
@@ -91,7 +91,7 @@ func (m *metadataMetricsMgr) ListAllConsumerGroups(ctx thrift.Context, request *
 	return result, err
 }
 
-func (m *metadataMetricsMgr) ListConsumerGroups(ctx thrift.Context, request *m.ListConsumerGroupRequest) (result *m.ListConsumerGroupResult_, err error) {
+func (m *metadataMetricsMgr) ListConsumerGroups(ctx thrift.Context, request *shared.ListConsumerGroupRequest) (result *shared.ListConsumerGroupResult_, err error) {
 
 	m.m3.IncCounter(metrics.MetadataListConsumerGroupsScope, metrics.MetadataRequests)
 	sw := m.m3.StartTimer(metrics.MetadataListConsumerGroupsScope, metrics.MetadataLatency)

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -155,6 +155,8 @@ const (
 	MetadataUpdateServiceConfigScope
 	// MetadataCreateConsumerGroupScope defines scope for an operation on metadata
 	MetadataCreateConsumerGroupScope
+	// MetadataCreateConsumerGroupUUIDScope defines scope for an operation on metadata
+	MetadataCreateConsumerGroupUUIDScope
 	// MetadataCreateConsumerGroupExtentScope defines scope for an operation on metadata
 	MetadataCreateConsumerGroupExtentScope
 	// MetadataCreateDestinationScope defines scope for an operation on metadata
@@ -453,6 +455,7 @@ var scopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		MetadataUUIDToHostAddrScope:                    {operation: "MetadataUUIDToHostAddr"},
 		MetadataUpdateServiceConfigScope:               {operation: "MetadataUpdateServiceConfig"},
 		MetadataCreateConsumerGroupScope:               {operation: "MetadataCreateConsumerGroup"},
+		MetadataCreateConsumerGroupUUIDScope:           {operation: "MetadataCreateConsumerGroupUUID"},
 		MetadataCreateConsumerGroupExtentScope:         {operation: "MetadataCreateConsumerGroupExtent"},
 		MetadataCreateDestinationScope:                 {operation: "MetadataCreateDestination"},
 		MetadataCreateDestinationUUIDScope:             {operation: "MetadataCreateDestinationUUID"},
@@ -993,6 +996,12 @@ const (
 	ReplicatorReconcileDestFail
 	// ReplicatorReconcileDestFoundMissing indicates the reconcile for dest found a missing dest
 	ReplicatorReconcileDestFoundMissing
+	// ReplicatorReconcileCgRun indicates the reconcile for cg runs
+	ReplicatorReconcileCgRun
+	// ReplicatorReconcileCgFail indicates the reconcile for cg fails
+	ReplicatorReconcileCgFail
+	// ReplicatorReconcileCgFoundMissing indicates the reconcile for cg found a missing cg
+	ReplicatorReconcileCgFoundMissing
 	// ReplicatorReconcileDestExtentRun indicates the reconcile for dest extent runs
 	ReplicatorReconcileDestExtentRun
 	// ReplicatorReconcileDestExtentFail indicates the reconcile for dest extent fails
@@ -1166,6 +1175,9 @@ var metricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ReplicatorReconcileDestRun:                              {Gauge, "replicator.reconcile.dest.run"},
 		ReplicatorReconcileDestFail:                             {Gauge, "replicator.reconcile.dest.fail"},
 		ReplicatorReconcileDestFoundMissing:                     {Gauge, "replicator.reconcile.dest.foundmissing"},
+		ReplicatorReconcileCgRun:                              {Gauge, "replicator.reconcile.cg.run"},
+		ReplicatorReconcileCgFail:                             {Gauge, "replicator.reconcile.cg.fail"},
+		ReplicatorReconcileCgFoundMissing:                     {Gauge, "replicator.reconcile.cg.foundmissing"},
 		ReplicatorReconcileDestExtentRun:                        {Gauge, "replicator.reconcile.destextent.run"},
 		ReplicatorReconcileDestExtentFail:                       {Gauge, "replicator.reconcile.destextent.fail"},
 		ReplicatorReconcileDestExtentFoundMissing:               {Gauge, "replicator.reconcile.destextent.foundmissing"},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -406,6 +406,18 @@ const (
 	ReplicatorDeleteDestScope
 	// ReplicatorDeleteRmtDestScope represents replicator DeleteRemoteDestination API
 	ReplicatorDeleteRmtDestScope
+	// ReplicatorCreateCgUUIDScope represents replicator CreateConsumerGroupUUID API
+	ReplicatorCreateCgUUIDScope
+	// ReplicatorCreateRmtCgUUIDScope represents replicator CreateRemoteConsumerGroupUUID API
+	ReplicatorCreateRmtCgUUIDScope
+	// ReplicatorUpdateCgScope represents replicator UpdateConsumerGroup API
+	ReplicatorUpdateCgScope
+	// ReplicatorUpdateRmtCgScope represents replicator UpdateRemoteConsumerGroup API
+	ReplicatorUpdateRmtCgScope
+	// ReplicatorDeleteCgScope represents replicator DeleteConsumerGroup API
+	ReplicatorDeleteCgScope
+	// ReplicatorDeleteRmtCgScope represents replicator DeleteRemoteConsumerGroup API
+	ReplicatorDeleteRmtCgScope
 	// ReplicatorCreateExtentScope represents replicator CreateExtent API
 	ReplicatorCreateExtentScope
 	// ReplicatorCreateRmtExtentScope represents replicator CreateRemoteExtent API
@@ -539,6 +551,12 @@ var scopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		ReplicatorUpdateRmtDestScope:     {operation: "ReplicatorUpdateRemoteDestination"},
 		ReplicatorDeleteDestScope:        {operation: "ReplicatorDeleteDestination"},
 		ReplicatorDeleteRmtDestScope:     {operation: "ReplicatorDeleteRemoteDestination"},
+		ReplicatorCreateCgUUIDScope:    {operation: "ReplicatorCreateConsumerGroupUUID"},
+		ReplicatorCreateRmtCgUUIDScope: {operation: "ReplicatorCreateRemoteConsumerGroupUUID"},
+		ReplicatorUpdateCgScope:        {operation: "ReplicatorUpdateConsumerGroup"},
+		ReplicatorUpdateRmtCgScope:     {operation: "ReplicatorUpdateRemoteConsumerGroup"},
+		ReplicatorDeleteCgScope:        {operation: "ReplicatorDeleteConsumerGroup"},
+		ReplicatorDeleteRmtCgScope:     {operation: "ReplicatorDeleteRemoteConsumerGroup"},
 		ReplicatorCreateExtentScope:      {operation: "ReplicatorCreateExtent"},
 		ReplicatorCreateRmtExtentScope:   {operation: "ReplicatorCreateRemoteExtent"},
 		ReplicatorReconcileScope:         {operation: "ReplicatorReconcile"},

--- a/glide.lock
+++ b/glide.lock
@@ -113,7 +113,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: f8f813de692223b22b0a219f8586584018918ea4
+  version: 0337fc19d965cd5d9353531b1a9017f4f0d9c618
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/glide.lock
+++ b/glide.lock
@@ -113,7 +113,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: 09ed2ceaeab9e52820a81caece0dee9914c31f5d
+  version: f8f813de692223b22b0a219f8586584018918ea4
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/glide.lock
+++ b/glide.lock
@@ -113,7 +113,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: e7838ff66ed7987a12002a2dc2d043d89d5f8294
+  version: 959013313a26bbb974e23286ef4b9991fde4947b
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/glide.lock
+++ b/glide.lock
@@ -113,7 +113,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: 0337fc19d965cd5d9353531b1a9017f4f0d9c618
+  version: e7838ff66ed7987a12002a2dc2d043d89d5f8294
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/glide.yaml
+++ b/glide.yaml
@@ -34,6 +34,7 @@ import:
   - common/websocket
   - stream
 - package: github.com/uber/cherami-thrift
+  version: = multi_zone_cg
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/glide.yaml
+++ b/glide.yaml
@@ -34,7 +34,6 @@ import:
   - common/websocket
   - stream
 - package: github.com/uber/cherami-thrift
-  version: = multi_zone_cg
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/services/controllerhost/controllerhost.go
+++ b/services/controllerhost/controllerhost.go
@@ -898,7 +898,7 @@ func (mcp *Mcp) DeleteDestination(ctx thrift.Context, deleteRequest *shared.Dele
 	lclLg := context.log.WithField(common.TagDstPth, common.FmtDstPth(deleteRequest.GetPath()))
 
 	// first read the destination
-	readDestinationRequest := &m.ReadDestinationRequest{
+	readDestinationRequest := &shared.ReadDestinationRequest{
 		Path: common.StringPtr(deleteRequest.GetPath()),
 	}
 	destDesc, err := mcp.mClient.ReadDestination(ctx, readDestinationRequest)

--- a/services/controllerhost/controllerhost.go
+++ b/services/controllerhost/controllerhost.go
@@ -970,7 +970,7 @@ func (mcp *Mcp) CreateConsumerGroup(ctx thrift.Context, createRequest *shared.Cr
 		return nil, err
 	}
 
-	if createRequest.IsSetIsMultiZone() && createRequest.GetIsMultiZone() {
+	if createRequest.GetIsMultiZone() {
 		// get dest uuid from local consumer group, re-use for remote consumer group
 		cgUUID := cgDesc.GetConsumerGroupUUID()
 		createCGUUIDRequest := shared.NewCreateConsumerGroupUUIDRequest()
@@ -1029,21 +1029,29 @@ func (mcp *Mcp) UpdateConsumerGroup(ctx thrift.Context, updateRequest *shared.Up
 		return nil, err
 	}
 
-	//	updateRemoteCGs := func() {
-	//		// send to local replicator to fan out
-	//		localReplicator, err := mcp.GetClientFactory().GetReplicatorClient()
-	//		if err != nil {
-	//			lclLg.Error(err.Error())
-	//		}
+	if cgDesc.GetIsMultiZone() {
+		// send to local replicator to fan out
+		localReplicator, replicatorErr := mcp.GetClientFactory().GetReplicatorClient()
+		lclLg = lclLg.WithField(common.TagCnsm, common.FmtCnsm(cgDesc.GetConsumerGroupUUID()))
+		if replicatorErr != nil {
+			lclLg.Error(replicatorErr.Error())
+			context.m3Client.IncCounter(metrics.ControllerUpdateConsumerGroupScope, metrics.ControllerErrCallReplicatorCounter)
 
-	//		err = localReplicator.UpdateRemoteConsumerGroup(ctx, updateRequest)
-	//		if err != nil {
-	//			lclLg.Error(err.Error())
-	//		}
-	//	}
+			// errors in calling replicator doesn't fail this call
+			// a reconciliation process between replicators(slow path) will fix the inconsistency eventually
+			return cgDesc, nil
+		}
 
-	//	// best effort for fast path
-	//	go updateRemoteCGs()
+		_, replicatorErr = localReplicator.UpdateConsumerGroup(ctx, updateRequest)
+		if replicatorErr != nil {
+			lclLg.Error(replicatorErr.Error())
+			context.m3Client.IncCounter(metrics.ControllerUpdateConsumerGroupScope, metrics.ControllerErrCallReplicatorCounter)
+
+			// errors in calling replicator doesn't fail this call
+			// a reconciliation process between replicators(slow path) will fix the inconsistency eventually
+			return cgDesc, nil
+		}
+	}
 
 	return cgDesc, nil
 }
@@ -1066,29 +1074,49 @@ func (mcp *Mcp) DeleteConsumerGroup(ctx thrift.Context, deleteRequest *shared.De
 		common.TagCnsPth: common.FmtCnsPth(deleteRequest.GetConsumerGroupName()),
 	})
 
-	// delete local consumer group
-	err := mcp.mClient.DeleteConsumerGroup(ctx, deleteRequest)
+	readCGReq := &m.ReadConsumerGroupRequest{
+		DestinationPath:   deleteRequest.DestinationPath,
+		DestinationUUID:   deleteRequest.DestinationUUID,
+		ConsumerGroupName: deleteRequest.ConsumerGroupName,
+	}
+	cgDesc, err := mcp.mClient.ReadConsumerGroup(nil, readCGReq)
 	if err != nil {
 		lclLg.Error(err.Error())
 		context.m3Client.IncCounter(metrics.ControllerDeleteConsumerGroupScope, metrics.ControllerFailures)
 		return err
 	}
 
-	//	deleteRemoteCGs := func() {
-	//		// send to local replicator to fan out
-	//		localReplicator, err := mcp.GetClientFactory().GetReplicatorClient()
-	//		if err != nil {
-	//			lclLg.Error(err.Error())
-	//		}
+	// delete local consumer group
+	err = mcp.mClient.DeleteConsumerGroup(ctx, deleteRequest)
+	if err != nil {
+		lclLg.Error(err.Error())
+		context.m3Client.IncCounter(metrics.ControllerDeleteConsumerGroupScope, metrics.ControllerFailures)
+		return err
+	}
 
-	//		err = localReplicator.DeleteRemoteConsumerGroup(ctx, deleteRequest)
-	//		if err != nil {
-	//			lclLg.Error(err.Error())
-	//		}
-	//	}
+	if cgDesc.GetIsMultiZone() {
+		// send to local replicator to fan out
+		localReplicator, replicatorErr := mcp.GetClientFactory().GetReplicatorClient()
+		lclLg = lclLg.WithField(common.TagCnsm, common.FmtCnsm(cgDesc.GetConsumerGroupUUID()))
+		if replicatorErr != nil {
+			lclLg.Error(replicatorErr.Error())
+			context.m3Client.IncCounter(metrics.ControllerDeleteConsumerGroupScope, metrics.ControllerErrCallReplicatorCounter)
 
-	//	// best effort for fast path
-	//	go deleteRemoteCGs()
+			// errors in calling replicator doesn't fail this call
+			// a reconciliation process between replicators(slow path) will fix the inconsistency eventually
+			return nil
+		}
+
+		replicatorErr = localReplicator.DeleteConsumerGroup(ctx, deleteRequest)
+		if replicatorErr != nil {
+			lclLg.Error(replicatorErr.Error())
+			context.m3Client.IncCounter(metrics.ControllerDeleteConsumerGroupScope, metrics.ControllerErrCallReplicatorCounter)
+
+			// errors in calling replicator doesn't fail this call
+			// a reconciliation process between replicators(slow path) will fix the inconsistency eventually
+			return nil
+		}
+	}
 
 	return nil
 }

--- a/services/controllerhost/controllerhost_test.go
+++ b/services/controllerhost/controllerhost_test.go
@@ -660,7 +660,7 @@ func (s *McpSuite) TestMultiZoneDestCUD() {
 	s.True(destDesc.GetIsMultiZone())
 
 	// verify local operation
-	destDesc, err = s.mClient.ReadDestination(nil, &m.ReadDestinationRequest{Path: common.StringPtr(destPath)})
+	destDesc, err = s.mClient.ReadDestination(nil, &shared.ReadDestinationRequest{Path: common.StringPtr(destPath)})
 	s.NoError(err)
 	s.NotNil(destDesc)
 	s.Equal(destUUID, destDesc.GetDestinationUUID())
@@ -691,7 +691,7 @@ func (s *McpSuite) TestMultiZoneDestCUD() {
 	s.True(destDesc.GetIsMultiZone())
 
 	// verify local operation
-	destDesc, err = s.mClient.ReadDestination(nil, &m.ReadDestinationRequest{Path: common.StringPtr(destPath)})
+	destDesc, err = s.mClient.ReadDestination(nil, &shared.ReadDestinationRequest{Path: common.StringPtr(destPath)})
 	s.NoError(err)
 	s.NotNil(destDesc)
 	s.Equal(destUUID, destDesc.GetDestinationUUID())
@@ -715,7 +715,7 @@ func (s *McpSuite) TestMultiZoneDestCUD() {
 	s.NoError(err)
 
 	// verify local operation
-	destDesc, err = s.mClient.ReadDestination(nil, &m.ReadDestinationRequest{Path: common.StringPtr(destPath)})
+	destDesc, err = s.mClient.ReadDestination(nil, &shared.ReadDestinationRequest{Path: common.StringPtr(destPath)})
 	s.Error(err)
 	s.Nil(destDesc)
 	assert.IsType(s.T(), &shared.EntityNotExistsError{}, err)

--- a/services/controllerhost/controllerhost_test.go
+++ b/services/controllerhost/controllerhost_test.go
@@ -219,17 +219,13 @@ func (s *McpSuite) listInputHostExtents(dstUUID string, inputHostUUID string) (*
 }
 
 func (s *McpSuite) createConsumerGroup(dstPath, cgName string) (*shared.ConsumerGroupDescription, error) {
-	return s.createConsumerGroupWithDLQ(dstPath, cgName, ``)
+	return s.createConsumerGroupWithDLQ(dstPath, cgName)
 }
 
-func (s *McpSuite) createConsumerGroupWithDLQ(dstPath, cgName, dlqUUID string) (*shared.ConsumerGroupDescription, error) {
+func (s *McpSuite) createConsumerGroupWithDLQ(dstPath, cgName string) (*shared.ConsumerGroupDescription, error) {
 	mReq := &shared.CreateConsumerGroupRequest{
 		DestinationPath:   common.StringPtr(dstPath),
 		ConsumerGroupName: common.StringPtr(cgName),
-	}
-
-	if len(dlqUUID) != 0 {
-		mReq.DeadLetterQueueDestinationUUID = common.StringPtr(dlqUUID)
 	}
 
 	return s.mClient.CreateConsumerGroup(nil, mReq)

--- a/services/controllerhost/extentmon_test.go
+++ b/services/controllerhost/extentmon_test.go
@@ -295,7 +295,7 @@ func (s *ExtentStateMonitorSuite) TestExtentMonitor() {
 
 		for i := 0; i < len(destinations); i++ {
 
-			desc, err := s.mcp.mClient.ReadDestination(nil, &m.ReadDestinationRequest{DestinationUUID: common.StringPtr(destinations[i].GetDestinationUUID())})
+			desc, err := s.mcp.mClient.ReadDestination(nil, &shared.ReadDestinationRequest{DestinationUUID: common.StringPtr(destinations[i].GetDestinationUUID())})
 			s.Nil(err, "Failed to read destination")
 			stats, err := s.mcp.context.mm.ListExtentsByDstIDStatus(desc.GetDestinationUUID(), nil)
 			s.Nil(err, "Failed to list extents")

--- a/services/controllerhost/extentmon_test.go
+++ b/services/controllerhost/extentmon_test.go
@@ -328,7 +328,7 @@ func (s *ExtentStateMonitorSuite) TestExtentMonitor() {
 			}
 
 			if desc.GetStatus() == shared.DestinationStatus_DELETING {
-				cg, e := s.mcp.mClient.ListConsumerGroups(nil, &m.ListConsumerGroupRequest{
+				cg, e := s.mcp.mClient.ListConsumerGroups(nil, &shared.ListConsumerGroupRequest{
 					DestinationUUID:   common.StringPtr(desc.GetDestinationUUID()),
 					ConsumerGroupName: common.StringPtr(desc.GetPath() + "/consumer"),
 				})

--- a/services/controllerhost/metadataMgr.go
+++ b/services/controllerhost/metadataMgr.go
@@ -86,7 +86,7 @@ type (
 		// ListConsumerGroupsByDstID lists all consumer groups for a given destination uuid
 		ListConsumerGroupsByDstID(dstID string) ([]*shared.ConsumerGroupDescription, error)
 		// ListConsumerGroupsPage lists all consumer groups for a given destination uuid
-		ListConsumerGroupsPage(mReq *m.ListConsumerGroupRequest) (*m.ListConsumerGroupResult_, error)
+		ListConsumerGroupsPage(mReq *shared.ListConsumerGroupRequest) (*shared.ListConsumerGroupResult_, error)
 		// UpdateOutHost changes the out host for the consumer group extent
 		UpdateOutHost(dstID string, cgID string, extentID string, outHostID string) error
 		// DeleteConsumerGroup deletes the consumer group status
@@ -514,7 +514,7 @@ func (mm *metadataMgrImpl) AddExtentToConsumerGroup(dstID string, cgID string, e
 
 func (mm *metadataMgrImpl) ListConsumerGroupsByDstID(dstID string) ([]*shared.ConsumerGroupDescription, error) {
 
-	mReq := &m.ListConsumerGroupRequest{
+	mReq := &shared.ListConsumerGroupRequest{
 		DestinationUUID: common.StringPtr(dstID),
 		Limit:           common.Int64Ptr(defaultPageSize),
 	}
@@ -539,7 +539,7 @@ func (mm *metadataMgrImpl) ListConsumerGroupsByDstID(dstID string) ([]*shared.Co
 	return result, nil
 }
 
-func (mm *metadataMgrImpl) ListConsumerGroupsPage(mReq *m.ListConsumerGroupRequest) (*m.ListConsumerGroupResult_, error) {
+func (mm *metadataMgrImpl) ListConsumerGroupsPage(mReq *shared.ListConsumerGroupRequest) (*shared.ListConsumerGroupResult_, error) {
 	return mm.mClient.ListConsumerGroups(nil, mReq)
 }
 

--- a/services/controllerhost/metadataMgr.go
+++ b/services/controllerhost/metadataMgr.go
@@ -158,7 +158,7 @@ func (mm *metadataMgrImpl) ListDestinationsPage(mReq *shared.ListDestinationsReq
 
 func (mm *metadataMgrImpl) ReadDestination(dstID string, dstPath string) (*shared.DestinationDescription, error) {
 
-	mReq := &m.ReadDestinationRequest{}
+	mReq := &shared.ReadDestinationRequest{}
 
 	if len(dstID) > 0 {
 		mReq.DestinationUUID = common.StringPtr(dstID)

--- a/services/frontendhost/frontend.go
+++ b/services/frontendhost/frontend.go
@@ -1106,13 +1106,13 @@ func (h *Frontend) ListConsumerGroups(ctx thrift.Context, listRequest *c.ListCon
 		common.TagCnsPth: common.FmtCnsPth(listRequest.GetConsumerGroupName()),
 	})
 
-	mListRequest := m.NewListConsumerGroupRequest()
+	mListRequest := shared.NewListConsumerGroupRequest()
 	mListRequest.ConsumerGroupName = common.StringPtr(listRequest.GetConsumerGroupName())
 	mListRequest.DestinationPath = common.StringPtr(listRequest.GetDestinationPath())
 	mListRequest.PageToken = listRequest.PageToken
 	mListRequest.Limit = common.Int64Ptr(listRequest.GetLimit())
 
-	var listResult *m.ListConsumerGroupResult_
+	var listResult *shared.ListConsumerGroupResult_
 	listResult, err = h.metaClnt.ListConsumerGroups(ctx, mListRequest)
 
 	if err != nil {

--- a/services/frontendhost/frontend.go
+++ b/services/frontendhost/frontend.go
@@ -399,7 +399,7 @@ func (h *Frontend) convertConsumerGroupFromInternal(ctx thrift.Context, _cgDesc 
 
 	if len(destPath) == 0 {
 		var destDesc *shared.DestinationDescription
-		readRequest := m.NewReadDestinationRequest()
+		readRequest := shared.NewReadDestinationRequest()
 		readRequest.DestinationUUID = common.StringPtr(_cgDesc.GetDestinationUUID())
 		destDesc, err = h.metaClnt.ReadDestination(ctx, readRequest) // TODO: -= Maybe a GetDestinationPathForUUID =-
 
@@ -451,7 +451,7 @@ const (
 // that any destination that is returned by the metadata server will be returned to the client
 // TODO: Add a cache here with time-based retention
 func (h *Frontend) getUUIDForDestination(ctx thrift.Context, path string, rejectDisabled bool) (UUID string, err error) {
-	mGetRequest := m.ReadDestinationRequest{Path: common.StringPtr(path)}
+	mGetRequest := shared.ReadDestinationRequest{Path: common.StringPtr(path)}
 	destDesc, err := h.metaClnt.ReadDestination(ctx, &mGetRequest)
 
 	if err != nil {
@@ -633,7 +633,7 @@ func (h *Frontend) ReadDestination(ctx thrift.Context, readRequest *c.ReadDestin
 	if _, err = h.prolog(ctx, readRequest); err != nil {
 		return
 	}
-	var mReadRequest m.ReadDestinationRequest
+	var mReadRequest shared.ReadDestinationRequest
 
 	if common.UUIDRegex.MatchString(readRequest.GetPath()) {
 		mReadRequest.DestinationUUID = common.StringPtr(readRequest.GetPath())
@@ -696,7 +696,7 @@ func (h *Frontend) ReadPublisherOptions(ctx thrift.Context, r *c.ReadPublisherOp
 		}
 	}
 
-	readDestRequest := m.ReadDestinationRequest{Path: common.StringPtr(r.GetPath())}
+	readDestRequest := shared.ReadDestinationRequest{Path: common.StringPtr(r.GetPath())}
 	var destDesc *shared.DestinationDescription
 	destDesc, err = h.metaClnt.ReadDestination(ctx, &readDestRequest)
 	if err != nil {
@@ -1231,7 +1231,7 @@ func (h *Frontend) dlqOperationForConsumerGroup(ctx thrift.Context, destinationP
 	}
 
 	// Read the destination to see if we should allow this request
-	mReadDestRequest := m.NewReadDestinationRequest()
+	mReadDestRequest := shared.NewReadDestinationRequest()
 	mReadDestRequest.DestinationUUID = mCGDesc.DeadLetterQueueDestinationUUID
 	destDesc, err = h.metaClnt.ReadDestination(ctx, mReadDestRequest)
 

--- a/services/frontendhost/frontend_test.go
+++ b/services/frontendhost/frontend_test.go
@@ -37,7 +37,6 @@ import (
 	mockmeta "github.com/uber/cherami-server/test/mocks/metadata"
 	c "github.com/uber/cherami-thrift/.generated/go/cherami"
 	"github.com/uber/cherami-thrift/.generated/go/controller"
-	"github.com/uber/cherami-thrift/.generated/go/metadata"
 	"github.com/uber/cherami-thrift/.generated/go/shared"
 
 	log "github.com/Sirupsen/logrus"
@@ -1233,7 +1232,7 @@ func (s *FrontendHostSuite) TestFrontendHostListConsumerGroupsRejectBadPath() {
 // TestFrontendHostListConsumerGroupsNoExistPath tests that a non-extant consumer group path succeeds with no results
 func (s *FrontendHostSuite) TestFrontendHostListConsumerGroupsNoExistPath() {
 	frontendHost, ctx := s.utilGetContextAndFrontend()
-	s.mockMeta.On("ListConsumerGroups", mock.Anything, mock.Anything).Return(metadata.NewListConsumerGroupResult_(), nil)
+	s.mockMeta.On("ListConsumerGroups", mock.Anything, mock.Anything).Return(shared.NewListConsumerGroupResult_(), nil)
 
 	req := c.NewListConsumerGroupRequest()
 	req.DestinationPath = common.StringPtr(s.generateKey("/foo/bad"))
@@ -1255,7 +1254,7 @@ func (s *FrontendHostSuite) TestFrontendHostListConsumerGroups() {
 
 	// An accounting map to keep track of which consumer groups have been added/seen
 	groups := make(map[string]bool)
-	listResult := &metadata.ListConsumerGroupResult_{ConsumerGroups: make([]*shared.ConsumerGroupDescription, 0, 9)}
+	listResult := &shared.ListConsumerGroupResult_{ConsumerGroups: make([]*shared.ConsumerGroupDescription, 0, 9)}
 	for i := 0; i < 3; i++ {
 		for j := 0; j < 3; j++ {
 			reqCG := c.NewCreateConsumerGroupRequest()

--- a/services/inputhost/inputhost.go
+++ b/services/inputhost/inputhost.go
@@ -244,7 +244,7 @@ func (h *InputHost) getExtentsAndLoadPathCache(ctx thrift.Context, destPath, des
 // checkDestination reads destination from metadata store and make sure it's writable
 func (h *InputHost) checkDestination(ctx thrift.Context, path string) (string, shared.DestinationType, metrics.ErrorClass, error) {
 	// talk to metadata
-	mGetRequest := metadata.ReadDestinationRequest{Path: common.StringPtr(path)}
+	mGetRequest := shared.ReadDestinationRequest{Path: common.StringPtr(path)}
 	destDesc, err := h.mClient.ReadDestination(ctx, &mGetRequest)
 	if err != nil {
 		errC, newErr := common.ConvertDownstreamErrors(h.logger, err)

--- a/services/outputhost/cgcache.go
+++ b/services/outputhost/cgcache.go
@@ -484,7 +484,7 @@ func (cgCache *consumerGroupCache) refreshCgCache(ctx thrift.Context) error {
 	// If one of them is being deleted, then just unload all extents and
 	// move on. If not, check for new extents for this consumer group
 
-	dstReq := &metadata.ReadDestinationRequest{DestinationUUID: common.StringPtr(cgCache.cachedCGDesc.GetDestinationUUID())}
+	dstReq := &shared.ReadDestinationRequest{DestinationUUID: common.StringPtr(cgCache.cachedCGDesc.GetDestinationUUID())}
 	dstDesc, errRD := cgCache.metaClient.ReadDestination(ctx, dstReq)
 	if errRD != nil || dstDesc == nil {
 		cgCache.logger.WithField(common.TagErr, errRD).Error(`ReadDestination failed on refresh`)

--- a/services/replicator/metadataReconciler.go
+++ b/services/replicator/metadataReconciler.go
@@ -342,7 +342,7 @@ func (r *metadataReconciler) reconcileCg(localCgs []*shared.ConsumerGroupDescrip
 			if err != nil {
 				lclLg.WithFields(bark.Fields{
 					common.TagErr: err,
-				}).Error(`Failed to create ConsumerGroup in local zone because read destination failed`)
+				}).Error(`Failed to create ConsumerGroup in local zone because read destination failed in remote zone`)
 				continue
 			}
 

--- a/services/replicator/replicator.go
+++ b/services/replicator/replicator.go
@@ -289,7 +289,7 @@ func (r *Replicator) OpenReplicationRemoteReadStreamHandler(w http.ResponseWrite
 	return
 }
 
-// CreateDestinationUUID creates destination at local zone, expect to be called by remote replicator
+// CreateDestinationUUID creates destination at local zone, expect to be called by replicator from authoritative zone
 func (r *Replicator) CreateDestinationUUID(ctx thrift.Context, createRequest *shared.CreateDestinationUUIDRequest) (*shared.DestinationDescription, error) {
 	r.m3Client.IncCounter(metrics.ReplicatorCreateDestUUIDScope, metrics.ReplicatorRequests)
 
@@ -319,7 +319,7 @@ func (r *Replicator) CreateDestinationUUID(ctx thrift.Context, createRequest *sh
 	return destDesc, nil
 }
 
-// CreateRemoteDestinationUUID propagates creation to multiple remote zones, expect to be called by local zone services
+// CreateRemoteDestinationUUID propagates creation to multiple remote zones, expect to be called only in authoritative zone
 func (r *Replicator) CreateRemoteDestinationUUID(ctx thrift.Context, createRequest *shared.CreateDestinationUUIDRequest) error {
 	r.m3Client.IncCounter(metrics.ReplicatorCreateRmtDestUUIDScope, metrics.ReplicatorRequests)
 
@@ -392,7 +392,7 @@ func (r *Replicator) createDestinationRemoteCall(zone string, logger bark.Logger
 	return nil
 }
 
-// UpdateDestination updates destination at local zone, expect to be called by remote replicator
+// UpdateDestination updates destination at local zone, expect to be called by replicator from authoritative zone
 func (r *Replicator) UpdateDestination(ctx thrift.Context, updateRequest *shared.UpdateDestinationRequest) (*shared.DestinationDescription, error) {
 	r.m3Client.IncCounter(metrics.ReplicatorUpdateDestScope, metrics.ReplicatorRequests)
 
@@ -419,7 +419,7 @@ func (r *Replicator) UpdateDestination(ctx thrift.Context, updateRequest *shared
 	return destDesc, nil
 }
 
-// UpdateRemoteDestination propagates update to multiple remote zones, expect to be called by local zone services
+// UpdateRemoteDestination propagates update to multiple remote zones, expect to be called only in authoritative zone
 func (r *Replicator) UpdateRemoteDestination(ctx thrift.Context, updateRequest *shared.UpdateDestinationRequest) error {
 	r.m3Client.IncCounter(metrics.ReplicatorUpdateRmtDestScope, metrics.ReplicatorRequests)
 
@@ -484,7 +484,7 @@ func (r *Replicator) updateDestinationRemoteCall(zone string, logger bark.Logger
 	return nil
 }
 
-// DeleteDestination deletes destination at local zone, expect to be called by remote replicator
+// DeleteDestination deletes destination at local zone, expect to be called by replicator from authoritative zone
 func (r *Replicator) DeleteDestination(ctx thrift.Context, deleteRequest *shared.DeleteDestinationRequest) error {
 	r.m3Client.IncCounter(metrics.ReplicatorDeleteDestScope, metrics.ReplicatorRequests)
 
@@ -501,7 +501,7 @@ func (r *Replicator) DeleteDestination(ctx thrift.Context, deleteRequest *shared
 	return nil
 }
 
-// DeleteRemoteDestination propagate deletion to multiple remote zones, expect to be called by local zone services
+// DeleteRemoteDestination propagate deletion to multiple remote zones, expect to be called only in authoritative zone
 func (r *Replicator) DeleteRemoteDestination(ctx thrift.Context, deleteRequest *shared.DeleteDestinationRequest) error {
 	r.m3Client.IncCounter(metrics.ReplicatorDeleteRmtDestScope, metrics.ReplicatorRequests)
 
@@ -566,7 +566,7 @@ func (r *Replicator) deleteDestinationRemoteCall(zone string, logger bark.Logger
 	return nil
 }
 
-// CreateConsumerGroupUUID creates consumer group at local zone, expect to be called by remote replicator
+// CreateConsumerGroupUUID creates consumer group at local zone, expect to be called by replicator from authoritative zone
 func (r *Replicator) CreateConsumerGroupUUID(ctx thrift.Context, createRequest *shared.CreateConsumerGroupUUIDRequest) (*shared.ConsumerGroupDescription, error) {
 	r.m3Client.IncCounter(metrics.ReplicatorCreateCgUUIDScope, metrics.ReplicatorRequests)
 
@@ -594,7 +594,7 @@ func (r *Replicator) CreateConsumerGroupUUID(ctx thrift.Context, createRequest *
 	return cgDesc, nil
 }
 
-// CreateRemoteConsumerGroupUUID propagate creation to multiple remote zones, expect to be called by local zone services
+// CreateRemoteConsumerGroupUUID propagate creation to multiple remote zones, expect to be called only in authoritative zone
 func (r *Replicator) CreateRemoteConsumerGroupUUID(ctx thrift.Context, createRequest *shared.CreateConsumerGroupUUIDRequest) error {
 	r.m3Client.IncCounter(metrics.ReplicatorCreateRmtCgUUIDScope, metrics.ReplicatorRequests)
 
@@ -668,7 +668,7 @@ func (r *Replicator) createConsumerGroupRemoteCall(zone string, logger bark.Logg
 	return nil
 }
 
-// UpdateConsumerGroup updates consumer group at local zone, expect to be called by remote replicator
+// UpdateConsumerGroup updates consumer group at local zone, expect to be called by replicator from authoritative zone
 func (r *Replicator) UpdateConsumerGroup(ctx thrift.Context, updateRequest *shared.UpdateConsumerGroupRequest) (*shared.ConsumerGroupDescription, error) {
 	r.m3Client.IncCounter(metrics.ReplicatorUpdateCgScope, metrics.ReplicatorRequests)
 
@@ -695,7 +695,7 @@ func (r *Replicator) UpdateConsumerGroup(ctx thrift.Context, updateRequest *shar
 	return cgDesc, nil
 }
 
-// UpdateRemoteConsumerGroup propagate update to multiple remote zones, expect to be called by local zone services
+// UpdateRemoteConsumerGroup propagate update to multiple remote zones, expect to be called only in authoritative zone
 func (r *Replicator) UpdateRemoteConsumerGroup(ctx thrift.Context, updateRequest *shared.UpdateConsumerGroupRequest) error {
 	r.m3Client.IncCounter(metrics.ReplicatorUpdateRmtCgScope, metrics.ReplicatorRequests)
 
@@ -761,7 +761,7 @@ func (r *Replicator) updateCgRemoteCall(zone string, logger bark.Logger, updateR
 	return nil
 }
 
-// DeleteConsumerGroup deletes consumer group at local zone, expect to be called by remote replicator
+// DeleteConsumerGroup deletes consumer group at local zone, expect to be called by replicator from authoritative zone
 func (r *Replicator) DeleteConsumerGroup(ctx thrift.Context, deleteRequest *shared.DeleteConsumerGroupRequest) error {
 	r.m3Client.IncCounter(metrics.ReplicatorDeleteCgScope, metrics.ReplicatorRequests)
 
@@ -779,7 +779,7 @@ func (r *Replicator) DeleteConsumerGroup(ctx thrift.Context, deleteRequest *shar
 	return nil
 }
 
-// DeleteRemoteConsumerGroup propagate deletion to multiple remote zones, expect to be called by local zone services
+// DeleteRemoteConsumerGroup propagate deletion to multiple remote zones, expect to be called only in authoritative zone
 func (r *Replicator) DeleteRemoteConsumerGroup(ctx thrift.Context, deleteRequest *shared.DeleteConsumerGroupRequest) error {
 	r.m3Client.IncCounter(metrics.ReplicatorDeleteRmtCgScope, metrics.ReplicatorRequests)
 

--- a/services/replicator/replicator.go
+++ b/services/replicator/replicator.go
@@ -568,6 +568,32 @@ func (r *Replicator) deleteDestinationRemoteCall(zone string, logger bark.Logger
 
 // CreateConsumerGroupUUID creates consumer group at local zone, expect to be called by remote replicator
 func (r *Replicator) CreateConsumerGroupUUID(ctx thrift.Context, createRequest *shared.CreateConsumerGroupUUIDRequest) (*shared.ConsumerGroupDescription, error) {
+	r.m3Client.IncCounter(metrics.ReplicatorCreateCgUUIDScope, metrics.ReplicatorRequests)
+
+	//destDesc, err := r.metaClient.CreateDestinationUUID(ctx, createRequest)
+	//if err != nil {
+	//	r.logger.WithFields(bark.Fields{
+	//		common.TagDst:    common.FmtDst(createRequest.GetDestinationUUID()),
+	//		common.TagDstPth: common.FmtDstPth(createRequest.GetRequest().GetPath()),
+	//		common.TagErr:    err,
+	//	}).Error(`Error creating destination`)
+	//	r.m3Client.IncCounter(metrics.ReplicatorCreateDestUUIDScope, metrics.ReplicatorFailures)
+	//	return nil, err
+	//}
+	//
+	//r.logger.WithFields(bark.Fields{
+	//	common.TagDst:                 common.FmtDst(destDesc.GetDestinationUUID()),
+	//	common.TagDstPth:              common.FmtDstPth(destDesc.GetPath()),
+	//	`Type`:                        destDesc.GetType(),
+	//	`Status`:                      destDesc.GetStatus(),
+	//	`ConsumedMessagesRetention`:   destDesc.GetConsumedMessagesRetention(),
+	//	`UnconsumedMessagesRetention`: destDesc.GetUnconsumedMessagesRetention(),
+	//	`OwnerEmail`:                  destDesc.GetOwnerEmail(),
+	//	`ChecksumOption`:              destDesc.GetChecksumOption(),
+	//	`IsMultiZone`:                 destDesc.GetIsMultiZone(), // expected to be true
+	//}).Info(`Created Destination`)
+
+	//return destDesc, nil
 	return nil, nil
 }
 

--- a/services/replicator/replicator.go
+++ b/services/replicator/replicator.go
@@ -677,6 +677,7 @@ func (r *Replicator) UpdateConsumerGroup(ctx thrift.Context, updateRequest *shar
 		r.logger.WithFields(bark.Fields{
 			common.TagCnsPth: common.FmtCnsPth(updateRequest.GetConsumerGroupName()),
 			common.TagDstPth: common.FmtDstPth(updateRequest.GetDestinationPath()),
+			common.TagDst:    common.FmtDst(cgDesc.GetDestinationUUID()),
 			common.TagErr:    err,
 		}).Error(`Error updating cg`)
 		r.m3Client.IncCounter(metrics.ReplicatorUpdateCgScope, metrics.ReplicatorFailures)
@@ -686,7 +687,7 @@ func (r *Replicator) UpdateConsumerGroup(ctx thrift.Context, updateRequest *shar
 	r.logger.WithFields(bark.Fields{
 		common.TagCnsPth: common.FmtCnsPth(updateRequest.GetConsumerGroupName()),
 		common.TagDstPth: common.FmtDstPth(updateRequest.GetDestinationPath()),
-		common.TagDst:    common.FmtDstPth(cgDesc.GetDestinationUUID()),
+		common.TagDst:    common.FmtDst(cgDesc.GetDestinationUUID()),
 		common.TagDLQID:  common.FmtDLQID(cgDesc.GetDeadLetterQueueDestinationUUID()),
 		`IsMultiZone`:    cgDesc.GetIsMultiZone(),
 		`ActiveZone`:     cgDesc.GetActiveZone(),

--- a/services/replicator/replicator.go
+++ b/services/replicator/replicator.go
@@ -951,6 +951,11 @@ func (r *Replicator) ReadDestination(ctx thrift.Context, getRequest *shared.Read
 	return r.metaClient.ReadDestination(ctx, getRequest)
 }
 
+// ListConsumerGroups list consumer groups
+func (r *Replicator) ListConsumerGroups(ctx thrift.Context, getRequest *shared.ListConsumerGroupRequest) (*shared.ListConsumerGroupResult_, error) {
+	return r.metaClient.ListConsumerGroups(ctx, getRequest)
+}
+
 func (r *Replicator) createExtentRemoteCall(zone string, logger bark.Logger, createRequest *shared.CreateExtentRequest) error {
 	// acquire remote zone replicator thrift client
 	client, err := r.replicatorclientFactory.GetReplicatorClient(zone)

--- a/services/replicator/replicator_test.go
+++ b/services/replicator/replicator_test.go
@@ -419,6 +419,256 @@ func (s *ReplicatorSuite) TestDeleteRemoteDestinationSuccess() {
 	mockReplicator.AssertExpectations(s.T())
 }
 
+func (s *ReplicatorSuite) TestCreateCgUUID() {
+	repliator, _ := NewReplicator("replicator-test", s.mockService, s.mockMeta, s.mockReplicatorClientFactory, s.cfg)
+	cgUUID := uuid.New()
+	req := &shared.CreateConsumerGroupUUIDRequest{
+		ConsumerGroupUUID: common.StringPtr(cgUUID),
+		Request:           shared.NewCreateConsumerGroupRequest(),
+	}
+
+	s.mockMeta.On("CreateConsumerGroupUUID", mock.Anything, mock.Anything).Return(
+		&shared.ConsumerGroupDescription{
+			ConsumerGroupUUID: common.StringPtr(cgUUID),
+		}, nil,
+	).Run(func(args mock.Arguments) {
+		createReq := args.Get(1).(*shared.CreateConsumerGroupUUIDRequest)
+		s.True(createReq.IsSetRequest())
+		s.Equal(req.GetConsumerGroupUUID(), createReq.GetConsumerGroupUUID())
+	})
+	cgDesc, err := repliator.CreateConsumerGroupUUID(nil, req)
+	s.NoError(err)
+	s.NotNil(cgDesc)
+	s.mockMeta.AssertExpectations(s.T())
+}
+
+func (s *ReplicatorSuite) TestCreateRemoteConsumerGroupUUIDBadRequests() {
+	repliator, _ := NewReplicator("replicator-test", s.mockService, s.mockMeta, s.mockReplicatorClientFactory, s.cfg)
+
+	err := repliator.CreateRemoteConsumerGroupUUID(nil, shared.NewCreateConsumerGroupUUIDRequest())
+	s.Error(err)
+	assert.IsType(s.T(), &shared.BadRequestError{}, err)
+
+	err = repliator.CreateRemoteConsumerGroupUUID(nil, &shared.CreateConsumerGroupUUIDRequest{
+		ConsumerGroupUUID: common.StringPtr(uuid.New()),
+	})
+	s.Error(err)
+	assert.IsType(s.T(), &shared.BadRequestError{}, err)
+
+	err = repliator.CreateRemoteConsumerGroupUUID(nil, &shared.CreateConsumerGroupUUIDRequest{
+		Request: shared.NewCreateConsumerGroupRequest(),
+	})
+	s.Error(err)
+	assert.IsType(s.T(), &shared.BadRequestError{}, err)
+
+	err = repliator.CreateRemoteConsumerGroupUUID(nil, &shared.CreateConsumerGroupUUIDRequest{
+		ConsumerGroupUUID: common.StringPtr(uuid.New()),
+		Request: &shared.CreateConsumerGroupRequest{
+			IsMultiZone: common.BoolPtr(false),
+		},
+	})
+	s.Error(err)
+	assert.IsType(s.T(), &shared.BadRequestError{}, err)
+
+	err = repliator.CreateRemoteConsumerGroupUUID(nil, &shared.CreateConsumerGroupUUIDRequest{
+		ConsumerGroupUUID: common.StringPtr(uuid.New()),
+		Request: &shared.CreateConsumerGroupRequest{
+			IsMultiZone: common.BoolPtr(true),
+		},
+	})
+	s.Error(err)
+	assert.IsType(s.T(), &shared.BadRequestError{}, err)
+
+	err = repliator.CreateRemoteConsumerGroupUUID(nil, &shared.CreateConsumerGroupUUIDRequest{
+		ConsumerGroupUUID: common.StringPtr(uuid.New()),
+		Request: &shared.CreateConsumerGroupRequest{
+			IsMultiZone: common.BoolPtr(true),
+			ZoneConfigs: []*shared.ConsumerGroupZoneConfig{},
+		},
+	})
+	s.Error(err)
+	assert.IsType(s.T(), &shared.BadRequestError{}, err)
+}
+
+func (s *ReplicatorSuite) TestCreateRemoteCgUUIDFailed() {
+	repliator, _ := NewReplicator("replicator-test", s.mockService, s.mockMeta, s.mockReplicatorClientFactory, s.cfg)
+	createReq := &shared.CreateConsumerGroupUUIDRequest{
+		ConsumerGroupUUID: common.StringPtr(uuid.New()),
+		Request: &shared.CreateConsumerGroupRequest{
+			IsMultiZone: common.BoolPtr(true),
+			ZoneConfigs: []*shared.ConsumerGroupZoneConfig{shared.NewConsumerGroupZoneConfig()},
+		},
+	}
+	// setup mock
+	mockReplicator := new(mockreplicator.MockTChanReplicator)
+	mockReplicator.On("CreateConsumerGroupUUID", mock.Anything, mock.Anything).Return(nil, &shared.BadRequestError{Message: "test2"})
+	s.mockReplicatorClientFactory.On("GetReplicatorClient", mock.Anything).Return(mockReplicator, nil)
+
+	err := repliator.createConsumerGroupRemoteCall(`zone1`, repliator.logger, createReq)
+	s.Error(err)
+	s.mockReplicatorClientFactory.AssertExpectations(s.T())
+	mockReplicator.AssertExpectations(s.T())
+}
+
+func (s *ReplicatorSuite) TestCreateRemoteCgUUIDSuccess() {
+	cgUUID := uuid.New()
+	repliator, _ := NewReplicator("replicator-test", s.mockService, s.mockMeta, s.mockReplicatorClientFactory, s.cfg)
+	createReq := &shared.CreateConsumerGroupUUIDRequest{
+		ConsumerGroupUUID: common.StringPtr(cgUUID),
+		Request: &shared.CreateConsumerGroupRequest{
+			IsMultiZone: common.BoolPtr(true),
+			ZoneConfigs: []*shared.ConsumerGroupZoneConfig{shared.NewConsumerGroupZoneConfig()},
+		},
+	}
+
+	// setup mock
+	mockReplicator := new(mockreplicator.MockTChanReplicator)
+	mockReplicator.On("CreateConsumerGroupUUID", mock.Anything, mock.Anything).Return(nil, nil).Run(func(args mock.Arguments) {
+		req := args.Get(1).(*shared.CreateConsumerGroupUUIDRequest)
+		s.True(req.IsSetRequest())
+		s.True(req.GetRequest().GetIsMultiZone())
+		s.Equal(cgUUID, req.GetConsumerGroupUUID())
+	})
+	s.mockReplicatorClientFactory.On("GetReplicatorClient", mock.Anything).Return(mockReplicator, nil)
+
+	err := repliator.createConsumerGroupRemoteCall(`zone1`, repliator.logger, createReq)
+	s.NoError(err)
+	s.mockReplicatorClientFactory.AssertExpectations(s.T())
+	mockReplicator.AssertExpectations(s.T())
+}
+
+func (s *ReplicatorSuite) TestUpdateCg() {
+	repliator, _ := NewReplicator("replicator-test", s.mockService, s.mockMeta, s.mockReplicatorClientFactory, s.cfg)
+	cgName := `cg`
+	newEmail := `newowner@uber.com`
+	req := &shared.UpdateConsumerGroupRequest{
+		ConsumerGroupName: common.StringPtr(cgName),
+		OwnerEmail:        common.StringPtr(newEmail),
+	}
+
+	s.mockMeta.On("UpdateConsumerGroup", mock.Anything, mock.Anything).Return(
+		&shared.ConsumerGroupDescription{
+			ConsumerGroupName: common.StringPtr(cgName),
+			OwnerEmail:        common.StringPtr(newEmail),
+		}, nil,
+	).Run(func(args mock.Arguments) {
+		updateReq := args.Get(1).(*shared.UpdateConsumerGroupRequest)
+		s.Equal(req.GetConsumerGroupName(), updateReq.GetConsumerGroupName())
+		s.Equal(req.GetOwnerEmail(), updateReq.GetOwnerEmail())
+	})
+	cgDesc, err := repliator.UpdateConsumerGroup(nil, req)
+	s.NoError(err)
+	s.NotNil(cgDesc)
+	s.mockMeta.AssertExpectations(s.T())
+}
+
+func (s *ReplicatorSuite) TestUpdateRemoteCgFailed() {
+	repliator, _ := NewReplicator("replicator-test", s.mockService, s.mockMeta, s.mockReplicatorClientFactory, s.cfg)
+	cgName := `cg`
+	newEmail := `newowner@uber.com`
+	req := &shared.UpdateConsumerGroupRequest{
+		ConsumerGroupName: common.StringPtr(cgName),
+		OwnerEmail:        common.StringPtr(newEmail),
+	}
+
+	// setup mock
+	mockReplicator := new(mockreplicator.MockTChanReplicator)
+	mockReplicator.On("UpdateConsumerGroup", mock.Anything, mock.Anything).Return(nil, &shared.InternalServiceError{Message: "test2"})
+	s.mockReplicatorClientFactory.On("GetReplicatorClient", mock.Anything).Return(mockReplicator, nil)
+
+	err := repliator.updateCgRemoteCall(`zone1`, repliator.logger, req)
+	s.Error(err)
+	s.mockReplicatorClientFactory.AssertExpectations(s.T())
+	mockReplicator.AssertExpectations(s.T())
+}
+
+func (s *ReplicatorSuite) TestUpdateRemoteCgSuccess() {
+	repliator, _ := NewReplicator("replicator-test", s.mockService, s.mockMeta, s.mockReplicatorClientFactory, s.cfg)
+	cgName := uuid.New()
+	newEmail := `newowner@uber.com`
+	req := &shared.UpdateConsumerGroupRequest{
+		ConsumerGroupName: common.StringPtr(cgName),
+		OwnerEmail:        common.StringPtr(newEmail),
+	}
+
+	// setup mock
+	mockReplicator := new(mockreplicator.MockTChanReplicator)
+	mockReplicator.On("UpdateConsumerGroup", mock.Anything, mock.Anything).Return(nil, nil).Run(func(args mock.Arguments) {
+		req := args.Get(1).(*shared.UpdateConsumerGroupRequest)
+		s.Equal(cgName, req.GetConsumerGroupName())
+		s.Equal(newEmail, req.GetOwnerEmail())
+	})
+	s.mockReplicatorClientFactory.On("GetReplicatorClient", mock.Anything).Return(mockReplicator, nil)
+
+	err := repliator.updateCgRemoteCall(`zone1`, repliator.logger, req)
+	s.NoError(err)
+	s.mockReplicatorClientFactory.AssertExpectations(s.T())
+	mockReplicator.AssertExpectations(s.T())
+}
+
+func (s *ReplicatorSuite) TestDeleteCg() {
+	repliator, _ := NewReplicator("replicator-test", s.mockService, s.mockMeta, s.mockReplicatorClientFactory, s.cfg)
+	path := `path`
+	cg := `cg`
+	req := &shared.DeleteConsumerGroupRequest{
+		DestinationPath:   common.StringPtr(path),
+		ConsumerGroupName: common.StringPtr(cg),
+	}
+
+	s.mockMeta.On("DeleteConsumerGroup", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		delReq := args.Get(1).(*shared.DeleteConsumerGroupRequest)
+		s.Equal(path, delReq.GetDestinationPath())
+		s.Equal(cg, delReq.GetConsumerGroupName())
+	})
+	err := repliator.DeleteConsumerGroup(nil, req)
+	s.NoError(err)
+	s.mockMeta.AssertExpectations(s.T())
+}
+
+func (s *ReplicatorSuite) TestDeleteRemoteCgFailed() {
+	repliator, _ := NewReplicator("replicator-test", s.mockService, s.mockMeta, s.mockReplicatorClientFactory, s.cfg)
+	path := `path`
+	cg := `cg`
+	req := &shared.DeleteConsumerGroupRequest{
+		DestinationPath:   common.StringPtr(path),
+		ConsumerGroupName: common.StringPtr(cg),
+	}
+
+	// setup mock
+	mockReplicator := new(mockreplicator.MockTChanReplicator)
+	mockReplicator.On("DeleteConsumerGroup", mock.Anything, mock.Anything).Return(&shared.InternalServiceError{Message: "test2"})
+	s.mockReplicatorClientFactory.On("GetReplicatorClient", mock.Anything).Return(mockReplicator, nil)
+
+	err := repliator.deleteCgRemoteCall(`zone1`, repliator.logger, req)
+	s.Error(err)
+	s.mockReplicatorClientFactory.AssertExpectations(s.T())
+	mockReplicator.AssertExpectations(s.T())
+}
+
+func (s *ReplicatorSuite) TestDeleteRemoteCgSuccess() {
+	repliator, _ := NewReplicator("replicator-test", s.mockService, s.mockMeta, s.mockReplicatorClientFactory, s.cfg)
+	path := `path`
+	cg := `cg`
+	req := &shared.DeleteConsumerGroupRequest{
+		DestinationPath:   common.StringPtr(path),
+		ConsumerGroupName: common.StringPtr(cg),
+	}
+
+	// setup mock
+	mockReplicator := new(mockreplicator.MockTChanReplicator)
+	mockReplicator.On("DeleteConsumerGroup", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		req := args.Get(1).(*shared.DeleteConsumerGroupRequest)
+		s.Equal(path, req.GetDestinationPath())
+		s.Equal(cg, req.GetConsumerGroupName())
+	})
+	s.mockReplicatorClientFactory.On("GetReplicatorClient", mock.Anything).Return(mockReplicator, nil)
+
+	err := repliator.deleteCgRemoteCall(`zone1`, repliator.logger, req)
+	s.NoError(err)
+	s.mockReplicatorClientFactory.AssertExpectations(s.T())
+	mockReplicator.AssertExpectations(s.T())
+}
+
 func (s *ReplicatorSuite) TestCreateExtentSuccess() {
 	repliator, _ := NewReplicator("replicator-test", s.mockService, s.mockMeta, s.mockReplicatorClientFactory, s.cfg)
 	destUUID := uuid.New()

--- a/services/retentionmgr/metadataDep.go
+++ b/services/retentionmgr/metadataDep.go
@@ -214,7 +214,7 @@ func (t *metadataDepImpl) GetExtentInfo(destID destinationID, extID extentID) (e
 
 func (t *metadataDepImpl) GetConsumerGroups(destID destinationID) (consumerGroups []*consumerGroupInfo) {
 
-	req := metadata.NewListConsumerGroupRequest()
+	req := shared.NewListConsumerGroupRequest()
 	req.DestinationUUID = common.StringPtr(string(destID))
 	req.Limit = common.Int64Ptr(defaultPageSize)
 	ctx, _ := thrift.NewContext(time.Second)

--- a/test/integration/failure_test.go
+++ b/test/integration/failure_test.go
@@ -38,7 +38,6 @@ import (
 	localMetrics "github.com/uber/cherami-server/common/metrics"
 	"github.com/uber/cherami-server/services/controllerhost"
 	"github.com/uber/cherami-thrift/.generated/go/cherami"
-	m "github.com/uber/cherami-thrift/.generated/go/metadata"
 	"github.com/uber/cherami-thrift/.generated/go/shared"
 )
 
@@ -160,7 +159,7 @@ func (s *NodeFailureTestSuite) testNodeFailure(serviceName string, nKill int) {
 	_, err := s.createDestination(cheramiClient, destPath)
 	s.Nil(err)
 
-	mReq := &m.ReadDestinationRequest{Path: common.StringPtr(destPath)}
+	mReq := &shared.ReadDestinationRequest{Path: common.StringPtr(destPath)}
 	dstDesc, err := s.mClient.ReadDestination(nil, mReq)
 	s.Nil(err)
 

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -978,7 +978,7 @@ func (s *NetIntegrationSuiteParallelC) TestDLQWithCassandra() {
 	s.Equal(cgUpdateReq.GetOwnerEmail(), cgDesc2.GetOwnerEmail(), "Wrong Owner Email")
 
 	// Verify that the DLQ Destination can be read
-	dReq := metadata.NewReadDestinationRequest()
+	dReq := shared.NewReadDestinationRequest()
 	dReq.DestinationUUID = common.StringPtr(cgDesc2.GetDeadLetterQueueDestinationUUID())
 	dlqDestDesc, err := s.mClient.ReadDestination(nil, dReq)
 	s.Nil(err)

--- a/test/mocks/metadata/MetadataService.go
+++ b/test/mocks/metadata/MetadataService.go
@@ -199,20 +199,20 @@ func (_m *MetadataService) HostAddrToUUID(hostAddr string) (string, error) {
 }
 
 // ListConsumerGroups provides a mock function with given fields: listRequest
-func (_m *MetadataService) ListConsumerGroups(listRequest *metadata.ListConsumerGroupRequest) (*metadata.ListConsumerGroupResult_, error) {
+func (_m *MetadataService) ListConsumerGroups(listRequest *shared.ListConsumerGroupRequest) (*shared.ListConsumerGroupResult_, error) {
 	ret := _m.Called(listRequest)
 
-	var r0 *metadata.ListConsumerGroupResult_
-	if rf, ok := ret.Get(0).(func(*metadata.ListConsumerGroupRequest) *metadata.ListConsumerGroupResult_); ok {
+	var r0 *shared.ListConsumerGroupResult_
+	if rf, ok := ret.Get(0).(func(*shared.ListConsumerGroupRequest) *shared.ListConsumerGroupResult_); ok {
 		r0 = rf(listRequest)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*metadata.ListConsumerGroupResult_)
+			r0 = ret.Get(0).(*shared.ListConsumerGroupResult_)
 		}
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*metadata.ListConsumerGroupRequest) error); ok {
+	if rf, ok := ret.Get(1).(func(*shared.ListConsumerGroupRequest) error); ok {
 		r1 = rf(listRequest)
 	} else {
 		r1 = ret.Error(1)

--- a/test/mocks/metadata/MetadataService.go
+++ b/test/mocks/metadata/MetadataService.go
@@ -52,6 +52,29 @@ func (_m *MetadataService) CreateConsumerGroup(registerRequest *shared.CreateCon
 	return r0, r1
 }
 
+// CreateConsumerGroupUUID provides a mock function with given fields: registerRequest
+func (_m *MetadataService) CreateConsumerGroupUUID(registerRequest *shared.CreateConsumerGroupUUIDRequest) (*shared.ConsumerGroupDescription, error) {
+	ret := _m.Called(registerRequest)
+
+	var r0 *shared.ConsumerGroupDescription
+	if rf, ok := ret.Get(0).(func(*shared.CreateConsumerGroupUUIDRequest) *shared.ConsumerGroupDescription); ok {
+		r0 = rf(registerRequest)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*shared.ConsumerGroupDescription)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*shared.CreateConsumerGroupUUIDRequest) error); ok {
+		r1 = rf(registerRequest)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // CreateConsumerGroupExtent provides a mock function with given fields: request
 func (_m *MetadataService) CreateConsumerGroupExtent(request *metadata.CreateConsumerGroupExtentRequest) error {
 	ret := _m.Called(request)
@@ -420,11 +443,11 @@ func (_m *MetadataService) ReadConsumerGroupExtents(request *metadata.ReadConsum
 }
 
 // ReadDestination provides a mock function with given fields: getRequest
-func (_m *MetadataService) ReadDestination(getRequest *metadata.ReadDestinationRequest) (*shared.DestinationDescription, error) {
+func (_m *MetadataService) ReadDestination(getRequest *shared.ReadDestinationRequest) (*shared.DestinationDescription, error) {
 	ret := _m.Called(getRequest)
 
 	var r0 *shared.DestinationDescription
-	if rf, ok := ret.Get(0).(func(*metadata.ReadDestinationRequest) *shared.DestinationDescription); ok {
+	if rf, ok := ret.Get(0).(func(*shared.ReadDestinationRequest) *shared.DestinationDescription); ok {
 		r0 = rf(getRequest)
 	} else {
 		if ret.Get(0) != nil {
@@ -433,7 +456,7 @@ func (_m *MetadataService) ReadDestination(getRequest *metadata.ReadDestinationR
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*metadata.ReadDestinationRequest) error); ok {
+	if rf, ok := ret.Get(1).(func(*shared.ReadDestinationRequest) error); ok {
 		r1 = rf(getRequest)
 	} else {
 		r1 = ret.Error(1)

--- a/test/mocks/metadata/TChanMetadataExposable.go
+++ b/test/mocks/metadata/TChanMetadataExposable.go
@@ -104,20 +104,20 @@ func (_m *TChanMetadataExposable) HostAddrToUUID(ctx thrift.Context, hostAddr st
 }
 
 // ListAllConsumerGroups provides a mock function with given fields: ctx, listRequest
-func (_m *TChanMetadataExposable) ListAllConsumerGroups(ctx thrift.Context, listRequest *metadata.ListConsumerGroupRequest) (*metadata.ListConsumerGroupResult_, error) {
+func (_m *TChanMetadataExposable) ListAllConsumerGroups(ctx thrift.Context, listRequest *shared.ListConsumerGroupRequest) (*shared.ListConsumerGroupResult_, error) {
 	ret := _m.Called(ctx, listRequest)
 
-	var r0 *metadata.ListConsumerGroupResult_
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ListConsumerGroupRequest) *metadata.ListConsumerGroupResult_); ok {
+	var r0 *shared.ListConsumerGroupResult_
+	if rf, ok := ret.Get(0).(func(thrift.Context, *shared.ListConsumerGroupRequest) *shared.ListConsumerGroupResult_); ok {
 		r0 = rf(ctx, listRequest)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*metadata.ListConsumerGroupResult_)
+			r0 = ret.Get(0).(*shared.ListConsumerGroupResult_)
 		}
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ListConsumerGroupRequest) error); ok {
+	if rf, ok := ret.Get(1).(func(thrift.Context, *shared.ListConsumerGroupRequest) error); ok {
 		r1 = rf(ctx, listRequest)
 	} else {
 		r1 = ret.Error(1)
@@ -127,20 +127,20 @@ func (_m *TChanMetadataExposable) ListAllConsumerGroups(ctx thrift.Context, list
 }
 
 // ListConsumerGroups provides a mock function with given fields: ctx, listRequest
-func (_m *TChanMetadataExposable) ListConsumerGroups(ctx thrift.Context, listRequest *metadata.ListConsumerGroupRequest) (*metadata.ListConsumerGroupResult_, error) {
+func (_m *TChanMetadataExposable) ListConsumerGroups(ctx thrift.Context, listRequest *shared.ListConsumerGroupRequest) (*shared.ListConsumerGroupResult_, error) {
 	ret := _m.Called(ctx, listRequest)
 
-	var r0 *metadata.ListConsumerGroupResult_
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ListConsumerGroupRequest) *metadata.ListConsumerGroupResult_); ok {
+	var r0 *shared.ListConsumerGroupResult_
+	if rf, ok := ret.Get(0).(func(thrift.Context, *shared.ListConsumerGroupRequest) *shared.ListConsumerGroupResult_); ok {
 		r0 = rf(ctx, listRequest)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*metadata.ListConsumerGroupResult_)
+			r0 = ret.Get(0).(*shared.ListConsumerGroupResult_)
 		}
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ListConsumerGroupRequest) error); ok {
+	if rf, ok := ret.Get(1).(func(thrift.Context, *shared.ListConsumerGroupRequest) error); ok {
 		r1 = rf(ctx, listRequest)
 	} else {
 		r1 = ret.Error(1)

--- a/test/mocks/metadata/TChanMetadataExposable.go
+++ b/test/mocks/metadata/TChanMetadataExposable.go
@@ -403,11 +403,11 @@ func (_m *TChanMetadataExposable) ReadConsumerGroupExtentsByExtUUID(ctx thrift.C
 }
 
 // ReadDestination provides a mock function with given fields: ctx, getRequest
-func (_m *TChanMetadataExposable) ReadDestination(ctx thrift.Context, getRequest *metadata.ReadDestinationRequest) (*shared.DestinationDescription, error) {
+func (_m *TChanMetadataExposable) ReadDestination(ctx thrift.Context, getRequest *shared.ReadDestinationRequest) (*shared.DestinationDescription, error) {
 	ret := _m.Called(ctx, getRequest)
 
 	var r0 *shared.DestinationDescription
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ReadDestinationRequest) *shared.DestinationDescription); ok {
+	if rf, ok := ret.Get(0).(func(thrift.Context, *shared.ReadDestinationRequest) *shared.DestinationDescription); ok {
 		r0 = rf(ctx, getRequest)
 	} else {
 		if ret.Get(0) != nil {
@@ -416,7 +416,7 @@ func (_m *TChanMetadataExposable) ReadDestination(ctx thrift.Context, getRequest
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ReadDestinationRequest) error); ok {
+	if rf, ok := ret.Get(1).(func(thrift.Context, *shared.ReadDestinationRequest) error); ok {
 		r1 = rf(ctx, getRequest)
 	} else {
 		r1 = ret.Error(1)

--- a/test/mocks/metadata/TChanMetadataService.go
+++ b/test/mocks/metadata/TChanMetadataService.go
@@ -54,6 +54,29 @@ func (_m *TChanMetadataService) CreateConsumerGroup(ctx thrift.Context, createRe
 	return r0, r1
 }
 
+// CreateConsumerGroupUUID provides a mock function with given fields: ctx, createRequest
+func (_m *TChanMetadataService) CreateConsumerGroupUUID(ctx thrift.Context, createRequest *shared.CreateConsumerGroupUUIDRequest) (*shared.ConsumerGroupDescription, error) {
+	ret := _m.Called(ctx, createRequest)
+
+	var r0 *shared.ConsumerGroupDescription
+	if rf, ok := ret.Get(0).(func(thrift.Context, *shared.CreateConsumerGroupUUIDRequest) *shared.ConsumerGroupDescription); ok {
+		r0 = rf(ctx, createRequest)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*shared.ConsumerGroupDescription)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, *shared.CreateConsumerGroupUUIDRequest) error); ok {
+		r1 = rf(ctx, createRequest)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // CreateConsumerGroupExtent provides a mock function with given fields: ctx, request
 func (_m *TChanMetadataService) CreateConsumerGroupExtent(ctx thrift.Context, request *metadata.CreateConsumerGroupExtentRequest) error {
 	ret := _m.Called(ctx, request)
@@ -889,11 +912,11 @@ func (_m *TChanMetadataService) ReadConsumerGroupExtentsByExtUUID(ctx thrift.Con
 }
 
 // ReadDestination provides a mock function with given fields: ctx, getRequest
-func (_m *TChanMetadataService) ReadDestination(ctx thrift.Context, getRequest *metadata.ReadDestinationRequest) (*shared.DestinationDescription, error) {
+func (_m *TChanMetadataService) ReadDestination(ctx thrift.Context, getRequest *shared.ReadDestinationRequest) (*shared.DestinationDescription, error) {
 	ret := _m.Called(ctx, getRequest)
 
 	var r0 *shared.DestinationDescription
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ReadDestinationRequest) *shared.DestinationDescription); ok {
+	if rf, ok := ret.Get(0).(func(thrift.Context, *shared.ReadDestinationRequest) *shared.DestinationDescription); ok {
 		r0 = rf(ctx, getRequest)
 	} else {
 		if ret.Get(0) != nil {
@@ -902,7 +925,7 @@ func (_m *TChanMetadataService) ReadDestination(ctx thrift.Context, getRequest *
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ReadDestinationRequest) error); ok {
+	if rf, ok := ret.Get(1).(func(thrift.Context, *shared.ReadDestinationRequest) error); ok {
 		r1 = rf(ctx, getRequest)
 	} else {
 		r1 = ret.Error(1)

--- a/test/mocks/metadata/TChanMetadataService.go
+++ b/test/mocks/metadata/TChanMetadataService.go
@@ -613,20 +613,20 @@ func (_m *TChanMetadataService) HostAddrToUUID(ctx thrift.Context, hostAddr stri
 }
 
 // ListAllConsumerGroups provides a mock function with given fields: ctx, listRequest
-func (_m *TChanMetadataService) ListAllConsumerGroups(ctx thrift.Context, listRequest *metadata.ListConsumerGroupRequest) (*metadata.ListConsumerGroupResult_, error) {
+func (_m *TChanMetadataService) ListAllConsumerGroups(ctx thrift.Context, listRequest *shared.ListConsumerGroupRequest) (*shared.ListConsumerGroupResult_, error) {
 	ret := _m.Called(ctx, listRequest)
 
-	var r0 *metadata.ListConsumerGroupResult_
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ListConsumerGroupRequest) *metadata.ListConsumerGroupResult_); ok {
+	var r0 *shared.ListConsumerGroupResult_
+	if rf, ok := ret.Get(0).(func(thrift.Context, *shared.ListConsumerGroupRequest) *shared.ListConsumerGroupResult_); ok {
 		r0 = rf(ctx, listRequest)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*metadata.ListConsumerGroupResult_)
+			r0 = ret.Get(0).(*shared.ListConsumerGroupResult_)
 		}
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ListConsumerGroupRequest) error); ok {
+	if rf, ok := ret.Get(1).(func(thrift.Context, *shared.ListConsumerGroupRequest) error); ok {
 		r1 = rf(ctx, listRequest)
 	} else {
 		r1 = ret.Error(1)
@@ -636,20 +636,20 @@ func (_m *TChanMetadataService) ListAllConsumerGroups(ctx thrift.Context, listRe
 }
 
 // ListConsumerGroups provides a mock function with given fields: ctx, listRequest
-func (_m *TChanMetadataService) ListConsumerGroups(ctx thrift.Context, listRequest *metadata.ListConsumerGroupRequest) (*metadata.ListConsumerGroupResult_, error) {
+func (_m *TChanMetadataService) ListConsumerGroups(ctx thrift.Context, listRequest *shared.ListConsumerGroupRequest) (*shared.ListConsumerGroupResult_, error) {
 	ret := _m.Called(ctx, listRequest)
 
-	var r0 *metadata.ListConsumerGroupResult_
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ListConsumerGroupRequest) *metadata.ListConsumerGroupResult_); ok {
+	var r0 *shared.ListConsumerGroupResult_
+	if rf, ok := ret.Get(0).(func(thrift.Context, *shared.ListConsumerGroupRequest) *shared.ListConsumerGroupResult_); ok {
 		r0 = rf(ctx, listRequest)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*metadata.ListConsumerGroupResult_)
+			r0 = ret.Get(0).(*shared.ListConsumerGroupResult_)
 		}
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ListConsumerGroupRequest) error); ok {
+	if rf, ok := ret.Get(1).(func(thrift.Context, *shared.ListConsumerGroupRequest) error); ok {
 		r1 = rf(ctx, listRequest)
 	} else {
 		r1 = ret.Error(1)

--- a/test/mocks/metadata/TChanMetadataServiceClient.go
+++ b/test/mocks/metadata/TChanMetadataServiceClient.go
@@ -560,11 +560,11 @@ func (_m *TChanMetadataServiceClient) ReadConsumerGroupExtentsByExtUUID(ctx thri
 }
 
 // ReadDestination provides a mock function with given fields: ctx, getRequest
-func (_m *TChanMetadataServiceClient) ReadDestination(ctx thrift.Context, getRequest *metadata.ReadDestinationRequest) (*shared.DestinationDescription, error) {
+func (_m *TChanMetadataServiceClient) ReadDestination(ctx thrift.Context, getRequest *shared.ReadDestinationRequest) (*shared.DestinationDescription, error) {
 	ret := _m.Called(ctx, getRequest)
 
 	var r0 *shared.DestinationDescription
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ReadDestinationRequest) *shared.DestinationDescription); ok {
+	if rf, ok := ret.Get(0).(func(thrift.Context, *shared.ReadDestinationRequest) *shared.DestinationDescription); ok {
 		r0 = rf(ctx, getRequest)
 	} else {
 		if ret.Get(0) != nil {
@@ -573,7 +573,7 @@ func (_m *TChanMetadataServiceClient) ReadDestination(ctx thrift.Context, getReq
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ReadDestinationRequest) error); ok {
+	if rf, ok := ret.Get(1).(func(thrift.Context, *shared.ReadDestinationRequest) error); ok {
 		r1 = rf(ctx, getRequest)
 	} else {
 		r1 = ret.Error(1)

--- a/test/mocks/metadata/TChanMetadataServiceClient.go
+++ b/test/mocks/metadata/TChanMetadataServiceClient.go
@@ -224,20 +224,20 @@ func (_m *TChanMetadataServiceClient) HostAddrToUUID(ctx thrift.Context, hostAdd
 }
 
 // ListAllConsumerGroups provides a mock function with given fields: ctx, listRequest
-func (_m *TChanMetadataServiceClient) ListAllConsumerGroups(ctx thrift.Context, listRequest *metadata.ListConsumerGroupRequest) (*metadata.ListConsumerGroupResult_, error) {
+func (_m *TChanMetadataServiceClient) ListAllConsumerGroups(ctx thrift.Context, listRequest *shared.ListConsumerGroupRequest) (*shared.ListConsumerGroupResult_, error) {
 	ret := _m.Called(ctx, listRequest)
 
-	var r0 *metadata.ListConsumerGroupResult_
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ListConsumerGroupRequest) *metadata.ListConsumerGroupResult_); ok {
+	var r0 *shared.ListConsumerGroupResult_
+	if rf, ok := ret.Get(0).(func(thrift.Context, *shared.ListConsumerGroupRequest) *shared.ListConsumerGroupResult_); ok {
 		r0 = rf(ctx, listRequest)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*metadata.ListConsumerGroupResult_)
+			r0 = ret.Get(0).(*shared.ListConsumerGroupResult_)
 		}
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ListConsumerGroupRequest) error); ok {
+	if rf, ok := ret.Get(1).(func(thrift.Context, *shared.ListConsumerGroupRequest) error); ok {
 		r1 = rf(ctx, listRequest)
 	} else {
 		r1 = ret.Error(1)
@@ -270,20 +270,20 @@ func (_m *TChanMetadataServiceClient) ListEntityOps(ctx thrift.Context, listRequ
 }
 
 // ListConsumerGroups provides a mock function with given fields: ctx, listRequest
-func (_m *TChanMetadataServiceClient) ListConsumerGroups(ctx thrift.Context, listRequest *metadata.ListConsumerGroupRequest) (*metadata.ListConsumerGroupResult_, error) {
+func (_m *TChanMetadataServiceClient) ListConsumerGroups(ctx thrift.Context, listRequest *shared.ListConsumerGroupRequest) (*shared.ListConsumerGroupResult_, error) {
 	ret := _m.Called(ctx, listRequest)
 
-	var r0 *metadata.ListConsumerGroupResult_
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ListConsumerGroupRequest) *metadata.ListConsumerGroupResult_); ok {
+	var r0 *shared.ListConsumerGroupResult_
+	if rf, ok := ret.Get(0).(func(thrift.Context, *shared.ListConsumerGroupRequest) *shared.ListConsumerGroupResult_); ok {
 		r0 = rf(ctx, listRequest)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*metadata.ListConsumerGroupResult_)
+			r0 = ret.Get(0).(*shared.ListConsumerGroupResult_)
 		}
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ListConsumerGroupRequest) error); ok {
+	if rf, ok := ret.Get(1).(func(thrift.Context, *shared.ListConsumerGroupRequest) error); ok {
 		r1 = rf(ctx, listRequest)
 	} else {
 		r1 = ret.Error(1)

--- a/test/mocks/metadata/TChanMetadataServiceServer.go
+++ b/test/mocks/metadata/TChanMetadataServiceServer.go
@@ -178,20 +178,20 @@ func (_m *TChanMetadataServiceServer) HostAddrToUUID(ctx thrift.Context, hostAdd
 }
 
 // ListConsumerGroups provides a mock function with given fields: ctx, listRequest
-func (_m *TChanMetadataServiceServer) ListConsumerGroups(ctx thrift.Context, listRequest *metadata.ListConsumerGroupRequest) (*metadata.ListConsumerGroupResult_, error) {
+func (_m *TChanMetadataServiceServer) ListConsumerGroups(ctx thrift.Context, listRequest *shared.ListConsumerGroupRequest) (*shared.ListConsumerGroupResult_, error) {
 	ret := _m.Called(ctx, listRequest)
 
-	var r0 *metadata.ListConsumerGroupResult_
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ListConsumerGroupRequest) *metadata.ListConsumerGroupResult_); ok {
+	var r0 *shared.ListConsumerGroupResult_
+	if rf, ok := ret.Get(0).(func(thrift.Context, *shared.ListConsumerGroupRequest) *shared.ListConsumerGroupResult_); ok {
 		r0 = rf(ctx, listRequest)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*metadata.ListConsumerGroupResult_)
+			r0 = ret.Get(0).(*shared.ListConsumerGroupResult_)
 		}
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ListConsumerGroupRequest) error); ok {
+	if rf, ok := ret.Get(1).(func(thrift.Context, *shared.ListConsumerGroupRequest) error); ok {
 		r1 = rf(ctx, listRequest)
 	} else {
 		r1 = ret.Error(1)

--- a/test/mocks/metadata/TChanMetadataServiceServer.go
+++ b/test/mocks/metadata/TChanMetadataServiceServer.go
@@ -422,11 +422,11 @@ func (_m *TChanMetadataServiceServer) ReadConsumerGroupExtents(ctx thrift.Contex
 }
 
 // ReadDestination provides a mock function with given fields: ctx, getRequest
-func (_m *TChanMetadataServiceServer) ReadDestination(ctx thrift.Context, getRequest *metadata.ReadDestinationRequest) (*shared.DestinationDescription, error) {
+func (_m *TChanMetadataServiceServer) ReadDestination(ctx thrift.Context, getRequest *shared.ReadDestinationRequest) (*shared.DestinationDescription, error) {
 	ret := _m.Called(ctx, getRequest)
 
 	var r0 *shared.DestinationDescription
-	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.ReadDestinationRequest) *shared.DestinationDescription); ok {
+	if rf, ok := ret.Get(0).(func(thrift.Context, *shared.ReadDestinationRequest) *shared.DestinationDescription); ok {
 		r0 = rf(ctx, getRequest)
 	} else {
 		if ret.Get(0) != nil {
@@ -435,7 +435,7 @@ func (_m *TChanMetadataServiceServer) ReadDestination(ctx thrift.Context, getReq
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(thrift.Context, *metadata.ReadDestinationRequest) error); ok {
+	if rf, ok := ret.Get(1).(func(thrift.Context, *shared.ReadDestinationRequest) error); ok {
 		r1 = rf(ctx, getRequest)
 	} else {
 		r1 = ret.Error(1)

--- a/test/mocks/replicator/MockTChanReplicator.go
+++ b/test/mocks/replicator/MockTChanReplicator.go
@@ -338,3 +338,25 @@ func (m *MockTChanReplicator) ListExtentsStats(ctx thrift.Context, listRequest *
 
 	return r0, r1
 }
+
+func (m *MockTChanReplicator) ReadDestination(ctx thrift.Context, listRequest *shared.ReadDestinationRequest) (*shared.DestinationDescription, error) {
+	ret := m.Called(ctx, listRequest)
+
+	var r0 *shared.DestinationDescription
+	if rf, ok := ret.Get(0).(func(thrift.Context, *shared.ReadDestinationRequest) *shared.DestinationDescription); ok {
+		r0 = rf(ctx, listRequest)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*shared.DestinationDescription)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, *shared.ReadDestinationRequest) error); ok {
+		r1 = rf(ctx, listRequest)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/test/mocks/replicator/MockTChanReplicator.go
+++ b/test/mocks/replicator/MockTChanReplicator.go
@@ -360,3 +360,25 @@ func (m *MockTChanReplicator) ReadDestination(ctx thrift.Context, listRequest *s
 
 	return r0, r1
 }
+
+func (m *MockTChanReplicator) ListConsumerGroups(ctx thrift.Context, listRequest *shared.ListConsumerGroupRequest) (*shared.ListConsumerGroupResult_, error) {
+	ret := m.Called(ctx, listRequest)
+
+	var r0 *shared.ListConsumerGroupResult_
+	if rf, ok := ret.Get(0).(func(thrift.Context, *shared.ListConsumerGroupRequest) *shared.ListConsumerGroupResult_); ok {
+		r0 = rf(ctx, listRequest)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*shared.ListConsumerGroupResult_)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, *shared.ListConsumerGroupRequest) error); ok {
+		r1 = rf(ctx, listRequest)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/tools/common/lib.go
+++ b/tools/common/lib.go
@@ -681,7 +681,7 @@ func ReadDestination(c *cli.Context, mClient mcli.Client) {
 	if showCG == "true" {
 		// read all the consumer group for this destination, including deleted ones
 		destUUID := desc.GetDestinationUUID()
-		req := &metadata.ListConsumerGroupRequest{
+		req := &shared.ListConsumerGroupRequest{
 			Limit: common.Int64Ptr(DefaultPageSize),
 		}
 		var cgsInfo = make([]*shared.ConsumerGroupDescription, 0)

--- a/tools/common/lib.go
+++ b/tools/common/lib.go
@@ -285,7 +285,7 @@ func UpdateDestination(c *cli.Context, cClient ccli.Client, mClient mcli.Client)
 	// this is a prevention mechanism to prevent messages from being deleted in source zone in case there's some
 	// issue with cross zone replication(for example, network down between zones)
 	if c.IsSet(`unconsumed_messages_retention`) && int32(c.Int(`unconsumed_messages_retention`)) < MinUnconsumedMessagesRetentionForMultiZoneDest {
-		desc, err := mClient.ReadDestination(&metadata.ReadDestinationRequest{
+		desc, err := mClient.ReadDestination(&shared.ReadDestinationRequest{
 			Path: &path,
 		})
 		ExitIfError(err)
@@ -671,7 +671,7 @@ func ReadDestination(c *cli.Context, mClient mcli.Client) {
 
 	path := c.Args().First()
 	showCG := string(c.String("showcg"))
-	desc, err := mClient.ReadDestination(&metadata.ReadDestinationRequest{
+	desc, err := mClient.ReadDestination(&shared.ReadDestinationRequest{
 		Path: &path,
 	})
 	ExitIfError(err)
@@ -715,7 +715,7 @@ func ReadDlq(c *cli.Context, mClient mcli.Client) {
 	}
 
 	dlqUUID := c.Args().First()
-	desc, err0 := mClient.ReadDestination(&metadata.ReadDestinationRequest{
+	desc, err0 := mClient.ReadDestination(&shared.ReadDestinationRequest{
 		Path: &dlqUUID,
 	})
 


### PR DESCRIPTION
This diff adds the multi_zone cg metadata propagation. Here's a summary of the change
1. Move DLQ creation from frontend to metadata. This is because replicator also needs to create cg by calling metadata so all logic needs to happen in metadata
2. cg CUD fast path. Request flow: local frontend->local controller (will call metadata to create cg locally)->local replicator->remote replicator(will call metadata to create cg locally)
3. cg CUD slow path: replicator in each zone will talk to authoritative zone, and compare (update is not in this diff because the current diff is too large now)

related thrift change: https://github.com/uber/cherami-thrift/pull/12

@GuillaumeBailey you're only required to review change #1 (change in metadata_cassandra) but feel free to review the whole PR
