### PR TITLE
Make sure we unlock the held lock

### DIFF
--- a/services/inputhost/inputhost_test.go
+++ b/services/inputhost/inputhost_test.go
@@ -1459,6 +1459,125 @@ func (s *InputHostSuite) TestInputExtHostDrain() {
 	inputHost.Shutdown()
 }
 
+func (s *InputHostSuite) TestInputExtHostDrainDuplicate() {
+	destinationPath := "foo"
+
+	// setup mockService here to use the mock admin controller client
+	ch, _ := tchannel.NewChannel("cherami-test-drain-in", nil)
+	mockService := new(common.MockService)
+	mockService.On("GetConfig").Return(s.cfg.GetServiceConfig(common.InputServiceName))
+	mockService.On("GetMetricsReporter").Return(common.NewMetricReporterWithHostname(configure.NewCommonServiceConfig()))
+	mockService.On("GetDConfigClient").Return(dconfig.NewDconfigClient(configure.NewCommonServiceConfig(), common.InputServiceName))
+	mockService.On("GetTChannel").Return(ch)
+	mockService.On("IsLimitsEnabled").Return(true)
+	mockService.On("GetHostConnLimit").Return(100)
+	mockService.On("GetHostConnLimitPerSecond").Return(100)
+	mockService.On("GetWSConnector").Return(s.mockWSConnector, nil)
+
+	mockAdminC := &mockAdminController{}
+	mockClientFactory := new(mockcommon.MockClientFactory)
+	mockClientFactory.On("GetThriftStoreClient", mock.Anything, mock.Anything).Return(store.TChanBStore(s.mockStore), nil)
+	mockClientFactory.On("ReleaseThriftStoreClient", mock.Anything).Return(nil)
+	mockClientFactory.On("GetAdminControllerClient").Return(mockAdminC, nil)
+	mockService.On("GetClientFactory").Return(mockClientFactory)
+
+	mockLoadReporterDaemonFactory := setupMockLoadReporterDaemonFactory()
+	mockService.On("GetLoadReporterDaemonFactory").Return(mockLoadReporterDaemonFactory)
+	mockService.On("GetHostUUID").Return("99999999-9999-9999-9999-999999999999")
+	mockService.On("GetRingpopMonitor").Return(s.mockRpm)
+
+	inputHost, _ := NewInputHost("inputhost-test", mockService, s.mockMeta, nil)
+	ctx, cancel := utilGetThriftContextWithPath(destinationPath)
+	defer cancel()
+
+	msg := cherami.NewPutMessage()
+	msg.ID = common.StringPtr(strconv.Itoa(1))
+	msg.Data = []byte("hello")
+
+	wCh := make(chan time.Time)
+
+	s.mockAppend.On("Read").Return(nil, io.EOF).WaitUntil(wCh)
+	s.mockAppend.On("Write", mock.Anything).Return(io.EOF).WaitUntil(wCh)
+	s.mockPub.On("Read").Return(nil, io.EOF).WaitUntil(wCh)
+	s.mockPub.On("Write", mock.Anything).Return(io.EOF).WaitUntil(wCh)
+
+	aMsg := store.NewAppendMessageAck()
+	aMsg.Status = common.CheramiStatusPtr(cherami.Status_OK)
+	aMsg.Address = common.Int64Ptr(int64(100))
+
+	putMsgCh := make(chan *inPutMessage, 1)
+	ackChannel := make(chan *cherami.PutMessageAck, 1)
+
+	go func() {
+		inputHost.OpenPublisherStream(ctx, s.mockPub)
+	}()
+
+	// wait for the extent to be loaded
+	common.SpinWaitOnCondition(func() bool {
+		return inputHost.hostMetrics.Get(load.HostMetricNumOpenExtents) == 1
+	}, time.Second)
+
+	// 3. Make sure we just have one extent
+	var connection *extHost
+	pathCache, ok := inputHost.getPathCacheByDestPath("foo")
+	s.True(ok)
+	pathCache.Lock()
+	s.Equal(1, len(pathCache.extentCache))
+	for _, extCache := range pathCache.extentCache {
+		connection = extCache.connection
+	}
+	pathCache.Unlock()
+
+	inMsg := &inPutMessage{
+		putMsg:      msg,
+		putMsgAckCh: ackChannel,
+	}
+	putMsgCh <- inMsg
+
+	// send a drain request
+	req := admin.NewDrainExtentsRequest()
+	req.UpdateUUID = common.StringPtr(uuid.New())
+
+	drainReq := admin.NewDrainExtents()
+	drainReq.DestinationUUID = common.StringPtr(pathCache.destUUID)
+	drainReq.ExtentUUID = common.StringPtr(connection.extUUID)
+	req.Extents = append(req.Extents, drainReq)
+
+	dCtx, dCancel := thrift.NewContext(2 * time.Second)
+	defer dCancel()
+	err := inputHost.DrainExtent(dCtx, req)
+	s.Error(err)
+	// Note: we will timeout here since the store connections are mocked to block above
+	assert.IsType(s.T(), ErrDrainTimedout, err)
+	// we should have definitely stopped the write pump at this point
+	drained := false
+	select {
+	case <-connection.closeChannel:
+		drained = true
+	case <-time.After(5 * time.Second):
+	}
+
+	s.Equal(true, drained)
+
+	// send another drain request
+	// this should just bail out, since we have already started drain above
+	err = inputHost.DrainExtent(dCtx, req)
+	s.NoError(err)
+
+	// try to get the pathCacheLock, it should succeed
+	common.SpinWaitOnCondition(func() bool {
+		pathCache.Lock()
+		// got the lock.. now unlock
+		pathCache.Unlock()
+		return true
+	}, time.Second)
+
+	// close everything
+	close(wCh)
+	connection.close()
+	inputHost.Shutdown()
+}
+
 func setupMockLoadReporterDaemonFactory() *common.MockLoadReporterDaemonFactory {
 	mockLoadReporterDaemonFactory := new(common.MockLoadReporterDaemonFactory)
 	mockLoadReporterDaemon := new(common.MockLoadReporterDaemon)

--- a/services/inputhost/pathCache.go
+++ b/services/inputhost/pathCache.go
@@ -560,5 +560,8 @@ func (pathCache *inPathCache) drainExtent(extUUID string, updateUUID string, dra
 		// do best effort waiting to notify all connections here
 		common.AwaitWaitGroup(&connDrainWG, connWGTimeout)
 		extCache.connection.stopWrite(drainTimeout)
+	} else {
+		// we need to unlock the lock held above
+		pathCache.RUnlock()
 	}
 }

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -557,7 +557,7 @@ func (s *NetIntegrationSuiteParallelE) TestWriteWithDrain() {
 		Path:              destPath,
 		ConsumerGroupName: cgPath,
 		ConsumerName:      "TestConsumerName",
-		PrefetchCount:     1,
+		PrefetchCount:     50,
 		Options:           &client.ClientOptions{Timeout: time.Second * 30}, // this is the thrift context timeout
 	}
 
@@ -565,7 +565,7 @@ func (s *NetIntegrationSuiteParallelE) TestWriteWithDrain() {
 	s.NotNil(consumerTest)
 
 	// Open the consumer channel
-	delivery := make(chan client.Delivery, 1)
+	delivery := make(chan client.Delivery, 50)
 	delivery, err = consumerTest.Open(delivery)
 	s.NoError(err)
 


### PR DESCRIPTION
If an extent is already drained or is not active, we leave the RLock
as is when it should be unlocked!

TODO: In the process of adding more tests