### PR TITLE
Add cheramiCommitter and committer interface

### DIFF
--- a/common/ackid.go
+++ b/common/ackid.go
@@ -53,7 +53,7 @@ const (
 // 16 bit - Monotonically increasing number to identify all unique ack managers within a host
 // 32 bit - Sequence Number within the AckManager which is used to update the data structure within
 //          the ack manager
-// The reason for having the above fileds in the ackID is as follows:
+// The reason for having the above fields in the ackID is as follows:
 // sessionID - to make sure ack is to the same outputhost (let's say to prevent a bad client)
 // ackID - to uniquely identify the ack managers within this outputhost
 // seqNum - to identify the data structure within the ackMgr

--- a/common/unboundedSemaphore.go
+++ b/common/unboundedSemaphore.go
@@ -28,9 +28,9 @@ import "sync"
 // See also: https://godoc.org/github.com/dropbox/godropbox/sync2#NewUnboundedSemaphore
 //
 type UnboundedSemaphore struct {
-	resCount        int
-	once            sync.Once
-	c               *sync.Cond
+	resCount    int
+	once        sync.Once
+	c           *sync.Cond
 	m               sync.Mutex // need to name this so it's not exported. Don't use this directly, use through s.c.L
 	accumulatorLock sync.Mutex // Used by acquirer for credit accumulation
 }

--- a/common/unboundedSemaphore.go
+++ b/common/unboundedSemaphore.go
@@ -28,9 +28,9 @@ import "sync"
 // See also: https://godoc.org/github.com/dropbox/godropbox/sync2#NewUnboundedSemaphore
 //
 type UnboundedSemaphore struct {
-	resCount    int
-	once        sync.Once
-	c           *sync.Cond
+	resCount        int
+	once            sync.Once
+	c               *sync.Cond
 	m               sync.Mutex // need to name this so it's not exported. Don't use this directly, use through s.c.L
 	accumulatorLock sync.Mutex // Used by acquirer for credit accumulation
 }

--- a/services/outputhost/cheramiCommitter.go
+++ b/services/outputhost/cheramiCommitter.go
@@ -1,0 +1,169 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package outputhost
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/uber/cherami-server/common"
+	"github.com/uber/cherami-thrift/.generated/go/metadata"
+	"github.com/uber/cherami-thrift/.generated/go/shared"
+	"github.com/uber/tchannel-go/thrift"
+)
+
+const metaContextTimeout = 10 * time.Second
+
+// cheramiCommitter is commits ackLevels to Cassandra through the TChanMetadataClient interface
+type cheramiCommitter struct {
+	outputHostUUID     string
+	cgUUID             string
+	extUUID            string
+	connectedStoreUUID *string
+	commitLevel        CommitterLevel
+	readLevel          CommitterLevel
+	finalLevel         CommitterLevel
+	metaclient         metadata.TChanMetadataService
+	isMultiZone        bool
+	tClients           common.ClientFactory
+}
+
+/*
+ * Committer interface
+ */
+
+// SetCommitLevel just updates the next Cherami ack level that will be flushed
+func (c *cheramiCommitter) SetCommitLevel(l CommitterLevel) {
+	c.commitLevel = l
+}
+
+// SetReadLevel just updates the next Cherami read level that will be flushed
+func (c *cheramiCommitter) SetReadLevel(l CommitterLevel) {
+	c.readLevel = l
+}
+
+// SetFinalLevel just updates the last possible read level
+func (c *cheramiCommitter) SetFinalLevel(l CommitterLevel) {
+	c.finalLevel = l
+}
+
+// UnlockAndFlush pushes our commit and read levels to Cherami metadata, using SetAckOffset
+func (c *cheramiCommitter) UnlockAndFlush(l sync.Locker) error {
+	ctx, cancel := thrift.NewContext(metaContextTimeout)
+	defer cancel()
+
+	oReq := &shared.SetAckOffsetRequest{
+		Status:             common.CheramiConsumerGroupExtentStatusPtr(shared.ConsumerGroupExtentStatus_OPEN),
+		OutputHostUUID:     common.StringPtr(c.outputHostUUID),
+		ConsumerGroupUUID:  common.StringPtr(c.cgUUID),
+		ExtentUUID:         common.StringPtr(c.extUUID),
+		ConnectedStoreUUID: common.StringPtr(*c.connectedStoreUUID),
+		AckLevelAddress:    common.Int64Ptr(int64(c.commitLevel.address)),
+		AckLevelSeqNo:      common.Int64Ptr(int64(c.commitLevel.seqNo)),
+		ReadLevelAddress:   common.Int64Ptr(int64(c.readLevel.address)),
+		ReadLevelSeqNo:     common.Int64Ptr(int64(c.readLevel.seqNo)),
+	}
+
+	if c.finalLevel != CommitterLevel(CommitterLevel{}) { // If the final level has been set
+		if c.finalLevel.address == c.readLevel.address && c.readLevel.address == c.commitLevel.address { // And final==read==commit
+			oReq.Status = common.CheramiConsumerGroupExtentStatusPtr(shared.ConsumerGroupExtentStatus_CONSUMED)
+		}
+	}
+
+	// At this point we have the final state to be committed, just need to commit it, which may take some time
+	l.Unlock()
+
+	// Store the local-zone metadata
+	errLocal := c.metaclient.SetAckOffset(ctx, oReq)
+
+	// update the ack offset in remote zone.
+	// Failure is fine as a reconciliation process between replicators(slow path) will fix the inconsistency eventually
+	// DEVNOTE: SetAckOffsetInRemote modifies oReq
+	var errRemote error
+	if c.isMultiZone {
+		errRemote = c.SetAckOffsetInRemote(oReq)
+	}
+
+	// Prefer the local error
+	if errLocal != nil {
+		return errLocal
+	}
+	return errRemote
+}
+
+// GetReadLevel returns the next readlevel that will be flushed
+func (c *cheramiCommitter) GetReadLevel() (l CommitterLevel) {
+	l = c.readLevel
+	return
+}
+
+// GetCommitLevel returns the next commit level that will be flushed
+func (c *cheramiCommitter) GetCommitLevel() (l CommitterLevel) {
+	l = c.commitLevel
+	return
+}
+
+/*
+ * Setup & Utility
+ */
+
+// NewCheramiCommitter instantiates a cheramiCommitter
+func NewCheramiCommitter(metaclient metadata.TChanMetadataService,
+	outputHostUUID string,
+	cgUUID string,
+	extUUID string,
+	connectedStoreUUID *string,
+	isMultiZone bool,
+	tClients common.ClientFactory) *cheramiCommitter {
+	return &cheramiCommitter{
+		metaclient:         metaclient,
+		outputHostUUID:     outputHostUUID,
+		cgUUID:             cgUUID,
+		extUUID:            extUUID,
+		connectedStoreUUID: connectedStoreUUID,
+		isMultiZone:        isMultiZone,
+		tClients:           tClients,
+	}
+}
+
+// SetAckOffsetInRemote attempts to flush ack level to a remote zone
+// DEVNOTE: SetAckOffsetInRemote modifies setAckLevelRequest
+func (c *cheramiCommitter) SetAckOffsetInRemote(setAckLevelRequest *shared.SetAckOffsetRequest) error {
+	// send to local replicator to fan out
+	localReplicator, err := c.tClients.GetReplicatorClient()
+	if err != nil {
+		return errors.New(fmt.Sprintf("SetAckOffsetInRemote: GetReplicatorClient failed: %#v", err))
+	}
+
+	// empty the output host and store uuid as these apply to local zone only
+	setAckLevelRequest.OutputHostUUID = nil
+	setAckLevelRequest.ConnectedStoreUUID = nil
+
+	ctx, cancel := thrift.NewContext(replicatorCallTimeout)
+	defer cancel()
+	err = localReplicator.SetAckOffsetInRemote(ctx, setAckLevelRequest)
+	if err != nil {
+		return errors.New(fmt.Sprintf("SetAckOffsetInRemote: SetAckOffsetInRemote failed from replicator: %#v", err))
+	}
+	return nil
+}

