### PR TITLE
Add ability to handle planned upgrades

### DIFF
--- a/cmd/servicecmd/servicestartcmd.go
+++ b/cmd/servicecmd/servicestartcmd.go
@@ -79,7 +79,7 @@ func StartInputHostService() {
 		cfg.GetServiceConfig(serviceName).GetWebsocketPort(), h)
 
 	// start diagnosis local http server
-	common.ServiceLoop(cfg.GetServiceConfig(serviceName).GetPort()+diagnosticPortOffset, cfg, sCommon)
+	common.ServiceLoop(cfg.GetServiceConfig(serviceName).GetPort()+diagnosticPortOffset, cfg, h)
 }
 
 //StartControllerService starts the controller service of cherami

--- a/common/httphandlers.go
+++ b/common/httphandlers.go
@@ -37,7 +37,7 @@ import (
 // for controller
 type HTTPHandler struct {
 	cfg     configure.CommonAppConfig
-	service *Service
+	service SCommon
 }
 
 const (
@@ -49,7 +49,7 @@ var serviceNames = []string{InputServiceName, OutputServiceName, StoreServiceNam
 // NewHTTPHandler returns a new instance of
 // http handler. This call must be followed
 // by a call to httpHandler.Register().
-func NewHTTPHandler(cfg configure.CommonAppConfig, service *Service) *HTTPHandler {
+func NewHTTPHandler(cfg configure.CommonAppConfig, service SCommon) *HTTPHandler {
 	return &HTTPHandler{
 		cfg:     cfg,
 		service: service,
@@ -74,6 +74,9 @@ func (handler *HTTPHandler) Register(mux *http.ServeMux) {
 	mux.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
 	mux.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
 	mux.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
+
+	// Register service specific upgrade handlers
+	mux.Handle("/upgrade", http.HandlerFunc(handler.service.UpgradeHandler))
 }
 
 // Help is the http handler for /help

--- a/common/mockservice.go
+++ b/common/mockservice.go
@@ -21,6 +21,8 @@
 package common
 
 import (
+	"net/http"
+
 	"github.com/uber/cherami-server/common/configure"
 	dconfig "github.com/uber/cherami-server/common/dconfigclient"
 	"github.com/uber/cherami-server/common/metrics"
@@ -122,6 +124,12 @@ func (m *MockService) GetLoadReporterDaemonFactory() LoadReporterDaemonFactory {
 // Report is the implementation for reporting host specific load to controller
 func (m *MockService) Report(reporter LoadReporter) {
 	m.Called(reporter)
+	return
+}
+
+// UpgradeHandler is the implementation for upgrade handler
+func (m *MockService) UpgradeHandler(w http.ResponseWriter, r *http.Request) {
+	m.Called(w, r)
 	return
 }
 

--- a/common/service.go
+++ b/common/service.go
@@ -244,6 +244,7 @@ func (h *Service) Report(reporter LoadReporter) {
 	// TODO: Report Host specific load here like CPU, Memory and Diskspace
 }
 
+// UpgradeHandler is used to implement the upgrade endpoint
 func (h *Service) UpgradeHandler(w http.ResponseWriter, r *http.Request) {
 	// register service specific upgrade handler
 }

--- a/common/service.go
+++ b/common/service.go
@@ -23,6 +23,7 @@ package common
 import (
 	"fmt"
 	"math/rand"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -241,6 +242,10 @@ func (h *Service) Stop() {
 // Report is used for reporting Host specific load to controller
 func (h *Service) Report(reporter LoadReporter) {
 	// TODO: Report Host specific load here like CPU, Memory and Diskspace
+}
+
+func (h *Service) UpgradeHandler(w http.ResponseWriter, r *http.Request) {
+	// register service specific upgrade handler
 }
 
 // IsDevelopmentEnvironment detects if we are running in a development environment

--- a/common/servicetypes.go
+++ b/common/servicetypes.go
@@ -113,5 +113,8 @@ type (
 
 		// IsLimitsEnabled is used to see if we need to enforce limits on this service
 		IsLimitsEnabled() bool
+
+		// UpgradeHandler is the hanler for the upgrade end point for this service
+		UpgradeHandler(w http.ResponseWriter, r *http.Request)
 	}
 )

--- a/common/util.go
+++ b/common/util.go
@@ -176,9 +176,9 @@ func CreateHyperbahnClient(ch *tchannel.Channel, bootstrapFile string) *hyperbah
 	return hClient
 }
 
-// GetHttpListenAddress is a utlility routine to give out the appropriate
+// GetHTTPListenAddress is a utlility routine to give out the appropriate
 // listen address for the http endpoint
-func GetHttpListenAddress(cfgListenAddress net.IP) string {
+func GetHTTPListenAddress(cfgListenAddress net.IP) string {
 	listenAddress := `127.0.0.1`
 	if cfgListenAddress.IsLoopback() { // If we have a particular loopback listen address, override the default
 		listenAddress = cfgListenAddress.String()
@@ -193,7 +193,7 @@ func ServiceLoop(port int, cfg configure.CommonAppConfig, service SCommon) {
 	mux := http.NewServeMux()
 	httpHandlers.Register(mux)
 
-	listenAddress := GetHttpListenAddress(service.GetConfig().GetListenAddress())
+	listenAddress := GetHTTPListenAddress(service.GetConfig().GetListenAddress())
 	log.Info(fmt.Sprintf("Diagnostic http endpoint listening on %s:%d", listenAddress, port))
 	log.Panic(http.ListenAndServe(fmt.Sprintf("%s:%d", listenAddress, port), mux))
 }

--- a/common/util.go
+++ b/common/util.go
@@ -774,7 +774,7 @@ func StringSetEqual(a, b []string) bool {
 	return StringSetEqual(b, a) // Above we checked only that all A are in B; check all B in A
 }
 
-// HandleSignal handles the passed in signal and calls the upgrade endpoint
+// HandleSignal handles the passed in signal and calls the appropriate callback
 func HandleSignal(sig os.Signal, hostPort string, endpoint string, timeout time.Duration, handleFunc HandleSignalFunc) {
 	lcLg := GetDefaultLogger()
 	c := make(chan os.Signal, 1)

--- a/common/util.go
+++ b/common/util.go
@@ -172,14 +172,15 @@ func CreateHyperbahnClient(ch *tchannel.Channel, bootstrapFile string) *hyperbah
 }
 
 // ServiceLoop runs the http admin endpoints. This is a blocking call.
-func ServiceLoop(port int, cfg configure.CommonAppConfig, service *Service) {
+func ServiceLoop(port int, cfg configure.CommonAppConfig, service SCommon) {
 	httpHandlers := NewHTTPHandler(cfg, service)
 	mux := http.NewServeMux()
 	httpHandlers.Register(mux)
 
+	log.Infof("Registering upgrade handler>>")
 	listenAddress := `127.0.0.1`
-	if service.cfg.GetListenAddress().IsLoopback() { // If we have a particular loopback listen address, override the default
-		listenAddress = service.cfg.GetListenAddress().String()
+	if service.GetConfig().GetListenAddress().IsLoopback() { // If we have a particular loopback listen address, override the default
+		listenAddress = service.GetConfig().GetListenAddress().String()
 	}
 	log.Info(fmt.Sprintf("Diagnostic http endpoint listening on %s:%d", listenAddress, port))
 	log.Panic(http.ListenAndServe(fmt.Sprintf("%s:%d", listenAddress, port), mux))

--- a/services/inputhost/inputhost.go
+++ b/services/inputhost/inputhost.go
@@ -981,6 +981,13 @@ func (h *InputHost) RegisterWSHandler() *http.ServeMux {
 	return mux
 }
 
+// UpgradeHandler implements the upgrade end point
+func (h *InputHost) UpgradeHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	fmt.Fprintf(w, "Upgrade called!!!!\n")
+	// perform upgrade here
+}
+
 //
 // NewInputHost is the constructor for BIn
 func NewInputHost(serviceName string, sVice common.SCommon, mClient metadata.TChanMetadataService, opts *InOptions) (*InputHost, []thrift.TChanServer) {

--- a/services/inputhost/inputhost.go
+++ b/services/inputhost/inputhost.go
@@ -984,11 +984,12 @@ func (h *InputHost) RegisterWSHandler() *http.ServeMux {
 // UpgradeHandler implements the upgrade end point
 func (h *InputHost) UpgradeHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	fmt.Fprintf(w, "Upgrade called!!!!\n")
+	fmt.Fprintf(w, "Upgrade endpoint called on inputhost\n")
 	// perform upgrade here
+	// 1. Report the node as going down to controller
+	// 2. go drain everything in the pathCache
 }
 
-//
 // NewInputHost is the constructor for BIn
 func NewInputHost(serviceName string, sVice common.SCommon, mClient metadata.TChanMetadataService, opts *InOptions) (*InputHost, []thrift.TChanServer) {
 

--- a/services/inputhost/inputhost.go
+++ b/services/inputhost/inputhost.go
@@ -779,7 +779,7 @@ func getDrainTimeout(ctx thrift.Context) time.Duration {
 	return defaultDrainTimeout
 }
 
-// DrainExtents is the implementation of the thrift handler for the inputhost
+// DrainExtent is the implementation of the thrift handler for the inputhost
 func (h *InputHost) DrainExtent(ctx thrift.Context, request *admin.DrainExtentsRequest) (err error) {
 	defer atomic.AddInt32(&h.loadShutdownRef, -1)
 	sw := h.m3Client.StartTimer(metrics.DrainExtentsScope, metrics.InputhostLatencyTimer)


### PR DESCRIPTION
This patch adds the ability to handle upgrades by doing the following:
* Exposes a http endpoint, which can be called to perform upgrades. For example, inputhost will use this to mark itself as going down and start draining everything
* Exposes the ability to handle signals. For example, you can have a SIGTERM handler, if needed to make sure we catch it and do as is required.