### PR TITLE
fix data race due to unprotected update of last-seqnum in replicate-extent

### DIFF
--- a/services/storehost/replicate.go
+++ b/services/storehost/replicate.go
@@ -399,6 +399,7 @@ pump:
 
 		msg := readMsg.GetMessage()
 		msgSeqNum := msg.GetMessage().GetSequenceNumber()
+		visibilityTime := x.messageVisibilityTime(msg.GetMessage())
 
 		if replicateDebug {
 			log.WithFields(bark.Fields{ // #perfdisable
@@ -492,8 +493,10 @@ pump:
 
 		credLine.Return(1) // TODO: make credits proportional to payload size
 
-		// update lastSeqNum with this seqnum
-		x.setLastSeqNum(msgSeqNum)
+		// update last-seqnum, etc (reported by extStats)
+		x.extentLock()
+		x.setLastMsg(int64(key), msgSeqNum, visibilityTime)
+		x.extentUnlock()
 	}
 
 	close(t.credC) // this should close the sendPump


### PR DESCRIPTION
fix for this data-race: 
```
WARNING: DATA RACE
Read at 0x00c4278105c8 by goroutine 124:
  github.com/uber/cherami-server/services/storehost.(*extentContext).getLastMsg()
      github.com/uber/cherami-server/services/storehost/_test/_obj_test/extMgr.go:592 +0x5b
  github.com/uber/cherami-server/services/storehost.(*ExtStatsReporter).trySendReport()
      github.com/uber/cherami-server/services/storehost/_test/_obj_test/extStats.go:178 +0x27f
  github.com/uber/cherami-server/services/storehost.(*ExtStatsReporter).schedulerPump()
      github.com/uber/cherami-server/services/storehost/_test/_obj_test/extStats.go:237 +0x70c

Previous write at 0x00c4278105c8 by goroutine 2505:
  github.com/uber/cherami-server/services/storehost.(*ExtentObj).setLastSeqNum()
      github.com/uber/cherami-server/services/storehost/_test/_obj_test/extent.go:117 +0x6f
  github.com/uber/cherami-server/services/storehost.(*ReplicationJob).replicationPump()
      github.com/uber/cherami-server/services/storehost/_test/_obj_test/replicate.go:521 +0x784

Goroutine 124 (running) created at:
  github.com/uber/cherami-server/services/storehost.(*ExtStatsReporter).Start()
      github.com/uber/cherami-server/services/storehost/_test/_obj_test/extStats.go:150 +0x1d6
  github.com/uber/cherami-server/services/storehost.(*StoreHost).Start()
      github.com/uber/cherami-server/services/storehost/_test/_obj_test/storehost.go:319 +0x1347
  github.com/uber/cherami-server/services/storehost.(*testBase).newTestStoreHost()
      /home/venkat/code/src/github.com/uber/cherami-server/services/storehost/base_test.go:239 +0x736
  github.com/uber/cherami-server/services/storehost.(*StoreHostSuite).SetupSuite()
      /home/venkat/code/src/github.com/uber/cherami-server/services/storehost/base_test.go:181 +0x433
  github.com/uber/cherami-server/vendor/github.com/stretchr/testify/suite.Run()
      /home/venkat/code/src/github.com/uber/cherami-server/vendor/github.com/stretchr/testify/suite/suite.go:63 +0x76d
  github.com/uber/cherami-server/services/storehost.TestStoreHostSuite()
      /home/venkat/code/src/github.com/uber/cherami-server/services/storehost/base_test.go:101 +0x5e
  testing.tRunner()
      /usr/lib/go-1.7/src/testing/testing.go:610 +0xc9

Goroutine 2505 (running) created at:
  github.com/uber/cherami-server/services/storehost.(*ReplicationJob).Start()
      github.com/uber/cherami-server/services/storehost/_test/_obj_test/replicate.go:291 +0x1258
  github.com/uber/cherami-server/services/storehost.(*StoreHost).ReplicateExtent()
      github.com/uber/cherami-server/services/storehost/_test/_obj_test/storehost.go:1604 +0x1623
  github.com/uber/cherami-server/services/storehost.(*testStoreHost).ReplicateExtent()
      /home/venkat/code/src/github.com/uber/cherami-server/services/storehost/base_test.go:786 +0x2f6
  github.com/uber/cherami-server/services/storehost.(*StoreHostSuite).TestStoreHostReplicateExtent.func2()
      /home/venkat/code/src/github.com/uber/cherami-server/services/storehost/storehost_test.go:1765 +0x2e0
```