### PR TITLE
propagate cg visibility field for multi_zone destination extent

### DIFF
--- a/clients/metadata/metadata_cassandra.go
+++ b/clients/metadata/metadata_cassandra.go
@@ -2141,7 +2141,11 @@ func (s *CassandraMetadataService) CreateExtent(ctx thrift.Context, request *sha
 		}
 	}
 
-	epochMillisNow := s.createExtentImpl(extent, shared.ExtentStatus_OPEN, replicaStatsList, nil, batch)
+	var consumerGroupVisibility *string
+	if len(request.GetConsumerGroupVisibility()) > 0 {
+		consumerGroupVisibility = common.StringPtr(request.GetConsumerGroupVisibility())
+	}
+	epochMillisNow := s.createExtentImpl(extent, shared.ExtentStatus_OPEN, replicaStatsList, consumerGroupVisibility, batch)
 	if err := s.session.ExecuteBatch(batch); err != nil {
 		return nil, &shared.InternalServiceError{
 			Message: "CreateExtent: " + err.Error(),

--- a/clients/metadata/metadata_cassandra.go
+++ b/clients/metadata/metadata_cassandra.go
@@ -1210,6 +1210,7 @@ const (
 		` WHERE ` + columnDestinationUUID + `=? and ` + columnName + `=?`
 )
 
+// CreateConsumerGroup creates a consumer group.
 func (s *CassandraMetadataService) CreateConsumerGroup(ctx thrift.Context, request *shared.CreateConsumerGroupRequest) (*shared.ConsumerGroupDescription, error) {
 	uuidRequest := shared.NewCreateConsumerGroupUUIDRequest()
 	uuidRequest.Request = request

--- a/clients/metadata/metadata_cassandra_test.go
+++ b/clients/metadata/metadata_cassandra_test.go
@@ -819,7 +819,7 @@ func (s *CassandraSuite) TestUpdateStoreExtentReplicaStats() {
 	var lastSeqRate, availSeqRate float64 = 23.45, 67.89
 	var beginAddr, lastAddr int64 = 0x123456789ABCDE, 0xABCDEF012345678
 	var sizeInBytes int64 = 0x456123789
-	var sizeInBytesRate float64 = 987.67
+	var sizeInBytesRate = 987.67
 
 	stats1 := &shared.ExtentReplicaStats{
 		ExtentUUID:            common.StringPtr(extentUUID),
@@ -877,9 +877,8 @@ func (s *CassandraSuite) TestUpdateStoreExtentReplicaStats() {
 	timeDifference := func(t0, t1 int64) time.Duration {
 		if t0 > t1 {
 			return time.Unix(0, t0).Sub(time.Unix(0, t1))
-		} else {
-			return time.Unix(0, t1).Sub(time.Unix(0, t0))
 		}
+		return time.Unix(0, t1).Sub(time.Unix(0, t0))
 	}
 	s.True(timeDifference(stats1.GetBeginEnqueueTimeUtc(), stats[0].GetBeginEnqueueTimeUtc()) < time.Millisecond)
 	s.True(timeDifference(stats1.GetLastEnqueueTimeUtc(), stats[0].GetLastEnqueueTimeUtc()) < time.Millisecond)

--- a/clients/metadata/metadata_cassandra_test.go
+++ b/clients/metadata/metadata_cassandra_test.go
@@ -766,6 +766,35 @@ func (s *CassandraSuite) TestExtentCRU() {
 	}
 }
 
+func (s *CassandraSuite) TestCreateExtentWithCgVisibility() {
+	extentUUID := uuid.New()
+	destUUID := uuid.New()
+	cgUUID := uuid.New()
+	storeIds := []string{uuid.New(), uuid.New(), uuid.New()}
+	extent := &shared.Extent{
+		ExtentUUID:      common.StringPtr(extentUUID),
+		DestinationUUID: common.StringPtr(destUUID),
+		StoreUUIDs:      storeIds,
+		InputHostUUID:   common.StringPtr(uuid.New()),
+	}
+	createRequest := &shared.CreateExtentRequest{
+		Extent: extent,
+		ConsumerGroupVisibility: common.StringPtr(cgUUID),
+	}
+	_, err := s.client.CreateExtent(nil, createRequest)
+	s.Nil(err)
+
+	readExtentStats := &m.ReadExtentStatsRequest{
+		DestinationUUID: common.StringPtr(destUUID),
+		ExtentUUID: common.StringPtr(extentUUID),
+	}
+	extentStats, err := s.client.ReadExtentStats(nil, readExtentStats)
+	s.Nil(err)
+	s.NotNil(extentStats)
+	s.Equal(shared.ExtentStatus_OPEN, extentStats.GetExtentStats().GetStatus())
+	s.Equal(cgUUID, extentStats.GetExtentStats().GetConsumerGroupVisibility())
+}
+
 func (s *CassandraSuite) TestUpdateStoreExtentReplicaStats() {
 	extentUUID := uuid.New()
 	destUUID := uuid.New()

--- a/clients/metadata/metadata_cassandra_test.go
+++ b/clients/metadata/metadata_cassandra_test.go
@@ -778,7 +778,7 @@ func (s *CassandraSuite) TestCreateExtentWithCgVisibility() {
 		InputHostUUID:   common.StringPtr(uuid.New()),
 	}
 	createRequest := &shared.CreateExtentRequest{
-		Extent: extent,
+		Extent:                  extent,
 		ConsumerGroupVisibility: common.StringPtr(cgUUID),
 	}
 	_, err := s.client.CreateExtent(nil, createRequest)
@@ -786,7 +786,7 @@ func (s *CassandraSuite) TestCreateExtentWithCgVisibility() {
 
 	readExtentStats := &m.ReadExtentStatsRequest{
 		DestinationUUID: common.StringPtr(destUUID),
-		ExtentUUID: common.StringPtr(extentUUID),
+		ExtentUUID:      common.StringPtr(extentUUID),
 	}
 	extentStats, err := s.client.ReadExtentStats(nil, readExtentStats)
 	s.Nil(err)

--- a/glide.lock
+++ b/glide.lock
@@ -134,7 +134,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: 0e4e820e819caa95e2472e2b4f6a9576366460cc
+  version: 491bc3af350b3cdc0780c6f99ca9fd0a82aeb850
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/glide.lock
+++ b/glide.lock
@@ -134,7 +134,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: 861f8bd62edd6b89c8e200c230a6611647fecab8
+  version: 0e4e820e819caa95e2472e2b4f6a9576366460cc
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/services/controllerhost/consumer_test.go
+++ b/services/controllerhost/consumer_test.go
@@ -258,7 +258,7 @@ func (s *McpSuite) TestCGExtentSelectorHonorsRemoteExtent() {
 		if i%2 == 0 {
 			zone = `zone1`
 		}
-		context.mm.CreateRemoteZoneExtent(dstID, extID, inhosts[0].UUID, stores, zone, stores[0])
+		context.mm.CreateRemoteZoneExtent(dstID, extID, inhosts[0].UUID, stores, zone, stores[0], ``)
 		extents = append(extents, extID)
 		nExtents++
 	}

--- a/services/controllerhost/controllerhost.go
+++ b/services/controllerhost/controllerhost.go
@@ -1161,7 +1161,8 @@ func (mcp *Mcp) CreateRemoteZoneExtent(ctx thrift.Context, createRequest *shared
 	inputHost := common.InputHostForRemoteExtent
 
 	res, err := context.mm.CreateRemoteZoneExtent(createRequest.GetExtent().GetDestinationUUID(),
-		createRequest.GetExtent().GetExtentUUID(), inputHost, storeids, createRequest.GetExtent().GetOriginZone(), remoteExtentPrimaryStore)
+		createRequest.GetExtent().GetExtentUUID(), inputHost, storeids, createRequest.GetExtent().GetOriginZone(),
+		remoteExtentPrimaryStore, createRequest.GetConsumerGroupVisibility())
 	if err != nil {
 		lclLg.WithField(common.TagErr, err).Error("CreateRemoteZoneExtent: metadata CreateRemoteZoneExtent failed")
 		context.m3Client.IncCounter(metrics.ControllerCreateRemoteZoneExtentScope, metrics.ControllerErrMetadataUpdateCounter)

--- a/services/controllerhost/event_pipeline_test.go
+++ b/services/controllerhost/event_pipeline_test.go
@@ -314,7 +314,7 @@ func (s *EventPipelineSuite) TestStoreHostFailedEventStage2() {
 	originZone := `zone1`
 
 	for i := 0; i < len(extentIDs); i++ {
-		_, err := s.mcp.context.mm.CreateRemoteZoneExtent(dstID, extentIDs[i], inHostIDs[i], storeIDs, originZone, storeIDs[primaryStoreIdx])
+		_, err := s.mcp.context.mm.CreateRemoteZoneExtent(dstID, extentIDs[i], inHostIDs[i], storeIDs, originZone, storeIDs[primaryStoreIdx], ``)
 		s.Nil(err, "Failed to create extent")
 	}
 

--- a/services/controllerhost/extentmon_test.go
+++ b/services/controllerhost/extentmon_test.go
@@ -217,7 +217,7 @@ func (s *ExtentStateMonitorSuite) TestStoreRemoteExtentReplicatorDownTrigger() {
 	storeIDs := []string{uuid.New(), uuid.New(), uuid.New()}
 
 	context := s.mcp.context
-	_, err = context.mm.CreateRemoteZoneExtent(desc.GetDestinationUUID(), extentID, inHostID, storeIDs, "origin", storeIDs[0])
+	_, err = context.mm.CreateRemoteZoneExtent(desc.GetDestinationUUID(), extentID, inHostID, storeIDs, "origin", storeIDs[0], ``)
 	s.Nil(err, "failed to create remote zone extent")
 
 	// just have one store as healthy

--- a/services/controllerhost/metadataMgr.go
+++ b/services/controllerhost/metadataMgr.go
@@ -80,7 +80,7 @@ type (
 		// CreateExtent creates a new extent for the given destination and marks the status as OPEN
 		CreateExtent(dstID string, extentID string, inhostID string, storeIDs []string) (*shared.CreateExtentResult_, error)
 		// CreateRemoteZoneExtent creates a new remote zone extent for the given destination and marks the status as OPEN
-		CreateRemoteZoneExtent(dstID string, extentID string, inhostID string, storeIDs []string, originZone string, remoteExtentPrimaryStore string) (*shared.CreateExtentResult_, error)
+		CreateRemoteZoneExtent(dstID string, extentID string, inhostID string, storeIDs []string, originZone string, remoteExtentPrimaryStore string, consumerGroupVisibility string) (*shared.CreateExtentResult_, error)
 		// AddExtentToConsumerGroup adds an open extent to consumer group for consumption
 		AddExtentToConsumerGroup(dstID string, cgID string, extentID string, outHostID string, storeIDs []string) error
 		// ListConsumerGroupsByDstID lists all consumer groups for a given destination uuid
@@ -471,15 +471,15 @@ func (mm *metadataMgrImpl) ListExtentsByConsumerGroup(dstID string, cgID string,
 
 // CreateExtent creates a new extent for the given destination and marks the status as OPEN
 func (mm *metadataMgrImpl) CreateExtent(dstID string, extentID string, inhostID string, storeIDs []string) (*shared.CreateExtentResult_, error) {
-	return mm.createExtentInternal(dstID, extentID, inhostID, storeIDs, ``, ``)
+	return mm.createExtentInternal(dstID, extentID, inhostID, storeIDs, ``, ``, ``)
 }
 
 // CreateRemoteZoneExtent creates a new remote zone extent for the given destination and marks the status as OPEN
-func (mm *metadataMgrImpl) CreateRemoteZoneExtent(dstID string, extentID string, inhostID string, storeIDs []string, originZone string, remoteExtentPrimaryStore string) (*shared.CreateExtentResult_, error) {
-	return mm.createExtentInternal(dstID, extentID, inhostID, storeIDs, originZone, remoteExtentPrimaryStore)
+func (mm *metadataMgrImpl) CreateRemoteZoneExtent(dstID string, extentID string, inhostID string, storeIDs []string, originZone string, remoteExtentPrimaryStore string, consumerGroupVisibility string) (*shared.CreateExtentResult_, error) {
+	return mm.createExtentInternal(dstID, extentID, inhostID, storeIDs, originZone, remoteExtentPrimaryStore, consumerGroupVisibility)
 }
 
-func (mm *metadataMgrImpl) createExtentInternal(dstID string, extentID string, inhostID string, storeIDs []string, originZone string, remoteExtentPrimaryStore string) (*shared.CreateExtentResult_, error) {
+func (mm *metadataMgrImpl) createExtentInternal(dstID string, extentID string, inhostID string, storeIDs []string, originZone string, remoteExtentPrimaryStore string, consumerGroupVisibility string) (*shared.CreateExtentResult_, error) {
 
 	extent := &shared.Extent{
 		ExtentUUID:               common.StringPtr(extentID),
@@ -490,6 +490,9 @@ func (mm *metadataMgrImpl) createExtentInternal(dstID string, extentID string, i
 		RemoteExtentPrimaryStore: common.StringPtr(remoteExtentPrimaryStore),
 	}
 	mReq := &shared.CreateExtentRequest{Extent: extent}
+	if len(consumerGroupVisibility) > 0 {
+		mReq.ConsumerGroupVisibility = common.StringPtr(consumerGroupVisibility)
+	}
 
 	res, err := mm.mClient.CreateExtent(nil, mReq)
 	if err != nil {

--- a/services/replicator/metadataReconciler.go
+++ b/services/replicator/metadataReconciler.go
@@ -618,7 +618,7 @@ func (r *metadataReconciler) reconcileCgExtentMetadata(localCgs []*shared.Consum
 	return nil
 }
 
-func (r *metadataReconciler) getAllDestExtentInRemoteZone(zone string, destUUID string) (map[string]shared.ExtentStatus, error) {
+func (r *metadataReconciler) getAllDestExtentInRemoteZone(zone string, destUUID string) (map[string]*shared.ExtentStats, error) {
 	var err error
 	remoteReplicator, err := r.replicator.replicatorclientFactory.GetReplicatorClient(zone)
 	if err != nil {
@@ -635,7 +635,7 @@ func (r *metadataReconciler) getAllDestExtentInRemoteZone(zone string, destUUID 
 		Limit:            common.Int64Ptr(metadataListRequestPageSize),
 	}
 
-	extents := make(map[string]shared.ExtentStatus)
+	extents := make(map[string]*shared.ExtentStats)
 	for {
 		ctx, cancel := thrift.NewContext(remoteReplicatorCallTimeOut)
 		defer cancel()
@@ -646,7 +646,7 @@ func (r *metadataReconciler) getAllDestExtentInRemoteZone(zone string, destUUID 
 		}
 
 		for _, ext := range res.GetExtentStatsList() {
-			extents[ext.GetExtent().GetExtentUUID()] = ext.GetStatus()
+			extents[ext.GetExtent().GetExtentUUID()] = ext
 		}
 
 		if len(res.GetNextPageToken()) == 0 {
@@ -659,14 +659,14 @@ func (r *metadataReconciler) getAllDestExtentInRemoteZone(zone string, destUUID 
 	return extents, nil
 }
 
-func (r *metadataReconciler) getAllDestExtentInCurrentZone(destUUID string) (map[string]map[string]shared.ExtentStatus, error) {
+func (r *metadataReconciler) getAllDestExtentInCurrentZone(destUUID string) (map[string]map[string]*shared.ExtentStats, error) {
 	listReq := &shared.ListExtentsStatsRequest{
 		DestinationUUID:  common.StringPtr(destUUID),
 		LocalExtentsOnly: common.BoolPtr(false),
 		Limit:            common.Int64Ptr(metadataListRequestPageSize),
 	}
 
-	perZoneExtents := make(map[string]map[string]shared.ExtentStatus)
+	perZoneExtents := make(map[string]map[string]*shared.ExtentStats)
 	for {
 		res, err := r.mClient.ListExtentsStats(nil, listReq)
 		if err != nil {
@@ -677,9 +677,9 @@ func (r *metadataReconciler) getAllDestExtentInCurrentZone(destUUID string) (map
 		for _, ext := range res.GetExtentStatsList() {
 			zone := ext.GetExtent().GetOriginZone()
 			if _, ok := perZoneExtents[zone]; !ok {
-				perZoneExtents[zone] = make(map[string]shared.ExtentStatus)
+				perZoneExtents[zone] = make(map[string]*shared.ExtentStats)
 			}
-			perZoneExtents[zone][ext.GetExtent().GetExtentUUID()] = ext.GetStatus()
+			perZoneExtents[zone][ext.GetExtent().GetExtentUUID()] = ext
 		}
 
 		if len(res.GetNextPageToken()) == 0 {
@@ -767,13 +767,14 @@ func (r *metadataReconciler) getAllCgExtentInCurrentZone(destUUID string, cgUUID
 	return cgExtents, nil
 }
 
-func (r *metadataReconciler) reconcileDestExtent(destUUID string, localExtents map[string]shared.ExtentStatus, remoteExtents map[string]shared.ExtentStatus, remoteZone string) {
+func (r *metadataReconciler) reconcileDestExtent(destUUID string, localExtents map[string]*shared.ExtentStats, remoteExtents map[string]*shared.ExtentStats, remoteZone string) {
 	var remoteDeletedLocalNotCount int64
 	var remoteConsumedLocalMissingCount int64
 	var remoteDeletedLocalMissingCount int64
 	var foundMissingCount int64
-	for remoteExtentUUID, remoteExtentStatus := range remoteExtents {
-		localExtentStatus, ok := localExtents[remoteExtentUUID]
+	for remoteExtentUUID, remoteExtentStats := range remoteExtents {
+		remoteExtentStatus := remoteExtentStats.GetStatus()
+		localExtentStats, ok := localExtents[remoteExtentUUID]
 		if !ok {
 			r.logger.WithFields(bark.Fields{
 				common.TagDst:          common.FmtDst(destUUID),
@@ -803,6 +804,12 @@ func (r *metadataReconciler) reconcileDestExtent(destUUID string, localExtents m
 					OriginZone:      common.StringPtr(remoteZone),
 				},
 			}
+
+			// if the remote extent has cg visibility set (a merged dlq extent), propagate that field too.
+			if remoteExtentStats.IsSetConsumerGroupVisibility() {
+				createRequest.ConsumerGroupVisibility = common.StringPtr(remoteExtentStats.GetConsumerGroupVisibility())
+			}
+
 			ctx, cancel := thrift.NewContext(localReplicatorCallTimeOut)
 			defer cancel()
 			_, err := r.replicator.CreateExtent(ctx, createRequest)
@@ -816,6 +823,7 @@ func (r *metadataReconciler) reconcileDestExtent(destUUID string, localExtents m
 				continue
 			}
 		} else {
+			localExtentStatus := localExtentStats.GetStatus()
 			if (remoteExtentStatus == shared.ExtentStatus_SEALED || remoteExtentStatus == shared.ExtentStatus_CONSUMED) && localExtentStatus == shared.ExtentStatus_OPEN {
 				r.sealExtentInMetadata(destUUID, remoteExtentUUID)
 			}
@@ -833,9 +841,9 @@ func (r *metadataReconciler) reconcileDestExtent(destUUID string, localExtents m
 	// we act on it only after it has been missing for a certain period of time
 
 	remoteMissingExtents := make(map[string]struct{})
-	for localExtentUUID, localExtentStatus := range localExtents {
+	for localExtentUUID, localExtentStats := range localExtents {
 		// we're going to delete this extent soon locally so no need to act on it
-		if localExtentStatus == shared.ExtentStatus_CONSUMED || localExtentStatus == shared.ExtentStatus_DELETED {
+		if localExtentStats.GetStatus() == shared.ExtentStatus_CONSUMED || localExtentStats.GetStatus() == shared.ExtentStatus_DELETED {
 			continue
 		}
 		if _, ok := remoteExtents[localExtentUUID]; !ok {
@@ -853,7 +861,7 @@ func (r *metadataReconciler) reconcileDestExtent(destUUID string, localExtents m
 			delete(r.suspectMissingExtents, suspectExtent)
 		} else {
 			if time.Since(suspectExtentInfo.missingSince) > extentMissingDurationThreshold {
-				localStatus, ok := localExtents[suspectExtent]
+				localStats, ok := localExtents[suspectExtent]
 				if !ok {
 					r.logger.WithFields(bark.Fields{
 						common.TagDst: common.FmtDst(suspectExtentInfo.destUUID),
@@ -861,7 +869,7 @@ func (r *metadataReconciler) reconcileDestExtent(destUUID string, localExtents m
 					}).Error(`code bug!! suspect extent should in local extent map!!`)
 					continue
 				}
-				r.handleExtentDeletedOrMissingInRemote(suspectExtentInfo.destUUID, suspectExtent, localStatus, &remoteDeletedLocalNotCount)
+				r.handleExtentDeletedOrMissingInRemote(suspectExtentInfo.destUUID, suspectExtent, localStats.GetStatus(), &remoteDeletedLocalNotCount)
 			}
 		}
 	}

--- a/services/replicator/metadataReconciler.go
+++ b/services/replicator/metadataReconciler.go
@@ -1045,7 +1045,7 @@ func (r *metadataReconciler) handleExtentDeletedOrMissingInRemote(destUUID strin
 	}
 }
 
-func (r *metadataReconciler) cgExistInLocal(cgUUID string) (bool, error){
+func (r *metadataReconciler) cgExistInLocal(cgUUID string) (bool, error) {
 	_, err := r.mClient.ReadConsumerGroupByUUID(nil, &shared.ReadConsumerGroupRequest{
 		ConsumerGroupUUID: common.StringPtr(cgUUID),
 	})
@@ -1054,7 +1054,7 @@ func (r *metadataReconciler) cgExistInLocal(cgUUID string) (bool, error){
 			return false, nil
 		}
 		r.logger.WithFields(bark.Fields{
-			common.TagErr: err,
+			common.TagErr:  err,
 			common.TagCnsm: common.FmtCnsm(cgUUID),
 		}).Error(`cgExistInLocal: failed to call ReadConsumerGroupByUUID`)
 		return false, err

--- a/services/replicator/metadataReconciler.go
+++ b/services/replicator/metadataReconciler.go
@@ -897,7 +897,7 @@ func (r *metadataReconciler) reconcileDestExtent(destUUID string, localExtents m
 	}
 
 	// now add new suspect if there's any
-	for missingExtent, _ := range remoteMissingExtents {
+	for missingExtent := range remoteMissingExtents {
 		if _, ok := r.suspectMissingExtents[missingExtent]; !ok {
 			r.suspectMissingExtents[missingExtent] = missingExtentInfo{
 				destUUID:     destUUID,
@@ -1058,9 +1058,9 @@ func (r *metadataReconciler) cgExistInLocal(cgUUID string) (bool, error) {
 			common.TagCnsm: common.FmtCnsm(cgUUID),
 		}).Error(`cgExistInLocal: failed to call ReadConsumerGroupByUUID`)
 		return false, err
-	} else {
-		return true, nil
 	}
+
+	return true, nil
 }
 
 func (r *metadataReconciler) sealExtentInMetadata(destUUID string, extentUUID string) {

--- a/services/replicator/replicator_test.go
+++ b/services/replicator/replicator_test.go
@@ -1359,7 +1359,7 @@ func (s *ReplicatorSuite) TestDestExtentMetadataReconcileLocalMissingDLQExtent()
 	localExtents := make(map[string]*shared.ExtentStats)
 	remoteExtents := make(map[string]*shared.ExtentStats)
 	remoteExtents[missingExtent] = &shared.ExtentStats{
-		Status: common.MetadataExtentStatusPtr(shared.ExtentStatus_OPEN),
+		Status:                  common.MetadataExtentStatusPtr(shared.ExtentStatus_OPEN),
 		ConsumerGroupVisibility: common.StringPtr(cg),
 	}
 	reconciler.reconcileDestExtent(dest, localExtents, remoteExtents, remoteZone)
@@ -1387,7 +1387,7 @@ func (s *ReplicatorSuite) TestDestExtentMetadataReconcileLocalMissingDLQExtentRe
 	localExtents := make(map[string]*shared.ExtentStats)
 	remoteExtents := make(map[string]*shared.ExtentStats)
 	remoteExtents[missingExtent] = &shared.ExtentStats{
-		Status: common.MetadataExtentStatusPtr(shared.ExtentStatus_OPEN),
+		Status:                  common.MetadataExtentStatusPtr(shared.ExtentStatus_OPEN),
 		ConsumerGroupVisibility: common.StringPtr(cg),
 	}
 	reconciler.reconcileDestExtent(dest, localExtents, remoteExtents, remoteZone)

--- a/services/replicator/replicator_test.go
+++ b/services/replicator/replicator_test.go
@@ -1322,9 +1322,42 @@ func (s *ReplicatorSuite) TestDestExtentMetadataReconcileLocalMissing() {
 		s.Equal(remoteZone, req.GetExtent().GetOriginZone())
 	})
 
-	localExtents := make(map[string]shared.ExtentStatus)
-	remoteExtents := make(map[string]shared.ExtentStatus)
-	remoteExtents[missingExtent] = shared.ExtentStatus_OPEN
+	localExtents := make(map[string]*shared.ExtentStats)
+	remoteExtents := make(map[string]*shared.ExtentStats)
+	remoteExtents[missingExtent] = &shared.ExtentStats{
+		Status: common.MetadataExtentStatusPtr(shared.ExtentStatus_OPEN),
+	}
+	reconciler.reconcileDestExtent(dest, localExtents, remoteExtents, remoteZone)
+	s.mockControllerClient.AssertExpectations(s.T())
+}
+
+// local zone is missing one dlq destination extent compared to remote. Expect to create the missing destination extent
+func (s *ReplicatorSuite) TestDestExtentMetadataReconcileLocalMissingDLQExtent() {
+	localZone := `zone2`
+	remoteZone := `zone1`
+	missingExtent := uuid.New()
+	dest := uuid.New()
+	cg := uuid.New()
+
+	repliator, _ := NewReplicator("replicator-test", s.mockService, s.mockMeta, s.mockReplicatorClientFactory, s.cfg)
+	reconciler, _ := NewMetadataReconciler(repliator.metaClient, repliator, localZone, repliator.logger, repliator.m3Client).(*metadataReconciler)
+
+	// setup mock
+	s.mockControllerClient.On("CreateRemoteZoneExtent", mock.Anything, mock.Anything).Return(shared.NewCreateExtentResult_(), nil).Run(func(args mock.Arguments) {
+		req := args.Get(1).(*shared.CreateExtentRequest)
+		s.True(req.IsSetExtent())
+		s.Equal(missingExtent, req.GetExtent().GetExtentUUID())
+		s.Equal(dest, req.GetExtent().GetDestinationUUID())
+		s.Equal(remoteZone, req.GetExtent().GetOriginZone())
+		s.Equal(cg, req.GetConsumerGroupVisibility())
+	})
+
+	localExtents := make(map[string]*shared.ExtentStats)
+	remoteExtents := make(map[string]*shared.ExtentStats)
+	remoteExtents[missingExtent] = &shared.ExtentStats{
+		Status: common.MetadataExtentStatusPtr(shared.ExtentStatus_OPEN),
+		ConsumerGroupVisibility: common.StringPtr(cg),
+	}
 	reconciler.reconcileDestExtent(dest, localExtents, remoteExtents, remoteZone)
 	s.mockControllerClient.AssertExpectations(s.T())
 }
@@ -1339,9 +1372,11 @@ func (s *ReplicatorSuite) TestDestExtentMetadataReconcileLocalMissingConsumedExt
 	repliator, _ := NewReplicator("replicator-test", s.mockService, s.mockMeta, s.mockReplicatorClientFactory, s.cfg)
 	reconciler, _ := NewMetadataReconciler(repliator.metaClient, repliator, localZone, repliator.logger, repliator.m3Client).(*metadataReconciler)
 
-	localExtents := make(map[string]shared.ExtentStatus)
-	remoteExtents := make(map[string]shared.ExtentStatus)
-	remoteExtents[missingExtent] = shared.ExtentStatus_CONSUMED
+	localExtents := make(map[string]*shared.ExtentStats)
+	remoteExtents := make(map[string]*shared.ExtentStats)
+	remoteExtents[missingExtent] = &shared.ExtentStats{
+		Status: common.MetadataExtentStatusPtr(shared.ExtentStatus_CONSUMED),
+	}
 	reconciler.reconcileDestExtent(dest, localExtents, remoteExtents, remoteZone)
 	s.mockControllerClient.AssertExpectations(s.T())
 }
@@ -1355,8 +1390,8 @@ func (s *ReplicatorSuite) TestDestExtentMetadataReconcileLocalAndRemoteEmpty() {
 	repliator, _ := NewReplicator("replicator-test", s.mockService, s.mockMeta, s.mockReplicatorClientFactory, s.cfg)
 	reconciler, _ := NewMetadataReconciler(repliator.metaClient, repliator, localZone, repliator.logger, repliator.m3Client).(*metadataReconciler)
 
-	localExtents := make(map[string]shared.ExtentStatus)
-	remoteExtents := make(map[string]shared.ExtentStatus)
+	localExtents := make(map[string]*shared.ExtentStats)
+	remoteExtents := make(map[string]*shared.ExtentStats)
 	reconciler.reconcileDestExtent(dest, localExtents, remoteExtents, remoteZone)
 	s.mockControllerClient.AssertExpectations(s.T())
 }
@@ -1379,10 +1414,14 @@ func (s *ReplicatorSuite) TestDestExtentMetadataReconcileInconsistentStatus() {
 		s.Equal(shared.ExtentStatus_SEALED, req.GetStatus())
 	})
 
-	localExtents := make(map[string]shared.ExtentStatus)
-	remoteExtents := make(map[string]shared.ExtentStatus)
-	remoteExtents[extent] = shared.ExtentStatus_SEALED
-	localExtents[extent] = shared.ExtentStatus_OPEN
+	localExtents := make(map[string]*shared.ExtentStats)
+	remoteExtents := make(map[string]*shared.ExtentStats)
+	remoteExtents[extent] = &shared.ExtentStats{
+		Status: common.MetadataExtentStatusPtr(shared.ExtentStatus_SEALED),
+	}
+	localExtents[extent] = &shared.ExtentStats{
+		Status: common.MetadataExtentStatusPtr(shared.ExtentStatus_OPEN),
+	}
 	reconciler.reconcileDestExtent(dest, localExtents, remoteExtents, remoteZone)
 	s.mockMeta.AssertExpectations(s.T())
 }
@@ -1421,10 +1460,14 @@ func (s *ReplicatorSuite) TestDestExtentMetadataReconcileRemoteDeletedLocalNot()
 		s.Equal(extent, req.GetExtentUUID())
 	})
 
-	localExtents := make(map[string]shared.ExtentStatus)
-	remoteExtents := make(map[string]shared.ExtentStatus)
-	remoteExtents[extent] = shared.ExtentStatus_DELETED
-	localExtents[extent] = shared.ExtentStatus_OPEN
+	localExtents := make(map[string]*shared.ExtentStats)
+	remoteExtents := make(map[string]*shared.ExtentStats)
+	remoteExtents[extent] = &shared.ExtentStats{
+		Status: common.MetadataExtentStatusPtr(shared.ExtentStatus_DELETED),
+	}
+	localExtents[extent] = &shared.ExtentStats{
+		Status: common.MetadataExtentStatusPtr(shared.ExtentStatus_OPEN),
+	}
 	reconciler.reconcileDestExtent(dest, localExtents, remoteExtents, remoteZone)
 	s.mockMeta.AssertExpectations(s.T())
 	s.mockStoreClient.AssertExpectations(s.T())
@@ -1442,9 +1485,11 @@ func (s *ReplicatorSuite) TestDestExtentMetadataReconcileRemoteGoneLocalNot() {
 	reconciler, _ := NewMetadataReconciler(repliator.metaClient, repliator, localZone, repliator.logger, repliator.m3Client).(*metadataReconciler)
 
 	// step1: found extent missing from remote. No action expected, only added to suspect list
-	localExtents := make(map[string]shared.ExtentStatus)
-	remoteExtents := make(map[string]shared.ExtentStatus)
-	localExtents[extent] = shared.ExtentStatus_OPEN
+	localExtents := make(map[string]*shared.ExtentStats)
+	remoteExtents := make(map[string]*shared.ExtentStats)
+	localExtents[extent] = &shared.ExtentStats{
+		Status: common.MetadataExtentStatusPtr(shared.ExtentStatus_OPEN),
+	}
 	reconciler.reconcileDestExtent(dest, localExtents, remoteExtents, remoteZone)
 	s.mockMeta.AssertExpectations(s.T())
 	s.mockStoreClient.AssertExpectations(s.T())
@@ -1509,7 +1554,9 @@ func (s *ReplicatorSuite) TestDestExtentMetadataReconcileRemoteGoneLocalNot() {
 	s.Equal(1, len(reconciler.suspectMissingExtents))
 
 	// step4: add the extent in remote zone, expect no action, and extent removed from suspect list
-	remoteExtents[extent] = shared.ExtentStatus_OPEN
+	remoteExtents[extent] = &shared.ExtentStats{
+		Status: common.MetadataExtentStatusPtr(shared.ExtentStatus_OPEN),
+	}
 	reconciler.reconcileDestExtent(dest, localExtents, remoteExtents, remoteZone)
 	s.mockMeta.AssertExpectations(s.T())
 	s.mockStoreClient.AssertExpectations(s.T())


### PR DESCRIPTION
After a dlq extent is merged to a multi_zone destination(by calling MoveExtent), the reconciliation process in remote replicator(slow path) will detect that extent and create it in remote. This patch makes sure the cg visibility field in propagated in this case.

Note there's no fast path here. When MoveExtent is called locally, this call is NOT propagated to remote zone immediately. Ideally we should but it adds lots of complexity(basically we have to expose MoveExtent as an API call in a couple of places). In the other hand, the dlq extent is only useful after the consumer group does a active zone switch(failover) so having a larger delay(10 mins) shouldn't be a big deal.

thrift change: https://github.com/uber/cherami-thrift/pull/20