--- a/services/outputhost/committer.go
+++ b/services/outputhost/committer.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package outputhost
+
+import (
+	"github.com/uber/cherami-server/common"
+	"sync"
+)
+
+// Committer is an interface that wraps the internals of how offsets/acklevels are committed for a given queueing
+// system (e.g. Kafka or Cherami)
+type (
+	CommitterLevel struct {
+		seqNo   common.SequenceNumber // Logical sequence number of the ack manager
+		address storeHostAddress      // storage system address in the message
+	}
+
+	Committer interface {
+		// SetCommitLevel indicates that work up to and including the message specified by the sequence number and address
+		// has been acknowledged. Not guaranteed to be persisted until a successful call to Flush()
+		SetCommitLevel(l CommitterLevel)
+
+		// SetReadLevel indicates that a particular message has been read. Metadata not guaranteed to be communicated/persisted
+		// until a successful call to Flush()
+		SetReadLevel(l CommitterLevel)
+
+		// SetFinalLevel indicates that a particular level is the last that can possibly be read. Metadata not guaranteed
+		// to be communicated/persisted until a successful call to Flush()
+		SetFinalLevel(l CommitterLevel)
+
+		// UnlockAndFlush copies accumulated commit/read state, unlocks the provided lock, and then commits 
+		// the levels to durable storage, e.g. Kafka offset storage or Cherami-Cassandra AckLevel storage
+		UnlockAndFlush(l sync.Locker) error
+
+		// GetCommitLevel receives the last value given to Commit()
+		GetCommitLevel() (l CommitterLevel)
+
+		// GetReadLevel receives the last value given to Read()
+		GetReadLevel() (l CommitterLevel)
+	}
+)

