### PR TITLE
Fix controller

### DIFF
--- a/services/controllerhost/controllerhost.go
+++ b/services/controllerhost/controllerhost.go
@@ -555,7 +555,7 @@ func (mcp *Mcp) ReportNodeMetric(ctx thrift.Context, request *c.ReportNodeMetric
 	if metrics.IsSetOutgoingBytesCounter() {
 		loadMetrics.Put(hostID, load.EmptyTag, load.BytesOutPerSec, metrics.GetOutgoingBytesCounter(), timestamp)
 	}
-	if metrics.IsSetNodeStatus() && request.IsSetRole() {
+	if metrics.IsSetNodeStatus() && request.IsSetRole() && metrics.GetNodeStatus() == c.NodeStatus_GOING_DOWN {
 		switch request.GetRole() {
 		case c.Role_IN:
 			context.failureDetector.ReportHostGoingDown(common.InputServiceName, hostID)

--- a/services/controllerhost/placement.go
+++ b/services/controllerhost/placement.go
@@ -265,6 +265,11 @@ func (p *DistancePlacement) getHealthyHosts(service string) ([]*common.HostInfo,
 		}
 		result = append(result, h)
 	}
+
+	// if no hosts are found error out; could happen if all the hosts are "going down"
+	if len(result) == 0 {
+		return nil, errNoHosts
+	}
 	return result, nil
 }
 


### PR DESCRIPTION
A couple of minor bugs which were revealed when testing graceful
upgrade:

* Make sure to mark a node as going down only if the status says so.
* If we cannot find any healthy host, we should return an error

TODO: Add unit test