### PR TITLE
ConfigMgr: Make the rule evaluator honor hierarchy

### DIFF
--- a/common/dconfig/configmgr.go
+++ b/common/dconfig/configmgr.go
@@ -129,8 +129,7 @@ var cfgRefreshInterval = time.Minute
 // default values that apply to a broad category, subject to
 // the following constraints:
 //
-//  (1) serviceName cannot be a wildcard
-//  (2) if sku is a wildcard, hostname MUST also be a wildcard
+//  (1) if hostname is specified, sku is always ignored (i.e. treated as wildcard)
 //
 // Config Evaluation:
 //   In general, the config evaluator ALWAYS returns the most specific config
@@ -146,8 +145,9 @@ var cfgRefreshInterval = time.Minute
 //  Example Queries:
 //       Get(inputhost, *, *, *)        = 111
 //       Get(inputhost, v1, *, *)       = 333
-//       Get(inputhost, v1, ec2m112, *) = 222 --> BEWARE, defaults applied
+//       Get(inputhost, v1, ec2m112, *) = 333
 //       Get(inputhost, v1, m1large, *) = 444
+//       Get(inputhost, v2, ec2m112, *) = 222 <-- SKU default applied
 //
 // The constructor to this class takes a configTypes param, which is a map
 // of serviceName to configObjects. The config object MUST be of struct type
@@ -226,6 +226,18 @@ func (cfgMgr *CassandraConfigManager) runLoop() {
 	cfgMgr.logger.Info("Config refresher stopped")
 }
 
