### PR TITLE
setting ack level remotely does not need to update output host and connected store

### DIFF
--- a/clients/metadata/metadata_cassandra.go
+++ b/clients/metadata/metadata_cassandra.go
@@ -1405,7 +1405,7 @@ func (s *CassandraMetadataService) readConsumerGroupByDstUUID(dstUUID string, cg
 		&zoneConfigsData); err != nil {
 		if err == gocql.ErrNotFound {
 			return nil, &shared.EntityNotExistsError{
-				Message: fmt.Sprintf("ConsumerGroup %s of destinationUUID %sdoes not exist", cgName, dstUUID),
+				Message: fmt.Sprintf("ConsumerGroup %s of destinationUUID %s does not exist", cgName, dstUUID),
 			}
 		}
 
@@ -3443,6 +3443,16 @@ const (
 		columnConnectedStore + `=?` +
 		` WHERE ` + columnConsumerGroupUUID + `=? AND ` + columnExtentUUID + `=?`
 
+	sqlCGUpdateAckOffsetNoOutputAndStore = `UPDATE ` + tableConsumerGroupExtents +
+		` SET ` +
+		columnAckLevelOffset + `=?, ` +
+		columnAckLevelSequence + `=?,` +
+		columnAckLevelSequenceRate + `=?,` +
+		columnReceivedLevelOffset + `=?,` +
+		columnReceivedLevelSequence + `=?,` +
+		columnReceivedLevelSequenceRate + `=?` +
+		` WHERE ` + columnConsumerGroupUUID + `=? AND ` + columnExtentUUID + `=?`
+
 	sqlCGUpdateAckOffsetConsumed = `UPDATE ` + tableConsumerGroupExtents +
 		` SET ` +
 		columnStatus + `=?,` +
@@ -3454,6 +3464,17 @@ const (
 		columnReceivedLevelSequence + `=?,` +
 		columnReceivedLevelSequenceRate + `=?,` +
 		columnConnectedStore + `=?` +
+		` WHERE ` + columnConsumerGroupUUID + `=? AND ` + columnExtentUUID + `=?`
+
+	sqlCGUpdateAckOffsetConsumedNoOutputAndStore = `UPDATE ` + tableConsumerGroupExtents +
+		` SET ` +
+		columnStatus + `=?,` +
+		columnAckLevelOffset + `=?, ` +
+		columnAckLevelSequence + `=?,` +
+		columnAckLevelSequenceRate + `=?,` +
+		columnReceivedLevelOffset + `=?, ` +
+		columnReceivedLevelSequence + `=?,` +
+		columnReceivedLevelSequenceRate + `=?` +
 		` WHERE ` + columnConsumerGroupUUID + `=? AND ` + columnExtentUUID + `=?`
 
 	sqlCGUpdateStatus = `UPDATE ` + tableConsumerGroupExtents + ` SET ` + columnStatus + `=?` +
@@ -3554,37 +3575,72 @@ func (s *CassandraMetadataService) SetAckOffset(ctx thrift.Context, request *sha
 		connectedStore = request.GetConnectedStoreUUID()
 	}
 
+	// check whether output host and stores are set. If not, no need to update these columns
+	updateWithOutputHostAndStore := true
+	if !request.IsSetOutputHostUUID() && !request.IsSetConnectedStoreUUID() {
+		updateWithOutputHostAndStore = false
+	}
+
 	if request.Status != nil && request.GetStatus() == shared.ConsumerGroupExtentStatus_CONSUMED {
-		query := s.session.Query(
-			sqlCGUpdateAckOffsetConsumed,
-			request.GetStatus(),
-			request.GetOutputHostUUID(),
-			request.GetAckLevelAddress(),
-			request.GetAckLevelSeqNo(),
-			request.GetAckLevelSeqNoRate(),
-			request.GetReadLevelAddress(),
-			request.GetReadLevelSeqNo(),
-			request.GetReadLevelSeqNoRate(),
-			connectedStore,
-			request.GetConsumerGroupUUID(),
-			request.GetExtentUUID())
+		var query *gocql.Query
+		if updateWithOutputHostAndStore {
+			query = s.session.Query(
+				sqlCGUpdateAckOffsetConsumed,
+				request.GetStatus(),
+				request.GetOutputHostUUID(),
+				request.GetAckLevelAddress(),
+				request.GetAckLevelSeqNo(),
+				request.GetAckLevelSeqNoRate(),
+				request.GetReadLevelAddress(),
+				request.GetReadLevelSeqNo(),
+				request.GetReadLevelSeqNoRate(),
+				connectedStore,
+				request.GetConsumerGroupUUID(),
+				request.GetExtentUUID())
+		} else {
+			query = s.session.Query(
+				sqlCGUpdateAckOffsetConsumedNoOutputAndStore,
+				request.GetStatus(),
+				request.GetAckLevelAddress(),
+				request.GetAckLevelSeqNo(),
+				request.GetAckLevelSeqNoRate(),
+				request.GetReadLevelAddress(),
+				request.GetReadLevelSeqNo(),
+				request.GetReadLevelSeqNoRate(),
+				request.GetConsumerGroupUUID(),
+				request.GetExtentUUID())
+		}
 		// this query updates the offsets + changes the status of the
 		// extent, prefer mid level conistency
 		query.Consistency(s.midConsLevel)
 		err = query.Exec()
 	} else {
-		query := s.session.Query(
-			sqlCGUpdateAckOffset,
-			request.GetOutputHostUUID(),
-			request.GetAckLevelAddress(),
-			request.GetAckLevelSeqNo(),
-			request.GetAckLevelSeqNoRate(),
-			request.GetReadLevelAddress(),
-			request.GetReadLevelSeqNo(),
-			request.GetReadLevelSeqNoRate(),
-			connectedStore,
-			request.GetConsumerGroupUUID(),
-			request.GetExtentUUID())
+		var query *gocql.Query
+		if updateWithOutputHostAndStore {
+			query = s.session.Query(
+				sqlCGUpdateAckOffset,
+				request.GetOutputHostUUID(),
+				request.GetAckLevelAddress(),
+				request.GetAckLevelSeqNo(),
+				request.GetAckLevelSeqNoRate(),
+				request.GetReadLevelAddress(),
+				request.GetReadLevelSeqNo(),
+				request.GetReadLevelSeqNoRate(),
+				connectedStore,
+				request.GetConsumerGroupUUID(),
+				request.GetExtentUUID())
+		} else {
+			query = s.session.Query(
+				sqlCGUpdateAckOffsetNoOutputAndStore,
+				request.GetAckLevelAddress(),
+				request.GetAckLevelSeqNo(),
+				request.GetAckLevelSeqNoRate(),
+				request.GetReadLevelAddress(),
+				request.GetReadLevelSeqNo(),
+				request.GetReadLevelSeqNoRate(),
+				request.GetConsumerGroupUUID(),
+				request.GetExtentUUID())
+		}
 		query.Consistency(s.lowConsLevel)
 		err = query.Exec()
 	}

--- a/services/controllerhost/controllerhost.go
+++ b/services/controllerhost/controllerhost.go
@@ -1107,7 +1107,7 @@ func (mcp *Mcp) DeleteConsumerGroup(ctx thrift.Context, deleteRequest *shared.De
 			return nil
 		}
 
-		replicatorErr = localReplicator.DeleteConsumerGroup(ctx, deleteRequest)
+		replicatorErr = localReplicator.DeleteRemoteConsumerGroup(ctx, deleteRequest)
 		if replicatorErr != nil {
 			lclLg.WithField(common.TagErr, err).Error("DeleteConsumerGroup: DeleteRemoteConsumerGroup failed")
 			context.m3Client.IncCounter(metrics.ControllerDeleteConsumerGroupScope, metrics.ControllerErrCallReplicatorCounter)

--- a/services/replicator/replicator.go
+++ b/services/replicator/replicator.go
@@ -688,6 +688,7 @@ func (r *Replicator) UpdateConsumerGroup(ctx thrift.Context, updateRequest *shar
 
 	r.logger.WithFields(bark.Fields{
 		common.TagCnsPth: common.FmtCnsPth(updateRequest.GetConsumerGroupName()),
+		common.TagCnsm:   common.FmtCnsm(cgDesc.GetConsumerGroupUUID()),
 		common.TagDstPth: common.FmtDstPth(updateRequest.GetDestinationPath()),
 		common.TagDst:    common.FmtDst(cgDesc.GetDestinationUUID()),
 		common.TagDLQID:  common.FmtDLQID(cgDesc.GetDeadLetterQueueDestinationUUID()),
@@ -777,6 +778,11 @@ func (r *Replicator) DeleteConsumerGroup(ctx thrift.Context, deleteRequest *shar
 		r.m3Client.IncCounter(metrics.ReplicatorDeleteCgScope, metrics.ReplicatorFailures)
 		return err
 	}
+
+	r.logger.WithFields(bark.Fields{
+		common.TagCnsPth: common.FmtCnsPth(deleteRequest.GetConsumerGroupName()),
+		common.TagDstPth: common.FmtDstPth(deleteRequest.GetDestinationPath()),
+	}).Info(`Deleted cg`)
 
 	return nil
 }


### PR DESCRIPTION
When a ack level update is from remote, we don't update the output host or connected store. These two fields will be empty in the SetAckOffsetRequest request. This patch makes sure we exclude these two fields when updating Cassandra. 

Also included a minor bug fix related to multi_zone consumer group.