### PR TITLE
Fix drain

### DIFF
--- a/config/base.yaml
+++ b/config/base.yaml
@@ -90,8 +90,8 @@ ReplicatorConfig:
 
 # Logging configuration
 logging:
-  level: info
-  stdout: true
+  level: error
+  stdout: false
 
 # DefaultDestinationConfig right now configures how many replicas you want
 DefaultDestinationConfig:

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -90,8 +90,8 @@ ReplicatorConfig:
 
 # Logging configuration
 logging:
-  level: error
-  stdout: false
+  level: info
+  stdout: true
 
 # DefaultDestinationConfig right now configures how many replicas you want
 DefaultDestinationConfig:

--- a/services/inputhost/inputhost.go
+++ b/services/inputhost/inputhost.go
@@ -810,7 +810,7 @@ func (h *InputHost) DrainExtent(ctx thrift.Context, request *admin.DrainExtentsR
 			extentUUID = req.GetExtentUUID()
 			if pathCache.isActiveNoLock() {
 				drainWG.Add(1)
-				go pathCache.drainExtent(extentUUID, updateUUID, &drainWG)
+				go pathCache.drainExtent(extentUUID, updateUUID, &drainWG, timeoutTime)
 			} else {
 				intErr = errPathCacheUnloading
 			}

--- a/services/inputhost/pathCache.go
+++ b/services/inputhost/pathCache.go
@@ -537,7 +537,7 @@ func (pathCache *inPathCache) getState() *admin.DestinationState {
 	return destState
 }
 
-func (pathCache *inPathCache) drainExtent(extUUID string, updateUUID string, drainWG *sync.WaitGroup) {
+func (pathCache *inPathCache) drainExtent(extUUID string, updateUUID string, drainWG *sync.WaitGroup, drainTimeout time.Duration) {
 	defer drainWG.Done()
 	pathCache.RLock()
 
@@ -559,6 +559,6 @@ func (pathCache *inPathCache) drainExtent(extUUID string, updateUUID string, dra
 		pathCache.RUnlock()
 		// do best effort waiting to notify all connections here
 		common.AwaitWaitGroup(&connDrainWG, connWGTimeout)
-		extCache.connection.stopWrite()
+		extCache.connection.stopWrite(drainTimeout)
 	}
 }

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -481,7 +481,7 @@ func (s *NetIntegrationSuiteParallelE) TestWriteWithDrain() {
 	// Publish messages
 	// Make the doneCh to be a minimum size so that we don't
 	// fill up immediately
-	doneCh := make(chan *client.PublisherReceipt, 1)
+	doneCh := make(chan *client.PublisherReceipt, 500)
 	var wg sync.WaitGroup
 
 	for i := 0; i < testMsgCount; i++ {
@@ -515,7 +515,7 @@ func (s *NetIntegrationSuiteParallelE) TestWriteWithDrain() {
 	drainReq.ExtentUUID = common.StringPtr(receiptParts[0])
 	dReq.Extents = append(dReq.Extents, drainReq)
 
-	ctx, _ := thrift.NewContext(2 * time.Minute)
+	ctx, _ := thrift.NewContext(1 * time.Minute)
 	err = ih.DrainExtent(ctx, dReq)
 	s.Nil(err)
 

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -295,7 +295,7 @@ ReadLoop2:
 	consumerTest.Close()
 }
 
-func (s *NetIntegrationSuiteParallelC) TestWriteEndToEndSuccessWithCassandra() {
+func (s *NetIntegrationSuiteParallelE) TestWriteEndToEndSuccessWithCassandra() {
 	destPath := "/dest/testWriteEndToEndCassandra"
 	cgPath := "/cg/testWriteEndToEndCassandra"
 	testMsgCount := 100

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -63,6 +63,9 @@ type NetIntegrationSuiteParallelC struct {
 type NetIntegrationSuiteParallelD struct {
 	testBase
 }
+type NetIntegrationSuiteParallelE struct {
+	testBase
+}
 type NetIntegrationSuiteSerial struct {
 	testBase
 }
@@ -87,6 +90,12 @@ func TestNetIntegrationSuiteParallelC(t *testing.T) {
 }
 func TestNetIntegrationSuiteParallelD(t *testing.T) {
 	s := new(NetIntegrationSuiteParallelD)
+	s.testBase.SetupSuite(t)
+	t.Parallel()
+	suite.Run(t, s)
+}
+func TestNetIntegrationSuiteParallelE(t *testing.T) {
+	s := new(NetIntegrationSuiteParallelE)
 	s.testBase.SetupSuite(t)
 	t.Parallel()
 	suite.Run(t, s)
@@ -426,7 +435,7 @@ ReadLoop:
 	s.Nil(err, "Failed to delete destination")
 }
 
-func (s *NetIntegrationSuiteParallelC) TestWriteWithDrain() {
+func (s *NetIntegrationSuiteParallelE) TestWriteWithDrain() {
 	destPath := "/dest/testWriteDrain"
 	cgPath := "/cg/testWriteDrain"
 	testMsgCount := 1000
@@ -2002,7 +2011,7 @@ ReadLoop2_TheReloopening:
 
 }
 
-func (s *NetIntegrationSuiteParallelC) TestStartFromWithCassandra() {
+func (s *NetIntegrationSuiteParallelE) TestStartFromWithCassandra() {
 	destPath := "/dest/TestStartFromWithCassandra"
 	cgPathEverything := "/cg/TestStartFromWithCassandraEverything"
 	cgPathStartFrom := "/cg/TestStartFromWithCassandra"


### PR DESCRIPTION
We were not actually waiting for the drain to finish before returning
but rather we just stopped the write pump (inflight messages are not yet drained).
This will mean the controller will simply seal the extent as soon
as we return.

To fix this, we need to make sure we actually wait for the drain, i.e,
the readpump is done reading all the inflight messages.
