### PR TITLE
outputhost: fix a bug that results in stuck consumer groups

### DIFF
--- a/services/outputhost/consconnection.go
+++ b/services/outputhost/consconnection.go
@@ -58,9 +58,10 @@ type (
 		// one message at a time) and are read during connection close after
 		// the pumps have closed -- therefore these don't need to be protected
 		// for concurrent access.
-		recvCreds  int64 // total credits received
-		sentMsgs   int64 // total messages sent out
-		reSentMsgs int64 // count of sent messages that were re-deliveries
+		recvCreds      int64 // total credits received
+		sentMsgs       int64 // total messages sent out
+		reSentMsgs 	   int64 // count of sent messages that were re-deliveries
+		sentToMsgCache int64 // count of message sent to message cache
 
 		lk     sync.Mutex
 		opened bool
@@ -122,7 +123,6 @@ func (conn *consConnection) open() *sync.WaitGroup {
 
 func (conn *consConnection) close() {
 	conn.lk.Lock()
-
 	if !conn.closed {
 		// unregister from the notifier
 		conn.cgCache.notifier.Unregister(conn.connID)
@@ -142,6 +142,7 @@ func (conn *consConnection) close() {
 			`sentMsgs`:   conn.sentMsgs,
 			`reSentMsgs`: conn.reSentMsgs,
 			`recvCreds`:  conn.recvCreds,
+			`sentToMsgCache`: conn.sentToMsgCache,
 		}).Info("consConn closed")
 	}
 	conn.lk.Unlock()
@@ -390,16 +391,6 @@ func (conn *consConnection) createMsgAndWriteToClientUtil(msg *cherami.ConsumerM
 	cmd := createMsgCmd(msg)
 	if err := conn.writeToClient(cmd); err == nil {
 		*unflushedWrites++
-		// Add the message to the message cache, on the appropriate channel
-		// this should be blocking because we should not proceed forward if we
-		// cannot write to the message cache
-		select {
-		case msgCacheCh <- cacheMsg{msg: msg, connID: conn.connID}:
-		case <-conn.closeChannel:
-			conn.logger.
-				WithField(common.TagAckID, common.FmtAckID(msg.GetAckId())).
-				Error("outputhost: Unable to write the message to the cache (shutdown?)")
-		}
 		*localCredits--
 		// flush if we have reached the threshold
 		if *unflushedWrites > common.FlushThreshold {
@@ -408,6 +399,15 @@ func (conn *consConnection) createMsgAndWriteToClientUtil(msg *cherami.ConsumerM
 			}
 		}
 	}
+	// Always add to the messageCache regardless of whether the write
+	// to the client succeeded or not. If we don't add it to the
+	// message cache, the message is *lost* and will never be redelivered.
+	// This can cause the CG to be stuck forever waiting for an ACK from client.
+	// The blocking operation below can delay the closing of stream when a
+	// conn close signal is received, the assumption here is that the
+	// operation if it blocks, will only do so for less than a second
+	msgCacheCh <- cacheMsg{msg: msg, connID: conn.connID}
+	conn.sentToMsgCache++
 }
 
 func createMsgCmd(msg *cherami.ConsumerMessage) *cherami.OutputHostCommand {

--- a/services/outputhost/consconnection.go
+++ b/services/outputhost/consconnection.go
@@ -60,7 +60,7 @@ type (
 		// for concurrent access.
 		recvCreds      int64 // total credits received
 		sentMsgs       int64 // total messages sent out
-		reSentMsgs 	   int64 // count of sent messages that were re-deliveries
+		reSentMsgs     int64 // count of sent messages that were re-deliveries
 		sentToMsgCache int64 // count of message sent to message cache
 
 		lk     sync.Mutex
@@ -139,9 +139,9 @@ func (conn *consConnection) close() {
 		// now set the WG to unblock cgCache unload
 		conn.cgCache.connsWG.Done()
 		conn.logger.WithFields(bark.Fields{
-			`sentMsgs`:   conn.sentMsgs,
-			`reSentMsgs`: conn.reSentMsgs,
-			`recvCreds`:  conn.recvCreds,
+			`sentMsgs`:       conn.sentMsgs,
+			`reSentMsgs`:     conn.reSentMsgs,
+			`recvCreds`:      conn.recvCreds,
 			`sentToMsgCache`: conn.sentToMsgCache,
 		}).Info("consConn closed")
 	}

--- a/services/outputhost/outputhost_test.go
+++ b/services/outputhost/outputhost_test.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"testing"
 	"time"
+	"errors"
 
 	"golang.org/x/net/context"
 
@@ -165,8 +166,8 @@ func (s *OutputHostSuite) TestOutputHostRejectNoPath() {
 // TestOutputHostReadMessage just reads a bunch of messages and make sure
 // we get the msg back
 func (s *OutputHostSuite) TestOutputHostReadMessage() {
-	var count int32
-	count = 10
+
+	count := 10
 
 	outputHost, _ := NewOutputHost("outputhost-test", s.mockService, s.mockMeta, nil, nil)
 	httpRequest := utilGetHTTPRequestWithPath("foo")
@@ -192,40 +193,177 @@ func (s *OutputHostSuite) TestOutputHostReadMessage() {
 	cgRes.Extents = append(cgRes.Extents, cgExt)
 	s.mockMeta.On("ReadConsumerGroupExtents", mock.Anything, mock.Anything).Return(cgRes, nil).Once()
 	s.mockRead.On("Write", mock.Anything).Return(nil)
-	s.mockCons.On("Write", mock.Anything).Return(nil)
+
+	nWritten := 0
+	writeDoneCh := make(chan struct{})
+
+	s.mockCons.On("Write", mock.Anything).Return(nil).Times(count).Run(func(args mock.Arguments) {
+		nWritten++
+		if nWritten == count {
+			close(writeDoneCh)
+		}
+	})
 
 	cFlow := cherami.NewControlFlow()
-	cFlow.Credits = common.Int32Ptr(count)
+	cFlow.Credits = common.Int32Ptr(int32(count))
 
-	s.mockCons.On("Read").Return(cFlow, nil).Once()
+	connOpenedCh := make(chan struct{})
+	s.mockCons.On("Read").Return(cFlow, nil).Once().Run(func(args mock.Arguments){close(connOpenedCh)})
 
 	// setup the mock so that we can read 10 messages
-	for i := 0; i < int(count); i++ {
-		aMsg := store.NewAppendMessage()
-		aMsg.SequenceNumber = common.Int64Ptr(int64(i))
-		pMsg := cherami.NewPutMessage()
-		pMsg.ID = common.StringPtr(strconv.Itoa(i))
-		pMsg.Data = []byte(fmt.Sprintf("hello-%d", i))
+	writeSeq := int64(0)
 
+
+	rmc := store.NewReadMessageContent()
+	rmc.Type = store.ReadMessageContentTypePtr(store.ReadMessageContentType_MESSAGE)
+
+	s.mockRead.On("Read").Return(rmc, nil).Times(10).Run(func(args mock.Arguments){
+		aMsg := store.NewAppendMessage()
+		aMsg.SequenceNumber = common.Int64Ptr(writeSeq)
+		pMsg := cherami.NewPutMessage()
+		pMsg.ID = common.StringPtr(strconv.Itoa(int(writeSeq)))
+		pMsg.Data = []byte(fmt.Sprintf("hello-%d", writeSeq))
 		aMsg.Payload = pMsg
 		rMsg := store.NewReadMessage()
 		rMsg.Message = aMsg
-
-		rmc := store.NewReadMessageContent()
-		rmc.Type = store.ReadMessageContentTypePtr(store.ReadMessageContentType_MESSAGE)
 		rmc.Message = rMsg
+		writeSeq++
+	}).Times(count)
 
-		s.mockRead.On("Read").Return(rmc, nil).Once()
-	}
+	streamDoneCh := make(chan struct{})
+	go func() {
+		outputHost.OpenConsumerStreamHandler(s.mockHTTPResponse, httpRequest)
+		close(streamDoneCh)
+	}()
 
 	// close the read stream
+	creditUnblockCh := make(chan struct{})
 	s.mockRead.On("Read").Return(nil, io.EOF)
-	s.mockCons.On("Read").Return(nil, io.EOF)
+	s.mockCons.On("Read").Return(nil, io.EOF).Run(func(args mock.Arguments){<-writeDoneCh; <-creditUnblockCh})
 
-	outputHost.OpenConsumerStreamHandler(s.mockHTTPResponse, httpRequest)
+	<-connOpenedCh // wait for the consConnection to open
+
+	// look up cgcache and the underlying client connnection
+	outputHost.cgMutex.RLock()
+	cgCache, ok := outputHost.cgCache[cgDesc.GetConsumerGroupUUID()]
+	outputHost.cgMutex.RUnlock()
+	s.True(ok, "cannot find cgcache entry")
+
+	var nConns = 0
+	var conn *consConnection
+	cgCache.extMutex.RLock()
+	for _, conn = range cgCache.connections {
+		break
+	}
+	nConns = len(cgCache.connections)
+	cgCache.extMutex.RUnlock()
+	s.Equal(1, nConns, "wrong number of consumer connections")
+	s.NotNil(conn, "failed to find consConnection within cgcache")
+
+	creditUnblockCh <- struct{}{} // now unblock the readCreditsPump on the consconnection
+	<-streamDoneCh
+
 	s.mockHTTPResponse.AssertNotCalled(s.T(), "WriteHeader", mock.Anything)
+	s.Equal(int64(count), conn.sentMsgs, "wrong sentMsgs count")
+	s.Equal(int64(0), conn.reSentMsgs, "wrong reSentMsgs count")
+	s.Equal(conn.sentMsgs, conn.sentToMsgCache, "sentMsgs != sentToMsgCache")
 	outputHost.Shutdown()
 }
+
+// TestOutputHostPutsMsgIntoMsgCacheOnWriteError verifies that
+// consConnection always puts a dequeued into message cache regardless
+// of whether write() succeeds or fails.
+func (s *OutputHostSuite) TestOutputHostPutsMsgIntoMsgCacheOnWriteError() {
+
+	outputHost, _ := NewOutputHost("outputhost-test", s.mockService, s.mockMeta, nil, nil)
+	httpRequest := utilGetHTTPRequestWithPath("foo")
+
+	destUUID := uuid.New()
+	destDesc := shared.NewDestinationDescription()
+	destDesc.Path = common.StringPtr("/foo/bar")
+	destDesc.DestinationUUID = common.StringPtr(destUUID)
+	destDesc.Status = common.InternalDestinationStatusPtr(shared.DestinationStatus_ENABLED)
+	s.mockMeta.On("ReadDestination", mock.Anything, mock.Anything).Return(destDesc, nil).Once()
+	s.mockMeta.On("ReadExtentStats", mock.Anything, mock.Anything).Return(nil, fmt.Errorf(`foo`))
+
+	cgDesc := shared.NewConsumerGroupDescription()
+	cgDesc.ConsumerGroupUUID = common.StringPtr(uuid.New())
+	cgDesc.DestinationUUID = common.StringPtr(destUUID)
+	s.mockMeta.On("ReadConsumerGroup", mock.Anything, mock.Anything).Return(cgDesc, nil).Twice()
+
+	cgExt := metadata.NewConsumerGroupExtent()
+	cgExt.ExtentUUID = common.StringPtr(uuid.New())
+	cgExt.StoreUUIDs = []string{"mock"}
+
+	cgRes := &metadata.ReadConsumerGroupExtentsResult_{}
+	cgRes.Extents = append(cgRes.Extents, cgExt)
+	s.mockMeta.On("ReadConsumerGroupExtents", mock.Anything, mock.Anything).Return(cgRes, nil).Once()
+	s.mockRead.On("Write", mock.Anything).Return(nil)
+
+	writeDoneCh := make(chan struct{}) // signal after write() is called
+	s.mockCons.On("Write", mock.Anything).Return(errors.New("write error")).Run(func(args mock.Arguments){close(writeDoneCh)})
+
+	cFlow := cherami.NewControlFlow()
+	cFlow.Credits = common.Int32Ptr(10)
+
+	s.mockCons.On("Read").Return(cFlow, nil).Once()
+
+	// setup to send a mock message from store
+	aMsg := store.NewAppendMessage()
+	aMsg.SequenceNumber = common.Int64Ptr(int64(1))
+	pMsg := cherami.NewPutMessage()
+	pMsg.ID = common.StringPtr(strconv.Itoa(1))
+	pMsg.Data = []byte("hello")
+
+	aMsg.Payload = pMsg
+	rMsg := store.NewReadMessage()
+	rMsg.Message = aMsg
+
+	rmc := store.NewReadMessageContent()
+	rmc.Type = store.ReadMessageContentTypePtr(store.ReadMessageContentType_MESSAGE)
+	rmc.Message = rMsg
+	// message from store to output
+	s.mockRead.On("Read").Return(rmc, nil).Once()
+
+	creditUnblockCh := make(chan struct{}) // channel to keep the consConnection open until we validate results
+	// close the read stream
+	s.mockRead.On("Read").Return(nil, io.EOF)
+	// make the credit channel wait until we verify the output, this prevents the cgcache from unloading
+	s.mockCons.On("Read").Return(nil, io.EOF).Run(func(args mock.Arguments) {<-creditUnblockCh})
+
+	// initiate a consumer connection
+	streamDoneCh := make(chan struct{})
+	go func() {
+		outputHost.OpenConsumerStreamHandler(s.mockHTTPResponse, httpRequest)
+		close(streamDoneCh)
+	}()
+
+	<-writeDoneCh // wait for the message to be written
+
+	// look up cgcache and the underlying client connnection
+	outputHost.cgMutex.RLock()
+	cgCache, ok := outputHost.cgCache[cgDesc.GetConsumerGroupUUID()]
+	outputHost.cgMutex.RUnlock()
+	s.True(ok, "cannot find cgcache entry")
+
+	var nConns = 0
+	var conn *consConnection
+	cgCache.extMutex.RLock()
+	for _, conn = range cgCache.connections {
+		break
+	}
+	nConns = len(cgCache.connections)
+	cgCache.extMutex.RUnlock()
+	s.Equal(1, nConns, "wrong number of consumer connections")
+	s.NotNil(conn, "failed to find consConnection within cgcache")
+
+	creditUnblockCh <- struct{}{} // now unblock the readCreditsPump on the consconnection
+	outputHost.Shutdown()
+	<-streamDoneCh
+	// now that the whole CG is unloaded, assert that we actually put msgs into message cache
+	s.Equal(int64(1), conn.sentToMsgCache, "consConnection failed to put message into message cache")
+}
+
 
 func (s *OutputHostSuite) TestOutputHostAckMessage() {
 	outputHost, _ := NewOutputHost("outputhost-test", s.mockService, s.mockMeta, nil, nil)


### PR DESCRIPTION
Uncovered a bug in output host while investigating a customer reported case last week. The symptom is a stuck consumer group i.e. consumers don't make any progress, no messages are sent from output hosts to clients. 

The trigger for this bug is one of the consuming worker process on the application rebooting, thereby killing all connections from that host to the output host. When that happens, there is a chance of a message getting black-holed per connection on the output host i.e. the last message sent on the socket from the output host to client can be forgotten by the output host. This message won't be acked by the worker process, because the socket is closed. It won't be redelivered by output-host because it lost the state for it. As a result, there will be a hold in in the sequence number space, which will never get filled and the ConsumerGroup will be stuck waiting for that hole to be filled.

The root cause is the output host consConnection failing to put a message back to msgDeliveryCache during connection shutdown. This patch does the following:

* Fixes the bug
* Adds a unit test covering the case that triggered the bug
* While working on the fix, noticed a unit test, which was totally broken (it was a no-op). Fixed this unit test - TestOutputHostReadMessage