### PR TITLE
controller: added support to drain extent before sealing

### DIFF
--- a/clients/inputhost/client.go
+++ b/clients/inputhost/client.go
@@ -74,7 +74,7 @@ func (s *InClientImpl) UnloadDestinations(req *admin.UnloadDestinationsRequest) 
 }
 
 // ListLoadedDestinations lists all the loaded destinations from the inputhost
-func (s *InClientImpl) ListLoadedDestinations() (*admin.ListDestinationsResult_, error) {
+func (s *InClientImpl) ListLoadedDestinations() (*admin.ListLoadedDestinationsResult_, error) {
 	ctx, cancel := tcthrift.NewContext(defaultThriftTimeout)
 	defer cancel()
 

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -926,6 +926,8 @@ const (
 	ControllerErrBadRequestCounter
 	// ControllerErrBadEntityCounter indicates either an entity not exists or disabled error
 	ControllerErrBadEntityCounter
+	// ControllerErrDrainFailed indicates that a drain command issued to input failed
+	ControllerErrDrainFailed
 
 	// ControllerEventsDropped indicates an event drop due to queue full
 	ControllerEventsDropped
@@ -1158,6 +1160,7 @@ var metricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ControllerErrNoRetryWorkers:                {Counter, "controller.errors.no-retry-workers"},
 		ControllerErrBadRequestCounter:             {Counter, "controller.errors.bad-requests"},
 		ControllerErrBadEntityCounter:              {Counter, "controller.errors.bad-entity"},
+		ControllerErrDrainFailed:                   {Counter, "controller.errors.drain-failed"},
 		ControllerEventsDropped:                    {Counter, "controller.events-dropped"},
 		ControllerRequests:                         {Counter, "controller.requests"},
 		ControllerFailures:                         {Counter, "controller.errors"},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -244,6 +244,8 @@ const (
 	ListLoadedDestinationsScope
 	// ReadDestStateScope represents ReadDestState API
 	ReadDestStateScope
+	// DrainExtentsScope represents DrainExtentsScope API
+	DrainExtentsScope
 
 	// -- Operation scopes for OutputHost --
 
@@ -528,6 +530,7 @@ var scopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		UnloadDestinationsScope:       {operation: "UnloadDestinations"},
 		ListLoadedDestinationsScope:   {operation: "ListLoadedDestinations"},
 		ReadDestStateScope:            {operation: "ReadDestState"},
+		DrainExtentsScope:             {operation: "DrainExtentsScope"},
 	},
 
 	// Outputhost operation tag values as seen by the Metrics backend

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 95f30a537dc5b2841e061722d66e26c58126e82c19e9ba29bb6b0f44cf1741d0
-updated: 2017-03-20T09:58:47.035659706-07:00
+updated: 2017-03-31T16:09:33.820595835-07:00
 imports:
 - name: github.com/apache/thrift
   version: b2a4d4ae21c789b689dd162deb819665567f481c
@@ -68,7 +68,7 @@ imports:
 - name: github.com/golang/snappy
   version: d7b1e156f50d3c4664f683603af70e3e47fa0aa2
 - name: github.com/gorilla/websocket
-  version: c36f2fe5c330f0ac404b616b96c438b8616b1aaf
+  version: 3ab3a8b8831546bd18fd182c20687ca853b2bb13
 - name: github.com/hailocab/go-hostpool
   version: e80d13ce29ede4452c43dea11e79b9bc8a15b478
 - name: github.com/jmespath/go-jmespath
@@ -104,7 +104,7 @@ imports:
 - name: github.com/uber-go/atomic
   version: 3b8db5e93c4c02efbc313e17b2e796b0914a01fb
 - name: github.com/uber/cherami-client-go
-  version: 1ef6560c59eeb170f2381c02287ca44a5c50a523
+  version: de07d3a434a354d72c5cea1c6afd40d9d26c62f3
   subpackages:
   - client/cherami
   - common
@@ -113,7 +113,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: 3fecab6f4e017bf30308fb4104e8c944f2a2bb81
+  version: 8cf6af068f1f1afd930c6a43ecdd9d0dca2289d5
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/services/controllerhost/event_handlers.go
+++ b/services/controllerhost/event_handlers.go
@@ -95,6 +95,7 @@ type (
 		sealSeq  int64
 		dstID    string
 		extentID string
+		inputID  string
 		storeIDs []string
 	}
 
@@ -140,6 +141,7 @@ type (
 // ExtentDownEvent States
 const (
 	checkPreconditionState = iota
+	drainExtentState
 	sealExtentState
 	updateMetadataState
 	doneState
@@ -148,6 +150,9 @@ const (
 // how long from now are we willing to wait
 // for the cache to refresh itself ?
 const resultCacheRefreshMaxWaitTime = int64(500 * time.Millisecond)
+
+// how long to wait for an input host to respond to a drain command
+const drainExtentTimeout = time.Minute
 
 var (
 	sealExtentInitialCallTimeout = 2 * time.Second
@@ -814,7 +819,12 @@ func (event *ExtentDownEvent) Handle(context *Context) error {
 				}).Error("Cannot read extent stats")
 				return errRetryable
 			}
+			event.inputID = stats.GetExtent().GetInputHostUUID()
 			event.storeIDs = stats.GetExtent().GetStoreUUIDs()
+			event.state = drainExtentState
+
+		case drainExtentState:
+			drainExtent(context, event.dstID, event.extentID, event.inputID)
 			event.state = sealExtentState
 
 		case sealExtentState:
@@ -1035,7 +1045,8 @@ func reconfigureAllConsumers(context *Context, dstID, extentID, reason, reasonCo
 func createExtentDownEvents(context *Context, stats []*shared.ExtentStats) {
 	for _, stat := range stats {
 		if !common.IsRemoteZoneExtent(stat.GetExtent().GetOriginZone(), context.localZone) {
-			addExtentDownEvent(context, 0, stat.GetExtent().GetDestinationUUID(), stat.GetExtent().GetExtentUUID())
+			extent := stat.GetExtent()
+			addExtentDownEvent(context, 0, extent.GetDestinationUUID(), extent.GetExtentUUID())
 		}
 	}
 }
@@ -1089,6 +1100,38 @@ func sealExtentOnStore(context *Context, storeUUID string, storeAddr string, ext
 		}).Error("Sealing extent failed on store, retries exceeded")
 	}
 	return err
+}
+
+// drainExtent sends a drain command to input host to gracefully
+// drain the clients connected to a given extent. If the input
+// host is not alive in ringpop, this method will return immediately
+func drainExtent(context *Context, dstID string, extentID string, inputID string) {
+	addr, err := context.rpm.ResolveUUID(common.InputServiceName, inputID)
+	if err != nil {
+		return
+	}
+	adminClient, err := common.CreateInputHostAdminClient(context.channel, addr)
+	if err != nil {
+		context.log.WithField(common.TagErr, err).Error(`drainExtent: failed to create input host client`)
+		return
+	}
+	drainExtentInfo := &admin.DrainExtents{
+		DestinationUUID: common.StringPtr(dstID),
+		ExtentUUID:      common.StringPtr(extentID),
+	}
+	drainReq := &admin.DrainExtentsRequest{
+		UpdateUUID: common.StringPtr(uuid.New()),
+		Extents:    []*admin.DrainExtents{drainExtentInfo},
+	}
+	context.log.WithFields(bark.Fields{
+		common.TagDst: common.FmtDst(dstID),
+		common.TagExt: common.FmtExt(extentID),
+		`reconfigID`:  drainReq.GetUpdateUUID(),
+	}).Info(`sending drain command to input host`)
+
+	ctx, cancel := thrift.NewContext(drainExtentTimeout)
+	adminClient.DrainExtent(ctx, drainReq)
+	cancel()
 }
 
 func createRetryPolicy(initial time.Duration, max time.Duration, expiry time.Duration, maxAttempts int) backoff.RetryPolicy {

--- a/services/controllerhost/event_pipeline_test.go
+++ b/services/controllerhost/event_pipeline_test.go
@@ -377,6 +377,18 @@ func (s *EventPipelineSuite) TestInputHostFailedEvent() {
 
 	rpm := common.NewMockRingpopMonitor()
 
+	inputs := make([]*MockInputOutputService, len(inHostIDs))
+	for i := 0; i < len(inHostIDs); i++ {
+		inputs[i] = NewMockInputOutputService(common.InputServiceName)
+		thriftService := admin.NewTChanInputHostAdminServer(inputs[i])
+		inputs[i].Start(common.InputServiceName, thriftService)
+		rpm.Add(common.InputServiceName, inHostIDs[i], inputs[i].hostPort)
+	}
+
+	for _, e := range extentIDs {
+		inputs[0].failDrainExtentFor(e)
+	}
+
 	stores := make([]*MockStoreService, len(storeIDs))
 	for i := 0; i < len(storeIDs); i++ {
 		stores[i] = NewMockStoreService()
@@ -395,6 +407,15 @@ func (s *EventPipelineSuite) TestInputHostFailedEvent() {
 			succ := true
 			for j := 0; j < len(storeIDs); j++ {
 				if !stores[j].isSealed(extentIDs[i]) {
+					succ = false
+					break
+				}
+			}
+			if !succ {
+				return false
+			}
+			for j := 0; j < len(inHostIDs); j++ {
+				if inputs[j].drainExtentsRcvdFor(extentIDs[j]) != 1 {
 					succ = false
 					break
 				}
@@ -651,18 +672,22 @@ func (service *MockStoreService) isExtentReReplicated(extentID string) bool {
 }
 
 type MockInputOutputService struct {
-	name             string
-	server           *thrift.Server
-	ch               *tchannel.Channel
-	hostPort         string
-	mu               sync.Mutex
-	keyToUpdateCount map[string]int
+	name                  string
+	server                *thrift.Server
+	ch                    *tchannel.Channel
+	hostPort              string
+	mu                    sync.Mutex
+	keyToUpdateCount      map[string]int
+	drainExtentsRcvdCount map[string]int
+	drainExtentsToFail    map[string]struct{}
 }
 
 func NewMockInputOutputService(name string) *MockInputOutputService {
 	return &MockInputOutputService{
-		name:             name,
-		keyToUpdateCount: make(map[string]int),
+		name: name,
+		drainExtentsRcvdCount: make(map[string]int),
+		keyToUpdateCount:      make(map[string]int),
+		drainExtentsToFail:    make(map[string]struct{}),
 	}
 }
 
@@ -703,6 +728,40 @@ func (service *MockInputOutputService) DestinationsUpdated(ctx thrift.Context, r
 	}
 	service.mu.Unlock()
 	return nil
+}
+
+func (service *MockInputOutputService) DrainExtent(ctx thrift.Context, request *admin.DrainExtentsRequest) error {
+	service.mu.Lock()
+	defer service.mu.Unlock()
+	var err error
+	for _, extent := range request.GetExtents() {
+		count, ok := service.drainExtentsRcvdCount[extent.GetExtentUUID()]
+		if !ok {
+			count = 0
+		}
+		count++
+		service.drainExtentsRcvdCount[extent.GetExtentUUID()] = count
+		if _, ok := service.drainExtentsToFail[extent.GetExtentUUID()]; ok {
+			err = errors.New("drain failed")
+		}
+	}
+	return err
+}
+
+func (service *MockInputOutputService) drainExtentsRcvdFor(extID string) int {
+	service.mu.Lock()
+	defer service.mu.Unlock()
+	count, ok := service.drainExtentsRcvdCount[extID]
+	if !ok {
+		return 0
+	}
+	return count
+}
+
+func (service *MockInputOutputService) failDrainExtentFor(extID string) {
+	service.mu.Lock()
+	defer service.mu.Unlock()
+	service.drainExtentsToFail[extID] = struct{}{}
 }
 
 func (service *MockInputOutputService) GetUpdatedCount(key string) int {

--- a/services/controllerhost/event_pipeline_test.go
+++ b/services/controllerhost/event_pipeline_test.go
@@ -798,7 +798,3 @@ func (service *MockInputOutputService) ListLoadedDestinations(ctx thrift.Context
 func (service *MockInputOutputService) ReadDestState(ctx thrift.Context, req *admin.ReadDestinationStateRequest) (*admin.ReadDestinationStateResult_, error) {
 	return nil, fmt.Errorf("mock not implemented")
 }
-
-func (service *MockInputOutputService) DrainExtent(ctx thrift.Context, req *admin.DrainExtentsRequest) error {
-	return fmt.Errorf("mock not implemented")
-}

--- a/services/controllerhost/event_pipeline_test.go
+++ b/services/controllerhost/event_pipeline_test.go
@@ -732,10 +732,14 @@ func (service *MockInputOutputService) UnloadDestinations(ctx thrift.Context, re
 	return fmt.Errorf("mock not implemented")
 }
 
-func (service *MockInputOutputService) ListLoadedDestinations(ctx thrift.Context) (*admin.ListDestinationsResult_, error) {
+func (service *MockInputOutputService) ListLoadedDestinations(ctx thrift.Context) (*admin.ListLoadedDestinationsResult_, error) {
 	return nil, fmt.Errorf("mock not implemented")
 }
 
 func (service *MockInputOutputService) ReadDestState(ctx thrift.Context, req *admin.ReadDestinationStateRequest) (*admin.ReadDestinationStateResult_, error) {
 	return nil, fmt.Errorf("mock not implemented")
+}
+
+func (service *MockInputOutputService) DrainExtent(ctx thrift.Context, req *admin.DrainExtentsRequest) error {
+	return fmt.Errorf("mock not implemented")
 }

--- a/services/frontendhost/frontend_test.go
+++ b/services/frontendhost/frontend_test.go
@@ -789,7 +789,7 @@ func (s *FrontendHostSuite) TestFrontendHostCreateConsumerGroupStartFrom() {
 	testCG := s.generateKey("/bar/CGName")
 	frontendHost, ctx := s.utilGetContextAndFrontend()
 
-	testStartFrom := func(startFrom int64, willError bool) (startFromReturn int64, err error) {
+	testStartFrom := func(startFrom int64, willFail bool) (startFromReturn int64, err error) {
 
 		startFromReturn = math.MaxInt64
 
@@ -807,12 +807,9 @@ func (s *FrontendHostSuite) TestFrontendHostCreateConsumerGroupStartFrom() {
 			DestinationUUID: common.StringPtr(uuid.New()),
 		}
 
-		if !willError {
-			s.resetMocks()
-			// create destination is needed because of dlq destination been created at time of consumer group creation
-			s.mockController.On("CreateDestination", mock.Anything, mock.Anything).Return(destDesc, nil).Run(func(args mock.Arguments) {
-				s.Equal(dlqPath, args.Get(1).(*shared.CreateDestinationRequest).GetPath())
-			})
+		if !willFail {
+
+			s.mockController.On("CreateDestination", mock.Anything, mock.Anything).Return(destDesc, nil)
 
 			s.mockController.On("CreateConsumerGroup", mock.Anything, mock.Anything).Once().Return(cgDesc, nil).Run(func(args mock.Arguments) {
 				startFromReturn = args.Get(1).(*shared.CreateConsumerGroupRequest).GetStartFrom()
@@ -823,6 +820,8 @@ func (s *FrontendHostSuite) TestFrontendHostCreateConsumerGroupStartFrom() {
 		req.StartFrom = common.Int64Ptr(startFrom)
 
 		_, err = frontendHost.CreateConsumerGroup(ctx, req)
+
+		s.resetMocks() // reset mocks before the next test
 
 		return
 	}

--- a/services/inputhost/inputhost.go
+++ b/services/inputhost/inputhost.go
@@ -315,6 +315,11 @@ func (h *InputHost) OpenPublisherStreamHandler(w http.ResponseWriter, r *http.Re
 	}
 }
 
+// DrainExtent drains the given extents
+func (h *InputHost) DrainExtent(ctx thrift.Context, request *admin.DrainExtentsRequest) error {
+	return &cherami.InternalServiceError{Message: "not implemented"}
+}
+
 // OpenPublisherStream is the implementation of the thrift handler for the In service
 func (h *InputHost) OpenPublisherStream(ctx thrift.Context, call stream.BInOpenPublisherStreamInCall) error {
 

--- a/services/inputhost/inputhost.go
+++ b/services/inputhost/inputhost.go
@@ -315,11 +315,6 @@ func (h *InputHost) OpenPublisherStreamHandler(w http.ResponseWriter, r *http.Re
 	}
 }
 
-// DrainExtent drains the given extents
-func (h *InputHost) DrainExtent(ctx thrift.Context, request *admin.DrainExtentsRequest) error {
-	return &cherami.InternalServiceError{Message: "not implemented"}
-}
-
 // OpenPublisherStream is the implementation of the thrift handler for the In service
 func (h *InputHost) OpenPublisherStream(ctx thrift.Context, call stream.BInOpenPublisherStreamInCall) error {
 

--- a/services/inputhost/load/metrics.go
+++ b/services/inputhost/load/metrics.go
@@ -57,6 +57,9 @@ const (
 	DstMetricNumOpenConns = iota
 	// DstMetricNumOpenExtents represents number of open extents per dst
 	DstMetricNumOpenExtents
+	// DstMetricNumWritableExtents represents number of open and *writable* extents per dst
+	// A draining extent will decrement this and this is used to trigger client connection drain
+	DstMetricNumWritableExtents
 	// DstMetricMsgsIn represents count of incoming messages per dst
 	DstMetricMsgsIn
 	// DstMetricBytesIn represents count of incoming bytes per dst

--- a/test/integration/base.go
+++ b/test/integration/base.go
@@ -350,6 +350,14 @@ func (tb *testBase) GetOutput() *outputhost.OutputHost {
 	return nil
 }
 
+// GetInput returns a random input host instance
+func (tb *testBase) GetInput() *inputhost.InputHost {
+	for _, ih := range tb.InputHosts {
+		return ih
+	}
+	return nil
+}
+
 // GetController returns a random controller
 // instance object from the set of controllers
 // configured for this test. This method asssumes


### PR DESCRIPTION
This patch is the first step towards graceful extent sealing in controller. Specifically, this patch contains the following changes:

* On an ExtentDownEvent, the state machine is now modified to call inputHost.drain() before calling store.seal(). This ensures that an extent that's about to be sealed will first get an opportunity to drain the connected clients, before its sealed

* Added placeholder DrainExtent() implementation is input host after pulling the latest thrift changes, this can go away if #112 is merged before this PR.

What this change doesn't contain ?
* This diff doesn't contain the changes to handle graceful deployments on the input host. The proposed design for that involves input host sending its node status as part of the load reporting. This will be done on a separate PR.
* This diff also doesn't contain the changes to do store seal sequence number reconciliation