### PR TITLE
Add upgrade handler for storehost

### DIFF
--- a/common/defs.go
+++ b/common/defs.go
@@ -22,6 +22,7 @@ package common
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/uber/cherami-thrift/.generated/go/store"
 )
@@ -46,6 +47,9 @@ var services = []string{InputServiceName, OutputServiceName, StoreServiceName, C
 const (
 	// UUIDStringLength is the length of an UUID represented as a hex string
 	UUIDStringLength = 36 // xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+
+	// DefaultUpgradeTimeout is the timeout to wait in the upgrade handler
+	DefaultUpgradeTimeout = 10 * time.Second
 )
 
 // HostInfo is a type that contains the info about a cherami host

--- a/services/inputhost/inputhost.go
+++ b/services/inputhost/inputhost.go
@@ -76,9 +76,6 @@ const (
 	// before we start the drain
 	connWGTimeout = 5 * time.Second
 
-	// defaultUpgradeTimeout is the timeout to wait for upgrade
-	defaultUpgradeTimeout = 10 * time.Second
-
 	// drainAllUUID is the UUID used during drainAll
 	drainAllUUID = "D3A9C5DC-AE62-4465-9898-7FE71BD1FCA"
 )

--- a/services/inputhost/inputhost_test.go
+++ b/services/inputhost/inputhost_test.go
@@ -1559,9 +1559,11 @@ func (s *InputHostSuite) TestInputExtHostDrainDuplicate() {
 
 	s.Equal(true, drained)
 
+	dNewCtx, dNewCancel := thrift.NewContext(2 * time.Second)
+	defer dNewCancel()
 	// send another drain request
 	// this should just bail out, since we have already started drain above
-	err = inputHost.DrainExtent(dCtx, req)
+	err = inputHost.DrainExtent(dNewCtx, req)
 	s.NoError(err)
 
 	// try to get the pathCacheLock, it should succeed

--- a/services/inputhost/inputhost_util.go
+++ b/services/inputhost/inputhost_util.go
@@ -219,7 +219,7 @@ func (h *InputHost) drainAll() {
 		go pathCache.drain(&drainWG)
 	}
 
-	if ok := common.AwaitWaitGroup(&drainWG, defaultUpgradeTimeout); !ok {
+	if ok := common.AwaitWaitGroup(&drainWG, common.DefaultUpgradeTimeout); !ok {
 		h.logger.Warn("inputhost: drain all timed out")
 	}
 }

--- a/services/inputhost/pathCache.go
+++ b/services/inputhost/pathCache.go
@@ -574,6 +574,6 @@ func (pathCache *inPathCache) drain(drainWG *sync.WaitGroup) {
 	// drain all extents
 	for extUUID := range pathCache.extentCache {
 		drainWG.Add(1) //for all the extents
-		go pathCache.drainExtent(string(extUUID), drainAllUUID, drainWG, defaultUpgradeTimeout)
+		go pathCache.drainExtent(string(extUUID), drainAllUUID, drainWG, common.DefaultUpgradeTimeout)
 	}
 }

--- a/services/storehost/storehost.go
+++ b/services/storehost/storehost.go
@@ -1628,11 +1628,11 @@ func (t *StoreHost) UpgradeHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // GetNodeStatus is the current status of this host
-func (h *StoreHost) GetNodeStatus() controller.NodeStatus {
-	return h.nodeStatus.Load().(controller.NodeStatus)
+func (t *StoreHost) GetNodeStatus() controller.NodeStatus {
+	return t.nodeStatus.Load().(controller.NodeStatus)
 }
 
 // SetNodeStatus sets the status of this host
-func (h *StoreHost) SetNodeStatus(status controller.NodeStatus) {
-	h.nodeStatus.Store(status)
+func (t *StoreHost) SetNodeStatus(status controller.NodeStatus) {
+	t.nodeStatus.Store(status)
 }

--- a/services/storehost/storehost.go
+++ b/services/storehost/storehost.go
@@ -1618,11 +1618,8 @@ func (t *StoreHost) UpgradeHandler(w http.ResponseWriter, r *http.Request) {
 	t.reportHostMetric(reporter, 1)
 
 	// wait for upgrade timeout
-	upgradeTimer := common.NewTimer(common.DefaultUpgradeTimeout)
-	defer upgradeTimer.Stop()
-	select {
-	case <-upgradeTimer.C:
-	}
+	time.Sleep(common.DefaultUpgradeTimeout)
+
 	// at this point, we have marked ourself as down and waited for the timeout period. Exit since we are no longer useful
 	os.Exit(0)
 }

--- a/services/storehost/storehost.go
+++ b/services/storehost/storehost.go
@@ -206,6 +206,9 @@ type (
 		// unix nanos when the host level metrics were last reported
 		// to the controller
 		lastLoadReportedTime int64
+
+		// status of the node
+		nodeStatus atomic.Value
 	}
 )
 
@@ -286,6 +289,9 @@ func (t *StoreHost) Start(thriftService []thrift.TChanServer) {
 
 	t.replicationJobRunner = NewReplicationJobRunner(t.mClient, t, t.logger, t.m3Client)
 	go t.replicationJobRunner.Start()
+
+	// set the status as UP
+	t.SetNodeStatus(controller.NodeStatus_UP)
 
 	loadReporterDaemonfactory := t.GetLoadReporterDaemonFactory()
 	t.xMgr.loadReporterFactory = loadReporterDaemonfactory
@@ -1273,16 +1279,7 @@ func (t *StoreHost) RegisterWSHandler() *http.ServeMux {
 	return mux
 }
 
-// Report is used for reporting Host specific load to controller
-func (t *StoreHost) Report(reporter common.LoadReporter) {
-
-	now := time.Now().UnixNano()
-	diffSecs := (now - t.lastLoadReportedTime) / int64(time.Second)
-
-	if diffSecs == 0 {
-		return
-	}
-
+func (t *StoreHost) reportHostMetric(reporter common.LoadReporter, diffSecs int64) {
 	msgsInPerSec := t.hostMetrics.GetAndReset(load.HostMetricMsgsWritten) / diffSecs
 	msgsOutPerSec := t.hostMetrics.GetAndReset(load.HostMetricMsgsRead) / diffSecs
 	bytesInPerSec := t.hostMetrics.GetAndReset(load.HostMetricBytesWritten) / diffSecs
@@ -1295,6 +1292,7 @@ func (t *StoreHost) Report(reporter common.LoadReporter) {
 		IncomingBytesCounter:    common.Int64Ptr(bytesInPerSec),
 		OutgoingBytesCounter:    common.Int64Ptr(bytesOutPerSec),
 		NumberOfConnections:     common.Int64Ptr(numConns),
+		NodeStatus:              common.NodeStatusPtr(t.GetNodeStatus()),
 	}
 
 	remDiskSpaceBytes := t.hostMetrics.Get(load.HostMetricFreeDiskSpaceBytes)
@@ -1308,8 +1306,21 @@ func (t *StoreHost) Report(reporter common.LoadReporter) {
 		hostMetrics.RemainingDiskSpace = common.Int64Ptr(remDiskSpaceBytes)
 	}
 
-	t.lastLoadReportedTime = now
 	reporter.ReportHostMetric(hostMetrics)
+}
+
+// Report is used for reporting Host specific load to controller
+func (t *StoreHost) Report(reporter common.LoadReporter) {
+
+	now := time.Now().UnixNano()
+	diffSecs := (now - t.lastLoadReportedTime) / int64(time.Second)
+
+	if diffSecs == 0 {
+		return
+	}
+
+	t.reportHostMetric(reporter, diffSecs)
+	t.lastLoadReportedTime = now
 }
 
 // resolveReplica finds the websocket host-port to connect to for re-replication
@@ -1595,4 +1606,33 @@ func (t *StoreHost) ListExtents(tCtx thrift.Context) (res *store.ListExtentsResu
 	}
 
 	return res, nil
+}
+
+// UpgradeHandler implements the upgrade end point
+func (t *StoreHost) UpgradeHandler(w http.ResponseWriter, r *http.Request) {
+	t.logger.Info("Upgrade endpoint called on storehost")
+	// just report to controller as GOING_DOWN
+	t.SetNodeStatus(controller.NodeStatus_GOING_DOWN)
+	reporter := t.loadReporter.GetReporter()
+	// report as down
+	t.reportHostMetric(reporter, 1)
+
+	// wait for upgrade timeout
+	upgradeTimer := common.NewTimer(common.DefaultUpgradeTimeout)
+	defer upgradeTimer.Stop()
+	select {
+	case <-upgradeTimer.C:
+	}
+	// at this point, we have marked ourself as down and waited for the timeout period. Exit since we are no longer useful
+	os.Exit(0)
+}
+
+// GetNodeStatus is the current status of this host
+func (h *StoreHost) GetNodeStatus() controller.NodeStatus {
+	return h.nodeStatus.Load().(controller.NodeStatus)
+}
+
+// SetNodeStatus sets the status of this host
+func (h *StoreHost) SetNodeStatus(status controller.NodeStatus) {
+	h.nodeStatus.Store(status)
 }


### PR DESCRIPTION
Storehost simply reports itself as GOING_DOWN to the controller
and just waits for the default upgrade timeout which is 10s.

By this time, the hope is that the controller would have notified
the respective input hosts to start draining.