### PR TITLE
controller: added support to drain extent before sealing

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -926,6 +926,8 @@ const (
 	ControllerErrBadRequestCounter
 	// ControllerErrBadEntityCounter indicates either an entity not exists or disabled error
 	ControllerErrBadEntityCounter
+	// ControllerErrDrainFailed indicates that a drain command issued to input failed
+	ControllerErrDrainFailed
 
 	// ControllerEventsDropped indicates an event drop due to queue full
 	ControllerEventsDropped
@@ -1158,6 +1160,7 @@ var metricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ControllerErrNoRetryWorkers:                {Counter, "controller.errors.no-retry-workers"},
 		ControllerErrBadRequestCounter:             {Counter, "controller.errors.bad-requests"},
 		ControllerErrBadEntityCounter:              {Counter, "controller.errors.bad-entity"},
+		ControllerErrDrainFailed:                   {Counter, "controller.errors.drain-failed"},
 		ControllerEventsDropped:                    {Counter, "controller.events-dropped"},
 		ControllerRequests:                         {Counter, "controller.requests"},
 		ControllerFailures:                         {Counter, "controller.errors"},

--- a/services/controllerhost/event_handlers.go
+++ b/services/controllerhost/event_handlers.go
@@ -95,6 +95,7 @@ type (
 		sealSeq  int64
 		dstID    string
 		extentID string
+		inputID  string
 		storeIDs []string
 	}
 
@@ -140,6 +141,7 @@ type (
 // ExtentDownEvent States
 const (
 	checkPreconditionState = iota
+	drainExtentState
 	sealExtentState
 	updateMetadataState
 	doneState
@@ -148,6 +150,9 @@ const (
 // how long from now are we willing to wait
 // for the cache to refresh itself ?
 const resultCacheRefreshMaxWaitTime = int64(500 * time.Millisecond)
+
+// how long to wait for an input host to respond to a drain command
+const drainExtentTimeout = time.Minute
 
 var (
 	sealExtentInitialCallTimeout = 2 * time.Second
@@ -814,7 +819,12 @@ func (event *ExtentDownEvent) Handle(context *Context) error {
 				}).Error("Cannot read extent stats")
 				return errRetryable
 			}
+			event.inputID = stats.GetExtent().GetInputHostUUID()
 			event.storeIDs = stats.GetExtent().GetStoreUUIDs()
+			event.state = drainExtentState
+
+		case drainExtentState:
+			drainExtent(context, event.dstID, event.extentID, event.inputID)
 			event.state = sealExtentState
 
 		case sealExtentState:
@@ -1035,7 +1045,8 @@ func reconfigureAllConsumers(context *Context, dstID, extentID, reason, reasonCo
 func createExtentDownEvents(context *Context, stats []*shared.ExtentStats) {
 	for _, stat := range stats {
 		if !common.IsRemoteZoneExtent(stat.GetExtent().GetOriginZone(), context.localZone) {
-			addExtentDownEvent(context, 0, stat.GetExtent().GetDestinationUUID(), stat.GetExtent().GetExtentUUID())
+			extent := stat.GetExtent()
+			addExtentDownEvent(context, 0, extent.GetDestinationUUID(), extent.GetExtentUUID())
 		}
 	}
 }
@@ -1089,6 +1100,38 @@ func sealExtentOnStore(context *Context, storeUUID string, storeAddr string, ext
 		}).Error("Sealing extent failed on store, retries exceeded")
 	}
 	return err
+}
+
+// drainExtent sends a drain command to input host to gracefully
+// drain the clients connected to a given extent. If the input
+// host is not alive in ringpop, this method will return immediately
+func drainExtent(context *Context, dstID string, extentID string, inputID string) {
+	addr, err := context.rpm.ResolveUUID(common.InputServiceName, inputID)
+	if err != nil {
+		return
+	}
+	adminClient, err := common.CreateInputHostAdminClient(context.channel, addr)
+	if err != nil {
+		context.log.WithField(common.TagErr, err).Error(`drainExtent: failed to create input host client`)
+		return
+	}
+	drainExtentInfo := &admin.DrainExtents{
+		DestinationUUID: common.StringPtr(dstID),
+		ExtentUUID:      common.StringPtr(extentID),
+	}
+	drainReq := &admin.DrainExtentsRequest{
+		UpdateUUID: common.StringPtr(uuid.New()),
+		Extents:    []*admin.DrainExtents{drainExtentInfo},
+	}
+	context.log.WithFields(bark.Fields{
+		common.TagDst: common.FmtDst(dstID),
+		common.TagExt: common.FmtExt(extentID),
+		`reconfigID`:  drainReq.GetUpdateUUID(),
+	}).Info(`sending drain command to input host`)
+
+	ctx, cancel := thrift.NewContext(drainExtentTimeout)
+	adminClient.DrainExtent(ctx, drainReq)
+	cancel()
 }
 
 func createRetryPolicy(initial time.Duration, max time.Duration, expiry time.Duration, maxAttempts int) backoff.RetryPolicy {

--- a/services/controllerhost/event_pipeline_test.go
+++ b/services/controllerhost/event_pipeline_test.go
@@ -377,6 +377,18 @@ func (s *EventPipelineSuite) TestInputHostFailedEvent() {
 
 	rpm := common.NewMockRingpopMonitor()
 
+	inputs := make([]*MockInputOutputService, len(inHostIDs))
+	for i := 0; i < len(inHostIDs); i++ {
+		inputs[i] = NewMockInputOutputService(common.InputServiceName)
+		thriftService := admin.NewTChanInputHostAdminServer(inputs[i])
+		inputs[i].Start(common.InputServiceName, thriftService)
+		rpm.Add(common.InputServiceName, inHostIDs[i], inputs[i].hostPort)
+	}
+
+	for _, e := range extentIDs {
+		inputs[0].failDrainExtentFor(e)
+	}
+
 	stores := make([]*MockStoreService, len(storeIDs))
 	for i := 0; i < len(storeIDs); i++ {
 		stores[i] = NewMockStoreService()
@@ -395,6 +407,15 @@ func (s *EventPipelineSuite) TestInputHostFailedEvent() {
 			succ := true
 			for j := 0; j < len(storeIDs); j++ {
 				if !stores[j].isSealed(extentIDs[i]) {
+					succ = false
+					break
+				}
+			}
+			if !succ {
+				return false
+			}
+			for j := 0; j < len(inHostIDs); j++ {
+				if inputs[j].drainExtentsRcvdFor(extentIDs[j]) != 1 {
 					succ = false
 					break
 				}
@@ -651,18 +672,22 @@ func (service *MockStoreService) isExtentReReplicated(extentID string) bool {
 }
 
 type MockInputOutputService struct {
-	name             string
-	server           *thrift.Server
-	ch               *tchannel.Channel
-	hostPort         string
-	mu               sync.Mutex
-	keyToUpdateCount map[string]int
+	name                  string
+	server                *thrift.Server
+	ch                    *tchannel.Channel
+	hostPort              string
+	mu                    sync.Mutex
+	keyToUpdateCount      map[string]int
+	drainExtentsRcvdCount map[string]int
+	drainExtentsToFail    map[string]struct{}
 }
 
 func NewMockInputOutputService(name string) *MockInputOutputService {
 	return &MockInputOutputService{
-		name:             name,
-		keyToUpdateCount: make(map[string]int),
+		name: name,
+		drainExtentsRcvdCount: make(map[string]int),
+		keyToUpdateCount:      make(map[string]int),
+		drainExtentsToFail:    make(map[string]struct{}),
 	}
 }
 
@@ -703,6 +728,40 @@ func (service *MockInputOutputService) DestinationsUpdated(ctx thrift.Context, r
 	}
 	service.mu.Unlock()
 	return nil
+}
+
+func (service *MockInputOutputService) DrainExtent(ctx thrift.Context, request *admin.DrainExtentsRequest) error {
+	service.mu.Lock()
+	defer service.mu.Unlock()
+	var err error
+	for _, extent := range request.GetExtents() {
+		count, ok := service.drainExtentsRcvdCount[extent.GetExtentUUID()]
+		if !ok {
+			count = 0
+		}
+		count++
+		service.drainExtentsRcvdCount[extent.GetExtentUUID()] = count
+		if _, ok := service.drainExtentsToFail[extent.GetExtentUUID()]; ok {
+			err = errors.New("drain failed")
+		}
+	}
+	return err
+}
+
+func (service *MockInputOutputService) drainExtentsRcvdFor(extID string) int {
+	service.mu.Lock()
+	defer service.mu.Unlock()
+	count, ok := service.drainExtentsRcvdCount[extID]
+	if !ok {
+		return 0
+	}
+	return count
+}
+
+func (service *MockInputOutputService) failDrainExtentFor(extID string) {
+	service.mu.Lock()
+	defer service.mu.Unlock()
+	service.drainExtentsToFail[extID] = struct{}{}
 }
 
 func (service *MockInputOutputService) GetUpdatedCount(key string) int {

--- a/services/controllerhost/event_pipeline_test.go
+++ b/services/controllerhost/event_pipeline_test.go
@@ -798,7 +798,3 @@ func (service *MockInputOutputService) ListLoadedDestinations(ctx thrift.Context
 func (service *MockInputOutputService) ReadDestState(ctx thrift.Context, req *admin.ReadDestinationStateRequest) (*admin.ReadDestinationStateResult_, error) {
 	return nil, fmt.Errorf("mock not implemented")
 }
-
-func (service *MockInputOutputService) DrainExtent(ctx thrift.Context, req *admin.DrainExtentsRequest) error {
-	return fmt.Errorf("mock not implemented")
-}


### PR DESCRIPTION
This patch is the first step towards graceful extent sealing in controller. Specifically, this patch contains the following changes:

On an ExtentDownEvent, the state machine is now modified to call inputHost.drain() before calling store.seal(). This ensures that an extent that's about to be sealed will first get an opportunity to drain the connected clients, before its sealed

Added placeholder DrainExtent() implementation is input host after pulling the latest thrift changes, this can go away if #112 is merged before this PR.

What this change doesn't contain ?

This diff doesn't contain the changes to handle graceful deployments on the input host. The proposed design for that involves input host sending its node status as part of the load reporting. This will be done on a separate PR.
This diff also doesn't contain the changes to do store seal sequence number reconciliation