### PR TITLE
Add graceful drain of extents on inputhost

### DIFF
--- a/clients/inputhost/client.go
+++ b/clients/inputhost/client.go
@@ -74,7 +74,7 @@ func (s *InClientImpl) UnloadDestinations(req *admin.UnloadDestinationsRequest) 
 }
 
 // ListLoadedDestinations lists all the loaded destinations from the inputhost
-func (s *InClientImpl) ListLoadedDestinations() (*admin.ListDestinationsResult_, error) {
+func (s *InClientImpl) ListLoadedDestinations() (*admin.ListLoadedDestinationsResult_, error) {
 	ctx, cancel := tcthrift.NewContext(defaultThriftTimeout)
 	defer cancel()
 

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -242,6 +242,8 @@ const (
 	ListLoadedDestinationsScope
 	// ReadDestStateScope represents ReadDestState API
 	ReadDestStateScope
+	// DrainExtentsScope represents DrainExtentsScope API
+	DrainExtentsScope
 
 	// -- Operation scopes for OutputHost --
 
@@ -526,6 +528,7 @@ var scopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		UnloadDestinationsScope:       {operation: "UnloadDestinations"},
 		ListLoadedDestinationsScope:   {operation: "ListLoadedDestinations"},
 		ReadDestStateScope:            {operation: "ReadDestState"},
+		DrainExtentsScope:             {operation: "DrainExtentsScope"},
 	},
 
 	// Outputhost operation tag values as seen by the Metrics backend
@@ -564,12 +567,12 @@ var scopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		ReplicatorUpdateRmtDestScope:     {operation: "ReplicatorUpdateRemoteDestination"},
 		ReplicatorDeleteDestScope:        {operation: "ReplicatorDeleteDestination"},
 		ReplicatorDeleteRmtDestScope:     {operation: "ReplicatorDeleteRemoteDestination"},
-		ReplicatorCreateCgUUIDScope:    {operation: "ReplicatorCreateConsumerGroupUUID"},
-		ReplicatorCreateRmtCgUUIDScope: {operation: "ReplicatorCreateRemoteConsumerGroupUUID"},
-		ReplicatorUpdateCgScope:        {operation: "ReplicatorUpdateConsumerGroup"},
-		ReplicatorUpdateRmtCgScope:     {operation: "ReplicatorUpdateRemoteConsumerGroup"},
-		ReplicatorDeleteCgScope:        {operation: "ReplicatorDeleteConsumerGroup"},
-		ReplicatorDeleteRmtCgScope:     {operation: "ReplicatorDeleteRemoteConsumerGroup"},
+		ReplicatorCreateCgUUIDScope:      {operation: "ReplicatorCreateConsumerGroupUUID"},
+		ReplicatorCreateRmtCgUUIDScope:   {operation: "ReplicatorCreateRemoteConsumerGroupUUID"},
+		ReplicatorUpdateCgScope:          {operation: "ReplicatorUpdateConsumerGroup"},
+		ReplicatorUpdateRmtCgScope:       {operation: "ReplicatorUpdateRemoteConsumerGroup"},
+		ReplicatorDeleteCgScope:          {operation: "ReplicatorDeleteConsumerGroup"},
+		ReplicatorDeleteRmtCgScope:       {operation: "ReplicatorDeleteRemoteConsumerGroup"},
 		ReplicatorCreateExtentScope:      {operation: "ReplicatorCreateExtent"},
 		ReplicatorCreateRmtExtentScope:   {operation: "ReplicatorCreateRemoteExtent"},
 		ReplicatorReconcileScope:         {operation: "ReplicatorReconcile"},
@@ -1185,9 +1188,9 @@ var metricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ReplicatorReconcileDestRun:                              {Gauge, "replicator.reconcile.dest.run"},
 		ReplicatorReconcileDestFail:                             {Gauge, "replicator.reconcile.dest.fail"},
 		ReplicatorReconcileDestFoundMissing:                     {Gauge, "replicator.reconcile.dest.foundmissing"},
-		ReplicatorReconcileCgRun:                              {Gauge, "replicator.reconcile.cg.run"},
-		ReplicatorReconcileCgFail:                             {Gauge, "replicator.reconcile.cg.fail"},
-		ReplicatorReconcileCgFoundMissing:                     {Gauge, "replicator.reconcile.cg.foundmissing"},
+		ReplicatorReconcileCgRun:                                {Gauge, "replicator.reconcile.cg.run"},
+		ReplicatorReconcileCgFail:                               {Gauge, "replicator.reconcile.cg.fail"},
+		ReplicatorReconcileCgFoundMissing:                       {Gauge, "replicator.reconcile.cg.foundmissing"},
 		ReplicatorReconcileDestExtentRun:                        {Gauge, "replicator.reconcile.destextent.run"},
 		ReplicatorReconcileDestExtentFail:                       {Gauge, "replicator.reconcile.destextent.fail"},
 		ReplicatorReconcileDestExtentFoundMissing:               {Gauge, "replicator.reconcile.destextent.foundmissing"},

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 95f30a537dc5b2841e061722d66e26c58126e82c19e9ba29bb6b0f44cf1741d0
-updated: 2017-03-20T09:58:47.035659706-07:00
+hash: 37ad4a312e79f56cf5a130eacc6eb419da660e4c3bfa5faba392bcdb2c8376a1
+updated: 2017-03-27T11:00:26.129498321-07:00
 imports:
 - name: github.com/apache/thrift
   version: b2a4d4ae21c789b689dd162deb819665567f481c
@@ -113,7 +113,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: 959013313a26bbb974e23286ef4b9991fde4947b
+  version: 0ede83064ff6495044ab7901d0d215d713d76940
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/glide.yaml
+++ b/glide.yaml
@@ -34,6 +34,7 @@ import:
   - common/websocket
   - stream
 - package: github.com/uber/cherami-thrift
+  version: graceful_drain
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/services/controllerhost/event_pipeline_test.go
+++ b/services/controllerhost/event_pipeline_test.go
@@ -732,10 +732,14 @@ func (service *MockInputOutputService) UnloadDestinations(ctx thrift.Context, re
 	return fmt.Errorf("mock not implemented")
 }
 
-func (service *MockInputOutputService) ListLoadedDestinations(ctx thrift.Context) (*admin.ListDestinationsResult_, error) {
+func (service *MockInputOutputService) ListLoadedDestinations(ctx thrift.Context) (*admin.ListLoadedDestinationsResult_, error) {
 	return nil, fmt.Errorf("mock not implemented")
 }
 
 func (service *MockInputOutputService) ReadDestState(ctx thrift.Context, req *admin.ReadDestinationStateRequest) (*admin.ReadDestinationStateResult_, error) {
 	return nil, fmt.Errorf("mock not implemented")
+}
+
+func (service *MockInputOutputService) DrainExtent(ctx thrift.Context, req *admin.DrainExtentsRequest) error {
+	return fmt.Errorf("mock not implemented")
 }

--- a/services/inputhost/inputhost_test.go
+++ b/services/inputhost/inputhost_test.go
@@ -1252,6 +1252,104 @@ func (s *InputHostSuite) TestInputExtHostSizeLimit() {
 	inputHost.Shutdown()
 }
 
+func (s *InputHostSuite) TestInputExtHostDrain() {
+	destinationPath := "foo"
+
+	// setup mockService here to use the mock admin controller client
+	ch, _ := tchannel.NewChannel("cherami-test-drain-in", nil)
+	mockService := new(common.MockService)
+	mockService.On("GetConfig").Return(s.cfg.GetServiceConfig(common.InputServiceName))
+	mockService.On("GetMetricsReporter").Return(common.NewMetricReporterWithHostname(configure.NewCommonServiceConfig()))
+	mockService.On("GetDConfigClient").Return(dconfig.NewDconfigClient(configure.NewCommonServiceConfig(), common.InputServiceName))
+	mockService.On("GetTChannel").Return(ch)
+	mockService.On("IsLimitsEnabled").Return(true)
+	mockService.On("GetHostConnLimit").Return(100)
+	mockService.On("GetHostConnLimitPerSecond").Return(100)
+	mockService.On("GetWSConnector").Return(s.mockWSConnector, nil)
+
+	mockAdminC := &mockAdminController{}
+	mockClientFactory := new(mockcommon.MockClientFactory)
+	mockClientFactory.On("GetThriftStoreClient", mock.Anything, mock.Anything).Return(store.TChanBStore(s.mockStore), nil)
+	mockClientFactory.On("ReleaseThriftStoreClient", mock.Anything).Return(nil)
+	mockClientFactory.On("GetAdminControllerClient").Return(mockAdminC, nil)
+	mockService.On("GetClientFactory").Return(mockClientFactory)
+
+	mockLoadReporterDaemonFactory := setupMockLoadReporterDaemonFactory()
+	mockService.On("GetLoadReporterDaemonFactory").Return(mockLoadReporterDaemonFactory)
+	mockService.On("GetHostUUID").Return("99999999-9999-9999-9999-999999999999")
+	mockService.On("GetRingpopMonitor").Return(s.mockRpm)
+
+	inputHost, _ := NewInputHost("inputhost-test", mockService, s.mockMeta, nil)
+	ctx, cancel := utilGetThriftContextWithPath(destinationPath)
+	defer cancel()
+
+	msg := cherami.NewPutMessage()
+	msg.ID = common.StringPtr(strconv.Itoa(1))
+	msg.Data = []byte(fmt.Sprintf("hello"))
+
+	wCh := make(chan time.Time)
+
+	s.mockAppend.On("Read").Return(nil, io.EOF).WaitUntil(wCh)
+	s.mockAppend.On("Write", mock.Anything).Return(io.EOF).WaitUntil(wCh)
+	s.mockPub.On("Read").Return(nil, io.EOF).WaitUntil(wCh)
+	s.mockPub.On("Write", mock.Anything).Return(io.EOF).WaitUntil(wCh)
+
+	aMsg := store.NewAppendMessageAck()
+	aMsg.Status = common.CheramiStatusPtr(cherami.Status_OK)
+	aMsg.Address = common.Int64Ptr(int64(100))
+
+	putMsgCh := make(chan *inPutMessage, 1)
+	ackChannel := make(chan *cherami.PutMessageAck, 1)
+
+	go func() {
+		inputHost.OpenPublisherStream(ctx, s.mockPub)
+	}()
+
+	time.Sleep(1 * time.Second)
+
+	// 3. Make sure we just have one extent
+	var connection *extHost
+	pathCache, ok := inputHost.getPathCacheByDestPath("foo")
+	s.True(ok)
+	pathCache.Lock()
+	s.Equal(1, len(pathCache.extentCache))
+	for _, extCache := range pathCache.extentCache {
+		connection = extCache.connection
+	}
+	pathCache.Unlock()
+
+	inMsg := &inPutMessage{
+		putMsg:      msg,
+		putMsgAckCh: ackChannel,
+	}
+	putMsgCh <- inMsg
+
+	// send a drain request
+	req := admin.NewDrainExtentsRequest()
+	req.UpdateUUID = common.StringPtr(uuid.New())
+
+	drainReq := admin.NewDrainExtents()
+	drainReq.DestinationUUID = common.StringPtr(pathCache.destUUID)
+	drainReq.ExtentUUID = common.StringPtr(connection.extUUID)
+	req.Extents = append(req.Extents, drainReq)
+
+	err := inputHost.DrainExtent(ctx, req)
+	s.NoError(err)
+
+	drained := false
+	select {
+	case <-connection.closeChannel:
+		drained = true
+	case <-time.After(5 * time.Second):
+	}
+
+	s.Equal(true, drained)
+	close(wCh)
+	close(connection.forceUnloadCh)
+	connection.close()
+	inputHost.Shutdown()
+}
+
 func setupMockLoadReporterDaemonFactory() *common.MockLoadReporterDaemonFactory {
 	mockLoadReporterDaemonFactory := new(common.MockLoadReporterDaemonFactory)
 	mockLoadReporterDaemon := new(common.MockLoadReporterDaemon)

--- a/services/inputhost/pathCache.go
+++ b/services/inputhost/pathCache.go
@@ -508,3 +508,16 @@ func (pathCache *inPathCache) getState() *admin.DestinationState {
 
 	return destState
 }
+
+func (pathCache *inPathCache) drainExtent(extUUID string) error {
+	pathCache.RLock()
+	defer pathCache.RUnlock()
+
+	extCache, ok := pathCache.extentCache[extentUUID(extUUID)]
+	if !ok {
+		return &cherami.EntityNotExistsError{}
+	}
+
+	go extCache.connection.drain()
+	return nil
+}


### PR DESCRIPTION
This patch simply implements the graceful drain on inputhost without any client side involvement.
Whenever an inputhost gets a graceful drain request, it
does the following:
(1) Marks the extent as draining and stops the writepump and waits
    for the write pump to drain (for a timeout period)
(2) On the read pump if we have drained all the messages, then we
    can safely close the extent and go away.

A couple of caveats:
1. Note: close is idempotent and so we should be able to force close
   an extent anytime during the drain process.
2. We just need the RLock() during read pump aggregation and since it
   is not contended the profiling of inputhost didn't reveal it to be
   at top.

Also add a unit test for the same.