--- a/services/outputhost/kafkaAddresser.go
+++ b/services/outputhost/kafkaAddresser.go
@@ -110,6 +110,10 @@ func (k *kafkaTopicPartitionAddresser) GetStoreAddress(tp *topicPartition, offse
 	k.i2tp[k.nextTP] = tp
 	k.tp2i[*tp] = k.nextTP
 
+	if k.nextTP > kafkaAddresserMaxTP {
+		panic(`too many topic/partition assignments`)
+	}
+
 	logFn().WithFields(bark.Fields{
 		`module`:    `kafkaAddresser`,
 		`topic`:     tp.Topic,

--- a/services/outputhost/kafkaAddresser.go
+++ b/services/outputhost/kafkaAddresser.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package outputhost
+
+import (
+	"math"
+	"sync"
+
+	"github.com/uber-common/bark"
+	"github.com/uber/cherami-server/common"
+)
+
+// Kafka Addresser store address encoding scheme
+//                    -=-=-
+// t = topic+partition (map lookup)
+// o = offset
+//                     ttttttooooooooooooo
+// math.MaxInt64    =  9223372036854775807 = Max store address
+// divisor          =       10000000000000
+// MaxTP            =  922336 <- Note that it's 1 less, which makes the max offset uniform
+// MaxOffset        =        9999999999999
+// MaxAddress       =  9223369999999999999
+// MaxOffset10YrQPS =                31709 <-- The sustained QPS that would exhaust the max offset in 10 years
+//                    -=-=-
+// https://play.golang.org/p/VVMnGgHWSG
+
+const (
+	kafkaAddresserDivisor    = int64(1e13)
+	kafkaAddresserMaxTP      = int64(math.MaxInt64/kafkaAddresserDivisor) - 1
+	kafkaAddresserMaxOffset  = kafkaAddresserDivisor - 1
+	kafkaAddresserMaxAddress = kafkaAddresserMaxTP*kafkaAddresserDivisor + kafkaAddresserMaxOffset
+)
+
+// topicPartition
+type topicPartition struct {
+	Topic     string
+	Partition int32
+}
+
+type kafkaTopicPartitionAddresser struct {
+	sync.RWMutex
+	tp2i   map[topicPartition]int64
+	i2tp   map[int64]*topicPartition
+	nextTP int64
+}
+
+var kafkaAddresser = kafkaTopicPartitionAddresser{}
+
+// GetStoreAddress converts a given topic, partition, and offset into a store address
+func (k *kafkaTopicPartitionAddresser) GetStoreAddress(tp *topicPartition, offset int64, logFn func() bark.Logger) (address storeHostAddress) {
+	calc := func(tpInt int64, offset int64) storeHostAddress {
+		return storeHostAddress((tpInt * kafkaAddresserDivisor) + offset)
+	}
+
+	if offset > kafkaAddresserMaxOffset {
+		logFn().WithFields(bark.Fields{
+			`module`:    `kafkaAddresser`,
+			`topic`:     tp.Topic,
+			`partition`: tp.Partition,
+			`offset`:    offset,
+		}).Error(`Offset out of Kafka addresser design range`)
+	}
+
+	// Pegging the offset will just mean that we don't commit
+	// larger offsets to Kafka, but shouldn't cause an outage
+	offset = common.MinInt64(offset, kafkaAddresserMaxOffset)
+
+	k.RLock()
+	if i, ok := k.tp2i[*tp]; ok {
+		k.RUnlock()
+		return calc(i, offset)
+	}
+	k.RUnlock()
+
+	// New addresser assignment path
+	k.Lock()
+	defer k.Unlock() // Defer only on the unhappy (write) path
+
+	// Check for race between RUnlock and Lock
+	if i, ok := k.tp2i[*tp]; ok {
+		return calc(i, offset)
+	}
+
+	// Check initialization
+	if k.nextTP == 0 {
+		k.tp2i = make(map[topicPartition]int64)
+		k.i2tp = make(map[int64]*topicPartition)
+	}
+
+	// Assignment
+	k.nextTP++
+	k.i2tp[k.nextTP] = tp
+	k.tp2i[*tp] = k.nextTP
+
+	logFn().WithFields(bark.Fields{
+		`module`:    `kafkaAddresser`,
+		`topic`:     tp.Topic,
+		`partition`: tp.Partition,
+		`offset`:    offset,
+		`tpInt`:     k.nextTP,
+	}).Info(`New assignment`)
+	
+	return calc(k.nextTP, offset)
+}
+
+// GetTopicPartitionOffset recovers the original topic, partition, and offset from a store address
+func (k *kafkaTopicPartitionAddresser) GetTopicPartitionOffset(address storeHostAddress, logFn func() bark.Logger) (tp *topicPartition, offset int64) {
+	returnOffset := func(tp *topicPartition, address storeHostAddress) (tpOut *topicPartition, offset int64) {
+		return tp, int64(address) % kafkaAddresserDivisor
+	}
+
+	recoverTP := func(address storeHostAddress) (offset int64) {
+		return int64(address) / kafkaAddresserDivisor
+	}
+
+	k.RLock()
+	if tp, ok := k.i2tp[recoverTP(address)]; ok {
+		k.RUnlock()
+		return returnOffset(tp, address)
+	}
+	k.RUnlock()
+
+	tpInt := recoverTP(address)
+	_, offset = returnOffset(&topicPartition{}, address)
+
+	logFn().WithFields(bark.Fields{
+		`module`:            `kafkaAddresser`,
+		`offset`:            offset,
+		`topicPartitionInt`: tpInt,
+	}).Error(`Unmapped store address received`)
+	return nil, 0
+}

--- a/services/outputhost/kafkaCommitter.go
+++ b/services/outputhost/kafkaCommitter.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package outputhost
+
+import (
+	"encoding/json"
+	"sync"
+
+	sc "github.com/bsm/sarama-cluster"
+	"github.com/uber-common/bark"
+	"github.com/uber/cherami-server/common"
+	"github.com/uber/cherami-thrift/.generated/go/metadata"
+)
+
+// kafkaCommitter is commits ackLevels to Cassandra through the TChanMetadataClient interface
+type kafkaCommitter struct {
+	connectedStoreUUID *string
+	commitLevel        CommitterLevel
+	readLevel          CommitterLevel
+	finalLevel         CommitterLevel
+	metaclient         metadata.TChanMetadataService
+	*sc.OffsetStash
+	*sc.Consumer
+	KafkaOffsetMetadata
+	metadataString string // JSON version of KafkaOffsetMetadata
+	logger bark.Logger
+}
+
+// KafkaOffsetMetadata is a structure used for JSON encoding/decoding of the metadata stored for
+// Kafka offsets committed by Cherami
+type KafkaOffsetMetadata struct {
+	// Version is the version of this structure
+	Version uint
+
+	// CGUUID is the internal Cherami consumer group UUID that committed this offset
+	CGUUID string
+
+	// OutputHostUUID is the UUID of the Cherami Outputhost that committed this offset
+	OutputHostUUID string
+}
+
+const kafkaOffsetMetadataVersion = uint(0) // Current version of the KafkaOffsetMetadata
+
+/*
+ * Committer interface
+ */
+
+// SetCommitLevel just updates the next Cherami ack level that will be flushed
+func (c *kafkaCommitter) SetCommitLevel(l CommitterLevel) {
+	c.commitLevel = l
+	tp, offset := kafkaAddresser.GetTopicPartitionOffset(l.address, c.getLogFn())
+	if tp != nil {
+		c.OffsetStash.MarkPartitionOffset(tp.Topic, tp.Partition, offset, c.metadataString)
+	}
+}
+
+// SetReadLevel just updates the next Cherami read level that will be flushed
+func (c *kafkaCommitter) SetReadLevel(l CommitterLevel) {
+	c.readLevel = l
+}
+
+// SetFinalLevel just updates the last possible read level
+func (c *kafkaCommitter) SetFinalLevel(l CommitterLevel) {
+	c.finalLevel = l
+}
+
+// UnlockAndFlush pushes our commit and read levels to Cherami metadata, using SetAckOffset
+func (c *kafkaCommitter) UnlockAndFlush(l sync.Locker) error {
+	os := c.OffsetStash
+	c.OffsetStash = sc.NewOffsetStash()
+	l.Unlock() // MarkOffsets may take some time, so we unlock the thread that owns us
+	c.MarkOffsets(os)
+	return nil
+}
+
+// GetReadLevel returns the next readlevel that will be flushed
+func (c *kafkaCommitter) GetReadLevel() (l CommitterLevel) {
+	l = c.readLevel
+	return
+}
+
+// GetCommitLevel returns the next commit level that will be flushed
+func (c *kafkaCommitter) GetCommitLevel() (l CommitterLevel) {
+	l = c.commitLevel
+	return
+}
+
+/*
+ * Setup & Utility
+ */
+
+// NewkafkaCommitter instantiates a kafkaCommitter
+func NewkafkaCommitter(metaclient metadata.TChanMetadataService,
+	outputHostUUID string,
+	cgUUID string,
+	extUUID string,
+	connectedStoreUUID *string,
+	logger bark.Logger) *kafkaCommitter {
+	meta := KafkaOffsetMetadata{
+		Version:        kafkaOffsetMetadataVersion,
+		OutputHostUUID: outputHostUUID,
+		CGUUID:         cgUUID,
+	}
+
+	metaJSON, _ := json.Marshal(meta)
+	return &kafkaCommitter{
+		metaclient:          metaclient,
+		connectedStoreUUID:  connectedStoreUUID,
+		OffsetStash:         sc.NewOffsetStash(),
+		metadataString:      string(metaJSON),
+		KafkaOffsetMetadata: meta,
+		logger: logger,
+	}
+}
+
+func (c *kafkaCommitter) getLogFn() func() bark.Logger {
+	return func() bark.Logger {
+		return c.logger.WithFields(bark.Fields{
+			`module`:       `kafkaCommitter`,
+			common.TagOut:  common.FmtOut(c.OutputHostUUID),
+			common.TagCnsm: common.FmtCnsm(c.CGUUID),
+		})
+	}
+}

--- a/services/outputhost/kafkaStream.go
+++ b/services/outputhost/kafkaStream.go
@@ -85,9 +85,10 @@ func (k *kafkaStream) ResponseHeaders() (map[string]string, error) {
  * Setup & Utility
  */
 
-func OpenKafkaStream(c <-chan *s.ConsumerMessage) stream.BStoreOpenReadStreamOutCall {
+func OpenKafkaStream(c <-chan *s.ConsumerMessage, logger bark.Logger) stream.BStoreOpenReadStreamOutCall {
 	k := &kafkaStream{
 		kafkaMsgsCh: c,
+		logger: logger,
 	}
 	return k
 }

--- a/services/outputhost/kafkaStream.go
+++ b/services/outputhost/kafkaStream.go
@@ -21,9 +21,9 @@
 package outputhost
 
 import (
+	"sync/atomic"
 	"errors"
 	"strconv"
-	"sync/atomic"
 
 	s "github.com/Shopify/sarama"
 	"github.com/uber-common/bark"
@@ -98,7 +98,7 @@ func (s *kafkaStream) convertKafkaMessageToCherami(k *s.ConsumerMessage, logger 
 	}
 
 	c.Message = &store.ReadMessage{
-		Address: common.Int64Ptr(42), /*
+		Address: common.Int64Ptr(
 			int64(kafkaAddresser.GetStoreAddress(
 				&topicPartition{
 					Topic:     k.Topic,
@@ -112,7 +112,7 @@ func (s *kafkaStream) convertKafkaMessageToCherami(k *s.ConsumerMessage, logger 
 						`partition`: k.Partition,
 					})
 				},
-			))), */
+			))),
 	}
 
 	c.Message.Message = &store.AppendMessage{

--- a/services/outputhost/kafkaStream_test.go
+++ b/services/outputhost/kafkaStream_test.go
@@ -168,8 +168,8 @@ func (s *KafkaStreamSuite) WithTestMessages(count int, fn func(chan *sarama.Cons
 		sMsg := &sarama.ConsumerMessage{
 			Key:       []byte(strconv.Itoa(10*i + 1)),
 			Value:     []byte(strconv.Itoa(10*i + 5)),
-			Topic:     strconv.Itoa(10*i + 2),
-			Partition: int32(10*i + 3),
+			Topic:     strconv.Itoa((10*i + 2) % 100),
+			Partition: int32(10*i+3) % 100,
 			Offset:    int64(10*i + 4),
 			Timestamp: time.Now(),
 		}
@@ -183,7 +183,7 @@ func (s *KafkaStreamSuite) WithTestMessages(count int, fn func(chan *sarama.Cons
 }
 
 func (s *KafkaStreamSuite) WithKafkaStream(c chan *sarama.ConsumerMessage, fn func(stream.BStoreOpenReadStreamOutCall)) {
-	k := OpenKafkaStream(c)
+	k := OpenKafkaStream(c, common.GetDefaultLogger())
 	s.NotNil(k)
 	fn(k)
 	s.NoError(k.Flush())
@@ -220,8 +220,8 @@ func (s *KafkaStreamSuite) ValidateMessage(msg *store.ReadMessageContent) {
 
 	userContext := putMsg.GetUserContext()
 	s.Equal(strconv.Itoa(10*i+1), userContext[`key`])
-	s.Equal(strconv.Itoa(10*i+2), userContext[`topic`])
-	s.Equal(strconv.Itoa(10*i+3), userContext[`partition`])
+	s.Equal(strconv.Itoa((10*i+2)%100), userContext[`topic`])
+	s.Equal(strconv.Itoa((10*i+3)%100), userContext[`partition`])
 	s.Equal(strconv.Itoa(10*i+4), userContext[`offset`])
 	s.Equal(strconv.Itoa(10*i+5), string(putMsg.GetData()))
 }


### PR DESCRIPTION
The idea here is to separate the metadata operation and the tracking of what work is safe to commit. The Kafka version for this will be able to demux the stream of Commit() calls to the appropriate topic+partition.

Kafka Commit() will call https://godoc.org/github.com/bsm/sarama-cluster#OffsetStash.MarkPartitionOffset
Kafka Flush() will call https://godoc.org/github.com/bsm/sarama-cluster#Consumer.MarkOffsets