### PR TITLE
Build docker images simultaneously to save time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,19 +77,17 @@ after_success:
   - 'if [ "$BRANCH" == "master" ]; then
         docker login -u $DOCKER_USER -p $DOCKER_PASS;
         export TAG=latest;
+        
         export REPO=ubercherami/cherami-server-standalone;
         echo "Building docker image for TRAVIS_BRANCH=$TRAVIS_BRANCH, REPO=$REPO, PR=$PR, BRANCH=$BRANCH, TAG=$TAG";
-        time travis_wait 30 docker build -f docker/standalone/Dockerfile -t $REPO:$COMMIT -t $REPO:$TAG -t $REPO:travis-$TRAVIS_BUILD_NUMBER docker/standalone/;
-        echo "Pushing $REPO";
-        time travis_wait 20 docker push $REPO;
-    fi'
-  - 'if [ "$BRANCH" == "master" ]; then
-        docker login -u $DOCKER_USER -p $DOCKER_PASS;
-        export TAG=latest;
+        time docker build -f docker/standalone/Dockerfile -t $REPO:$COMMIT -t $REPO:$TAG -t $REPO:travis-$TRAVIS_BUILD_NUMBER docker/standalone/ &
+
         export REPO=ubercherami/cherami-server;
         echo "Building docker image for TRAVIS_BRANCH=$TRAVIS_BRANCH, REPO=$REPO, PR=$PR, BRANCH=$BRANCH, TAG=$TAG";
-        time travis_wait 30 docker build -f docker/server/Dockerfile -t $REPO:$COMMIT -t $REPO:$TAG -t $REPO:travis-$TRAVIS_BUILD_NUMBER docker/server/;
-        echo "Pushing $REPO";
-        time travis_wait 20 docker push $REPO;
+        time travis_wait 20 docker build -f docker/server/Dockerfile -t $REPO:$COMMIT -t $REPO:$TAG -t $REPO:travis-$TRAVIS_BUILD_NUMBER docker/server/;
+        wait;
+
+        time docker push ubercherami/cherami-server-standalone &
+        time docker push ubercherami/cherami-server;
+        wait;
     fi'
-  


### PR DESCRIPTION
This cuts test + full build + docker push to 42 minutes. Example: https://travis-ci.org/uber/cherami-server/builds/224569238