+func printConfigTree(tree *configTreeNode, keys []string, idx int) {
+
+	key := strings.Join(keys, ".")
+	fmt.Printf("key=%v %+v\n", key, tree.value)
+
+	for k,v := range tree.children {
+		keys[idx] = k
+		printConfigTree(v, keys, idx+1)
+		keys[idx] = "*"
+	}
+}
+
 // Get returns the config value that best matches the given
 // input criteria. svc param cannot be empty.
 func (cfgMgr *CassandraConfigManager) Get(svc string, version string, sku string, host string) (interface{}, error) {
@@ -245,7 +257,14 @@ func (cfgMgr *CassandraConfigManager) Get(svc string, version string, sku string
 
 		next, hasNext := curr.children[k]
 		if !hasNext {
-			break
+			if k == wildcardToken {
+				break
+			}
+			// if we don't have this value, substitute wildcard & retry
+			next, hasNext = curr.children[wildcardToken]
+			if !hasNext {
+				break
+			}
 		}
 		curr = next
 	}
@@ -299,6 +318,7 @@ func (cfgMgr *CassandraConfigManager) mkConfigTree(inputKVTree *kvTree) *configT
 	for k, v := range cfgMgr.configTypes {
 		tree := inputKVTree.children[k]
 		result.children[k] = cfgMgr.mkConfigTreeForSvc(v, nil, tree)
+		printConfigTree(result.children[k], []string{k, "*", "*", "*"}, 1)
 	}
 
 	return result
@@ -318,14 +338,37 @@ func (cfgMgr *CassandraConfigManager) mkConfigTreeForSvc(cfgType interface{}, de
 	return result
 }
 
+// mkKVTreeForSvc builds a hierarchical tree of key values
+// for a speicific service. The tree hierarchy is from
+// svc -> version -> sku -> host. The key values at each
+// level serve as the default for its children nodes.
+//
+// The actual construction of the tree is a 3 step process:
+// (1) Take every config item of form svc.version.sku.host.key=value and add it to tree
+//        (a) If the version & sku are wildcard (i.e. *), then the config item
+//            MUST serve as a default for every version/ every sku, so keep track of
+//            these separately
+//        (b) If the version is a wildcard but sku is not, then this config item
+//			  MUST serve as a default for every version.sku, so trace this separately
+//        (c) If the version is not wildcard, but sku is wildcard, then the
+//            config item MUST serve as a default for every sku for that version
+//            so keep track of these separately
+// (2) Add the items tracked in 1(b) to the tree (for every sku)
+// (3) Add the items tracked in 1(a) for every version
+//
+// Its important to apply the config items in the order (1).(2).(3) to honor
+// the hierarchial structure
 func (cfgMgr *CassandraConfigManager) mkKVTreeForSvc(service string, items []*m.ServiceConfigItem) *kvTreeNode {
 
 	root := newKVTreeNode()
 
-	versions := make(map[string]struct{})
-	wildcardVersionItems := make([]*m.ServiceConfigItem, 0, len(items))
+	allSkus := make(map[string]struct{})
+	allVersions := make(map[string]struct{})
+	wildcardVersionItems := make([]*m.ServiceConfigItem, 0, len(items)) // items with version as wildcard
+	wildcardVersionSkuItems := make([]*m.ServiceConfigItem, 0, len(items)) // items with version as wildcard and sku not a wildcard
+	versionToWildcardSkuItems := make(map[string][]*m.ServiceConfigItem, len(items)) // items with sku as wildcard
 
-	for _, item := range items {
+	for i, item := range items {
 
 		cfgKey := strings.ToLower(item.GetConfigKey())
 		cfgValue := item.GetConfigValue()
@@ -339,45 +382,74 @@ func (cfgMgr *CassandraConfigManager) mkKVTreeForSvc(service string, items []*m.
 			continue
 		}
 
-		versions[version] = struct{}{}
+		if sku != wildcardToken && host != wildcardToken {
+			key := strings.Join([]string{service,version, sku, host,cfgKey}, ".")
+			sku = wildcardToken
+			items[i].Sku = common.StringPtr(wildcardToken)
+			cfgMgr.logger.WithField(key, cfgValue).Warn("Forcing sku=*;host specific items MUST be sku agnostic")
+		}
+
+		allSkus[sku] = struct{}{}
+		allVersions[version] = struct{}{}
 
 		if version == wildcardToken {
 			if sku == wildcardToken {
-				if host != wildcardToken {
-					// when hostname is present, we always expect the sku
-					// this is an invariant for the hierarchial config store
-					cfgMgr.logger.Errorf("Skipping illegal config item with wildcard sku, item=%v", item)
+				if host == wildcardToken {
+					// service.*.*.*.key, add it at the root level
+					root.keyValues[cfgKey] = cfgValue
 					continue
 				}
-				// service.*.*.*.key, add it at the root level
-				root.keyValues[cfgKey] = cfgValue
+				// 1(a) keep track of svc.* config items
+				wildcardVersionItems = append(wildcardVersionItems, item)
 				continue
 			}
-			// keep track of service.* wildcards separtely
-			// they are the defaults for all service.version.*
-			wildcardVersionItems = append(wildcardVersionItems, item)
+			// 1(b) Keep track of svc.*.sku config items
+			wildcardVersionSkuItems = append(wildcardVersionSkuItems, item)
+			continue
+		}
+
+		if sku == wildcardToken {
+			defaults, ok := versionToWildcardSkuItems[version]
+			if !ok {
+				defaults = make([]*m.ServiceConfigItem, 0, 4)
+				versionToWildcardSkuItems[version] = defaults
+			}
+			// 1(c) keep track of svc.ver.* items
+			versionToWildcardSkuItems[version] = append(defaults, item)
 			continue
 		}
 
 		addToKVTree(root, version, sku, host, cfgKey, cfgValue)
 	}
 
-	// now apply the wildcarded version items for every
-	// version that we know of, including the wildcard
+	// apply svc.ver.* items as default for every svc.ver.sku
+	for ver, items := range versionToWildcardSkuItems {
+		for _, item := range items {
+			for s := range allSkus {
+				addToKVTree(root, ver, s, item.GetHostname(), item.GetConfigKey(), item.GetConfigValue())
+			}
+		}
+	}
+
+	// apply svc.*.sku. items as default for every svc.ver.sku items
+	for _, item := range wildcardVersionSkuItems {
+		for ver := range allVersions {
+			addToKVTree(root, ver, item.GetSku(), item.GetHostname(), item.GetConfigKey(), item.GetConfigValue())
+		}
+	}
+
+	// apply svc.*. items as default for every svc.ver.*
 	for _, item := range wildcardVersionItems {
-
-		sku := item.GetSku()
-		host := item.GetHostname()
-		cfgKey := item.GetConfigKey()
-		cfgValue := item.GetConfigValue()
-
-		for ver := range versions {
-			addToKVTree(root, ver, sku, host, cfgKey, cfgValue)
+ 		for ver := range allVersions {
+			for sku := range allSkus {
+				addToKVTree(root, ver, sku, item.GetHostname(), item.GetConfigKey(), item.GetConfigValue())
+			}
 		}
 	}
 
 	return root
 }
+
 
 // mkConfig constructs a config object of given type using the
 // values from the given set of key,value strings. If the given
@@ -455,7 +527,7 @@ func addToKVTree(root *kvTreeNode, version, sku, host, cfgKey, cfgValue string) 
 
 	var maxDepth = 1 // max depth of tree to traverse
 
-	if sku != wildcardToken {
+	if sku != wildcardToken || host != wildcardToken {
 		maxDepth++
 		if host != wildcardToken {
 			maxDepth++
@@ -492,6 +564,7 @@ func setIntField(field reflect.Value, fieldName string, keyValues map[string]str
 			return
 		}
 	}
+	fmt.Printf("Using default value for fieldName=%v defaultStr=%v\n", fieldName, defaultStr)
 	if defaultVal.IsValid() {
 		field.Set(defaultVal)
 		return

--- a/common/dconfig/configmgr.go
+++ b/common/dconfig/configmgr.go
@@ -226,18 +226,6 @@ func (cfgMgr *CassandraConfigManager) runLoop() {
 	cfgMgr.logger.Info("Config refresher stopped")
 }
 
-func printConfigTree(tree *configTreeNode, keys []string, idx int) {
-
-	key := strings.Join(keys, ".")
-	fmt.Printf("key=%v %+v\n", key, tree.value)
-
-	for k,v := range tree.children {
-		keys[idx] = k
-		printConfigTree(v, keys, idx+1)
-		keys[idx] = "*"
-	}
-}
-
 // Get returns the config value that best matches the given
 // input criteria. svc param cannot be empty.
 func (cfgMgr *CassandraConfigManager) Get(svc string, version string, sku string, host string) (interface{}, error) {
@@ -318,7 +306,6 @@ func (cfgMgr *CassandraConfigManager) mkConfigTree(inputKVTree *kvTree) *configT
 	for k, v := range cfgMgr.configTypes {
 		tree := inputKVTree.children[k]
 		result.children[k] = cfgMgr.mkConfigTreeForSvc(v, nil, tree)
-		printConfigTree(result.children[k], []string{k, "*", "*", "*"}, 1)
 	}
 
 	return result

--- a/common/dconfig/configmgr_test.go
+++ b/common/dconfig/configmgr_test.go
@@ -122,6 +122,11 @@ func (s *ConfigManagerTestSuite) TestConfigOverrides() {
 		SliceItem   []string `name:"slice-set" default:"a,b,c"`
 	}
 
+	type testOutputConfig1 struct {
+		CacheSizeBytes int64 	`name:"cache-size-bytes" default:"1024"`
+		AdminStatus    string   `name:"admin-status" default:"enabled"`
+	}
+
 	cfgItems := []m.ServiceConfigItem{
 		{ServiceName: strp("input"), ServiceVersion: strp("*"), Sku: strp("*"), Hostname: strp("*"), ConfigKey: strp("max-extents"), ConfigValue: strp("100")},
 		{ServiceName: strp("input"), ServiceVersion: strp("*"), Sku: strp("*"), Hostname: strp("*"), ConfigKey: strp("max-conns"), ConfigValue: strp("1000")},
@@ -135,6 +140,11 @@ func (s *ConfigManagerTestSuite) TestConfigOverrides() {
 		{ServiceName: strp("store"), ServiceVersion: strp("*"), Sku: strp("*"), Hostname: strp("*"), ConfigKey: strp("max-outconns"), ConfigValue: strp("1000")},
 		{ServiceName: strp("store"), ServiceVersion: strp("*"), Sku: strp("*"), Hostname: strp("*"), ConfigKey: strp("camelcase"), ConfigValue: strp("normalize")}, // intentionally use a normalized key to set in cassandra
 		{ServiceName: strp("store"), ServiceVersion: strp("*"), Sku: strp("*"), Hostname: strp("*"), ConfigKey: strp("slice-set"), ConfigValue: strp("Z")},
+		{ServiceName: strp("output"), ServiceVersion: strp("*"), Sku: strp("*"), Hostname: strp("cherami22"), ConfigKey: strp("admin-status"), ConfigValue: strp("disabled")},
+		{ServiceName: strp("output"), ServiceVersion: strp("*"), Sku: strp("*"), Hostname: strp("*"), ConfigKey: strp("cache-size-bytes"), ConfigValue: strp("10000")},
+		{ServiceName: strp("output"), ServiceVersion: strp("*"), Sku: strp("haswell"), Hostname: strp("*"), ConfigKey: strp("cache-size-bytes"), ConfigValue: strp("20000")},
+		{ServiceName: strp("output"), ServiceVersion: strp("v2"), Sku: strp("*"), Hostname: strp("*"), ConfigKey: strp("cache-size-bytes"), ConfigValue: strp("15000")},
+		{ServiceName: strp("output"), ServiceVersion: strp("v2"), Sku: strp("skylake"), Hostname: strp("*"), ConfigKey: strp("cache-size-bytes"), ConfigValue: strp("12000")},
 	}
 
 	for i, item := range cfgItems {
@@ -153,22 +163,27 @@ func (s *ConfigManagerTestSuite) TestConfigOverrides() {
 		output testStoreConfig1
 	}
 
+	type outputTestCase1 struct {
+		input  configGetterTestInput
+		output testOutputConfig1
+	}
+
 	inputTestCases := []inputTestCase1{
 		{configGetterTestInput{svc: "input"}, testInputConfig1{MaxConns: 1000, MaxExtents: 100, AdminStatus: "enabled"}},
 		{configGetterTestInput{svc: "input", sku: "whitesnake"}, testInputConfig1{MaxConns: 1000, MaxExtents: 150, AdminStatus: "enabled"}},
 		{configGetterTestInput{svc: "input", sku: "whitesnake", host: "cherami14"}, testInputConfig1{MaxConns: 1000, MaxExtents: 0, AdminStatus: "enabled"}},
 		{configGetterTestInput{svc: "input", vers: "v1"}, testInputConfig1{MaxConns: 1000, MaxExtents: 50, AdminStatus: "enabled"}},
-		{configGetterTestInput{svc: "input", vers: "v1", sku: "whitesnake"}, testInputConfig1{MaxConns: 1000, MaxExtents: 150, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "input", vers: "v1", sku: "whitesnake"}, testInputConfig1{MaxConns: 1000, MaxExtents: 50, AdminStatus: "enabled"}},
 		{configGetterTestInput{svc: "input", vers: "v1", sku: "whitesnake", host: "cherami14"}, testInputConfig1{MaxConns: 1000, MaxExtents: 0, AdminStatus: "enabled"}},
-		{configGetterTestInput{svc: "input", vers: "v1", sku: "m1.b ", host: "cherami15"}, testInputConfig1{MaxConns: 1000, MaxExtents: 50, AdminStatus: "enabled"}},
-		{configGetterTestInput{svc: "input", vers: "v1", sku: "m1.12", host: "cherami14"}, testInputConfig1{MaxConns: 1000, MaxExtents: 50, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "input", vers: "v1", sku: "m1.b ", host: "cherami15"}, testInputConfig1{MaxConns: 1000, MaxExtents: 1, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "input", vers: "v1", sku: "m1.12", host: "cherami14"}, testInputConfig1{MaxConns: 1000, MaxExtents: 0, AdminStatus: "enabled"}},
 		{configGetterTestInput{svc: "input", vers: "v1", sku: "k1.12"}, testInputConfig1{MaxConns: 1000, MaxExtents: 50, AdminStatus: "enabled"}},
 		{configGetterTestInput{svc: "input", vers: "v2"}, testInputConfig1{MaxConns: 1000, MaxExtents: 100, AdminStatus: "enabled"}},
 		{configGetterTestInput{svc: "input", vers: "v2", sku: "blackeye"}, testInputConfig1{MaxConns: 1000, MaxExtents: 200, AdminStatus: "enabled"}},
 		{configGetterTestInput{svc: "input", vers: "v2", sku: "blackeye", host: "cherami20"}, testInputConfig1{MaxConns: 1000, MaxExtents: 200, AdminStatus: "enabled"}},
 		{configGetterTestInput{svc: "input", vers: "v2", sku: "whitesnake"}, testInputConfig1{MaxConns: 1000, MaxExtents: 170, AdminStatus: "enabled"}},
 		{configGetterTestInput{svc: "input", vers: "v2", sku: "whitesnake", host: "cherami60"}, testInputConfig1{MaxConns: 1000, MaxExtents: 170, AdminStatus: "enabled"}},
-		{configGetterTestInput{svc: "input", vers: "v3", sku: "whitesnake", host: "cherami55"}, testInputConfig1{MaxConns: 1000, MaxExtents: 100, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "input", vers: "v3", sku: "whitesnake", host: "cherami55"}, testInputConfig1{MaxConns: 1000, MaxExtents: 150, AdminStatus: "enabled"}},
 		{configGetterTestInput{svc: "input", vers: "v3"}, testInputConfig1{MaxConns: 1000, MaxExtents: 100, AdminStatus: "enabled"}},
 	}
 
@@ -180,9 +195,27 @@ func (s *ConfigManagerTestSuite) TestConfigOverrides() {
 		{configGetterTestInput{svc: "store", vers: "v1", sku: "sku1", host: "host1"}, testStoreConfig1{MaxInConns: 2000, MaxOutConns: 1000, AdminStatus: "enabled", CamelCase: "normalize", SliceItem: []string{"Z"}}},
 	}
 
+	outputTestCases := []outputTestCase1{
+		{configGetterTestInput{svc: "output"}, testOutputConfig1{CacheSizeBytes:10000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", sku: "haswell"}, testOutputConfig1{CacheSizeBytes:20000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", vers: "v2"}, testOutputConfig1{CacheSizeBytes:15000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", vers: "v2", sku: "haswell"}, testOutputConfig1{CacheSizeBytes:15000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", vers: "v2", sku: "skylake"}, testOutputConfig1{CacheSizeBytes:12000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", vers: "v2", sku: "ivy"}, testOutputConfig1{CacheSizeBytes:15000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", vers: "v1", sku: "haswell"}, testOutputConfig1{CacheSizeBytes:20000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", vers: "v1", sku: "ivy"}, testOutputConfig1{CacheSizeBytes:10000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", host: "cherami22"}, testOutputConfig1{CacheSizeBytes:10000, AdminStatus: "disabled"}},
+		{configGetterTestInput{svc: "output", host: "cherami44"}, testOutputConfig1{CacheSizeBytes:10000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", vers: "v2", sku: "haswell", host: "cherami22"}, testOutputConfig1{CacheSizeBytes:15000, AdminStatus: "disabled"}},
+		{configGetterTestInput{svc: "output", vers: "v1", sku: "ivy", host: "cherami22"}, testOutputConfig1{CacheSizeBytes:10000, AdminStatus: "disabled"}},
+		{configGetterTestInput{svc: "output", sku: "haswell", host: "cherami22"}, testOutputConfig1{CacheSizeBytes:20000, AdminStatus: "disabled"}},
+		{configGetterTestInput{svc: "output", host: "cherami22"}, testOutputConfig1{CacheSizeBytes:10000, AdminStatus: "disabled"}},
+	}
+
 	configTypes := make(map[string]interface{})
 	configTypes["input"] = testInputConfig1{}
 	configTypes["store"] = testStoreConfig1{}
+	configTypes["output"] = testOutputConfig1{}
 
 	cfgMgrIface := NewCassandraConfigManager(s.cdb.GetClient(), configTypes, s.logger)
 	cfgMgr := cfgMgrIface.(*CassandraConfigManager)
@@ -192,13 +225,20 @@ func (s *ConfigManagerTestSuite) TestConfigOverrides() {
 		cfg, err := cfgMgr.Get(tc.input.svc, tc.input.vers, tc.input.sku, tc.input.host)
 		s.Nil(err, "configStore.Get() failed for input %v", i)
 		value := cfg.(testInputConfig1)
-		s.True(reflect.DeepEqual(tc.output, value), "Wrong output for input %v", i)
+		s.True(reflect.DeepEqual(tc.output, value), "Wrong output for input %v, output=%+v", i, value)
 	}
 
 	for i, tc := range storeTestCases {
 		cfg, err := cfgMgr.Get(tc.input.svc, tc.input.vers, tc.input.sku, tc.input.host)
 		s.Nil(err, "configStore.Get() failed for input %v", i)
 		value := cfg.(testStoreConfig1)
-		s.True(reflect.DeepEqual(tc.output, value), "Wrong output for input %v", i)
+		s.True(reflect.DeepEqual(tc.output, value), "Wrong output for input %v, output=%+v", i, value)
+	}
+
+	for i, tc := range outputTestCases {
+		cfg, err := cfgMgr.Get(tc.input.svc, tc.input.vers, tc.input.sku, tc.input.host)
+		s.Nil(err, "configStore.Get() failed for input %v", i)
+		value := cfg.(testOutputConfig1)
+		s.True(reflect.DeepEqual(tc.output, value), "Wrong output for input %v, output=%+v", i, value)
 	}
 }

--- a/common/dconfig/configmgr_test.go
+++ b/common/dconfig/configmgr_test.go
@@ -123,8 +123,8 @@ func (s *ConfigManagerTestSuite) TestConfigOverrides() {
 	}
 
 	type testOutputConfig1 struct {
-		CacheSizeBytes int64 	`name:"cache-size-bytes" default:"1024"`
-		AdminStatus    string   `name:"admin-status" default:"enabled"`
+		CacheSizeBytes int64  `name:"cache-size-bytes" default:"1024"`
+		AdminStatus    string `name:"admin-status" default:"enabled"`
 	}
 
 	cfgItems := []m.ServiceConfigItem{
@@ -196,20 +196,20 @@ func (s *ConfigManagerTestSuite) TestConfigOverrides() {
 	}
 
 	outputTestCases := []outputTestCase1{
-		{configGetterTestInput{svc: "output"}, testOutputConfig1{CacheSizeBytes:10000, AdminStatus: "enabled"}},
-		{configGetterTestInput{svc: "output", sku: "haswell"}, testOutputConfig1{CacheSizeBytes:20000, AdminStatus: "enabled"}},
-		{configGetterTestInput{svc: "output", vers: "v2"}, testOutputConfig1{CacheSizeBytes:15000, AdminStatus: "enabled"}},
-		{configGetterTestInput{svc: "output", vers: "v2", sku: "haswell"}, testOutputConfig1{CacheSizeBytes:15000, AdminStatus: "enabled"}},
-		{configGetterTestInput{svc: "output", vers: "v2", sku: "skylake"}, testOutputConfig1{CacheSizeBytes:12000, AdminStatus: "enabled"}},
-		{configGetterTestInput{svc: "output", vers: "v2", sku: "ivy"}, testOutputConfig1{CacheSizeBytes:15000, AdminStatus: "enabled"}},
-		{configGetterTestInput{svc: "output", vers: "v1", sku: "haswell"}, testOutputConfig1{CacheSizeBytes:20000, AdminStatus: "enabled"}},
-		{configGetterTestInput{svc: "output", vers: "v1", sku: "ivy"}, testOutputConfig1{CacheSizeBytes:10000, AdminStatus: "enabled"}},
-		{configGetterTestInput{svc: "output", host: "cherami22"}, testOutputConfig1{CacheSizeBytes:10000, AdminStatus: "disabled"}},
-		{configGetterTestInput{svc: "output", host: "cherami44"}, testOutputConfig1{CacheSizeBytes:10000, AdminStatus: "enabled"}},
-		{configGetterTestInput{svc: "output", vers: "v2", sku: "haswell", host: "cherami22"}, testOutputConfig1{CacheSizeBytes:15000, AdminStatus: "disabled"}},
-		{configGetterTestInput{svc: "output", vers: "v1", sku: "ivy", host: "cherami22"}, testOutputConfig1{CacheSizeBytes:10000, AdminStatus: "disabled"}},
-		{configGetterTestInput{svc: "output", sku: "haswell", host: "cherami22"}, testOutputConfig1{CacheSizeBytes:20000, AdminStatus: "disabled"}},
-		{configGetterTestInput{svc: "output", host: "cherami22"}, testOutputConfig1{CacheSizeBytes:10000, AdminStatus: "disabled"}},
+		{configGetterTestInput{svc: "output"}, testOutputConfig1{CacheSizeBytes: 10000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", sku: "haswell"}, testOutputConfig1{CacheSizeBytes: 20000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", vers: "v2"}, testOutputConfig1{CacheSizeBytes: 15000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", vers: "v2", sku: "haswell"}, testOutputConfig1{CacheSizeBytes: 15000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", vers: "v2", sku: "skylake"}, testOutputConfig1{CacheSizeBytes: 12000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", vers: "v2", sku: "ivy"}, testOutputConfig1{CacheSizeBytes: 15000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", vers: "v1", sku: "haswell"}, testOutputConfig1{CacheSizeBytes: 20000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", vers: "v1", sku: "ivy"}, testOutputConfig1{CacheSizeBytes: 10000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", host: "cherami22"}, testOutputConfig1{CacheSizeBytes: 10000, AdminStatus: "disabled"}},
+		{configGetterTestInput{svc: "output", host: "cherami44"}, testOutputConfig1{CacheSizeBytes: 10000, AdminStatus: "enabled"}},
+		{configGetterTestInput{svc: "output", vers: "v2", sku: "haswell", host: "cherami22"}, testOutputConfig1{CacheSizeBytes: 15000, AdminStatus: "disabled"}},
+		{configGetterTestInput{svc: "output", vers: "v1", sku: "ivy", host: "cherami22"}, testOutputConfig1{CacheSizeBytes: 10000, AdminStatus: "disabled"}},
+		{configGetterTestInput{svc: "output", sku: "haswell", host: "cherami22"}, testOutputConfig1{CacheSizeBytes: 20000, AdminStatus: "disabled"}},
+		{configGetterTestInput{svc: "output", host: "cherami22"}, testOutputConfig1{CacheSizeBytes: 10000, AdminStatus: "disabled"}},
 	}
 
 	configTypes := make(map[string]interface{})

--- a/common/rpm.go
+++ b/common/rpm.go
@@ -507,7 +507,7 @@ func (rpm *ringpopMonitorImpl) refresh(service string, currInfo *membershipInfo)
 				continue
 			}
 
-			v.Name = names[0] // cache hostname to avoid dns reverse lookup
+			v.Name = strings.Split(names[0], ".")[0] // cache hostname to avoid dns reverse lookup
 
 			hwInfo, err := rpm.hwInfoReader.Read(names[0])
 			if err != nil {


### PR DESCRIPTION
Currently, the cassandra backed dynamic config manager has some assumptions about how wildcards are processed. Every config item handled by the configMgr is of the form:

serviceName.serviceVersion.sku.host.key=value

And as you go towards the right, the rules get more specific and the longest matching rule wins. However, with the current code, wildcards are not really fully supported. The configMgr assumes it will always be dealing with all the params i.e. {name,version,sku,host}.

This patch does the following

Makes the configMgr support wildcards fully
Modifies rpm to truncate hostnames after the first period

This diff supersedes #88 