### PR TITLE
Bug fixes of multi_zone consumer group

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1048,6 +1048,8 @@ const (
 	// ReplicatorOutConnMsgRead indicates how many messages OutConn read
 	ReplicatorOutConnMsgRead
 
+	// ReplicatorReconcileDestRun indicates the reconcile fails
+	ReplicatorReconcileFail
 	// ReplicatorReconcileDestRun indicates the reconcile for dest runs
 	ReplicatorReconcileDestRun
 	// ReplicatorReconcileDestFail indicates the reconcile for dest fails
@@ -1245,6 +1247,7 @@ var metricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ReplicatorInConnMsgWritten:                              {Counter, "replicator.inconn.msgwritten"},
 		ReplicatorOutConnCreditsSent:                            {Counter, "replicator.outconn.creditssent"},
 		ReplicatorOutConnMsgRead:                                {Counter, "replicator.outconn.msgread"},
+		ReplicatorReconcileFail:                                 {Gauge, "replicator.reconcile.fail"},
 		ReplicatorReconcileDestRun:                              {Gauge, "replicator.reconcile.dest.run"},
 		ReplicatorReconcileDestFail:                             {Gauge, "replicator.reconcile.dest.fail"},
 		ReplicatorReconcileDestFoundMissing:                     {Gauge, "replicator.reconcile.dest.foundmissing"},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1025,6 +1025,8 @@ const (
 	ControllerNumOpenCGExtents
 	// ControllerNumConsumedCGExtents represents the count of consumed cg extents
 	ControllerNumConsumedCGExtents
+	// ControllerNoActiveZone indicates there's no active zone from dynamic config
+	ControllerNoActiveZone
 
 	// -- Replicator metrics -- //
 
@@ -1234,6 +1236,7 @@ var metricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ControllerRetentionJobDuration:             {Timer, "controller.retentionmgr.jobduration"},
 		ControllerGetAddressLatency:                {Timer, "controller.retentionmgr.getaddresslatency"},
 		ControllerPurgeMessagesLatency:             {Timer, "controller.retentionmgr.purgemessageslatency"},
+		ControllerNoActiveZone:                     {Gauge, "controller.no-active-zone"},
 	},
 
 	// definitions for Replicator metrics

--- a/services/controllerhost/consumer.go
+++ b/services/controllerhost/consumer.go
@@ -865,7 +865,7 @@ func shouldConsumeInZone(zone string, cgDesc *shared.ConsumerGroupDescription, d
 		return strings.EqualFold(zone, dConfig.ActiveZone)
 	}
 
-	if cgDesc.IsSetActiveZone() {
+	if len(cgDesc.GetActiveZone()) > 0 {
 		return strings.EqualFold(zone, cgDesc.GetActiveZone())
 	}
 

--- a/services/controllerhost/consumer.go
+++ b/services/controllerhost/consumer.go
@@ -859,7 +859,7 @@ func refreshOutputHostsForConsGroup(context *Context,
 // shouldConsumeInZone indicated whether we should consume from this zone for a multi_zone consumer group
 // If failover mode is enabled in dynamic config, the active zone will be the one specified in dynamic config
 // Otherwise, use the per cg override if it's specified
-// Last, check the active zone in dynamic config. If specified, use it. Otherwise always return true
+// Last, check the active zone in dynamic config. If specified, use it. Otherwise always return false
 func shouldConsumeInZone(zone string, cgDesc *shared.ConsumerGroupDescription, dConfig ControllerDynamicConfig) bool {
 	if strings.EqualFold(dConfig.FailoverMode, `enabled`) {
 		return strings.EqualFold(zone, dConfig.ActiveZone)
@@ -873,7 +873,7 @@ func shouldConsumeInZone(zone string, cgDesc *shared.ConsumerGroupDescription, d
 		return strings.EqualFold(zone, dConfig.ActiveZone)
 	}
 
-	return true
+	return false
 }
 
 func getControllerDynamicConfig(context *Context) (ControllerDynamicConfig, error) {

--- a/services/controllerhost/controllerhost.go
+++ b/services/controllerhost/controllerhost.go
@@ -395,7 +395,7 @@ func (mcp *Mcp) GetOutputHosts(ctx thrift.Context, inReq *c.GetOutputHostsReques
 
 	result = context.resultCache.readOutputHosts(cgUUID, now)
 	if result.cacheHit && !result.refreshCache {
-		return response(result.cachedResult, ErrUnavailable)
+		return response(result.cachedResult, nil)
 	}
 
 	if !context.dstLock.TryLock(dstUUID, getLockTimeout(result)) {
@@ -408,7 +408,7 @@ func (mcp *Mcp) GetOutputHosts(ctx thrift.Context, inReq *c.GetOutputHostsReques
 	result = context.resultCache.readOutputHosts(cgUUID, now)
 	if result.cacheHit && !result.refreshCache {
 		context.dstLock.Unlock(dstUUID)
-		return response(result.cachedResult, ErrUnavailable)
+		return response(result.cachedResult, nil)
 	}
 
 	hostIDs, err := refreshOutputHostsForConsGroup(context, dstUUID, cgUUID, *result, now)

--- a/services/controllerhost/controllerhost.go
+++ b/services/controllerhost/controllerhost.go
@@ -385,12 +385,10 @@ func (mcp *Mcp) GetOutputHosts(ctx thrift.Context, inReq *c.GetOutputHostsReques
 	}
 
 	response := func(outputHostIDs []string, err error) (*c.GetOutputHostsResult_, error) {
-		if len(outputHostIDs) < 1 {
-			// only count as failure if our answer contains no endpoints at all
+		if err != nil {
 			context.m3Client.IncCounter(metrics.GetOutputHostsScope, metrics.ControllerFailures)
-			return nil, err
 		}
-		return &c.GetOutputHostsResult_{OutputHostIds: outputHostIDs}, nil
+		return &c.GetOutputHostsResult_{OutputHostIds: outputHostIDs}, err
 	}
 
 	var now = context.timeSource.Now().UnixNano()
@@ -423,7 +421,7 @@ func (mcp *Mcp) GetOutputHosts(ctx thrift.Context, inReq *c.GetOutputHostsReques
 		return response(result.cachedResult, &shared.InternalServiceError{Message: err.Error()})
 	}
 
-	return response(hostIDs, ErrUnavailable)
+	return response(hostIDs, nil)
 }
 
 // GetQueueDepthInfo to return queue depth backlog infor for consumer group

--- a/services/controllerhost/controllerhost.go
+++ b/services/controllerhost/controllerhost.go
@@ -384,23 +384,25 @@ func (mcp *Mcp) GetOutputHosts(ctx thrift.Context, inReq *c.GetOutputHostsReques
 		return nil, ErrMalformedUUID
 	}
 
-	response := func(outputHostIDs []string, err error) (*c.GetOutputHostsResult_, error) {
-		if err != nil {
+	response := func() (*c.GetOutputHostsResult_, error) {
+		if len(result.cachedResult) < 1 && !result.consumeDisabled {
+			// only count as failure if our answer contains no endpoints at all and consuming is not disabled
 			context.m3Client.IncCounter(metrics.GetOutputHostsScope, metrics.ControllerFailures)
+			return nil, ErrUnavailable
 		}
-		return &c.GetOutputHostsResult_{OutputHostIds: outputHostIDs}, err
+		return &c.GetOutputHostsResult_{OutputHostIds: result.cachedResult}, nil
 	}
 
 	var now = context.timeSource.Now().UnixNano()
 
 	result = context.resultCache.readOutputHosts(cgUUID, now)
 	if result.cacheHit && !result.refreshCache {
-		return response(result.cachedResult, nil)
+		return response()
 	}
 
 	if !context.dstLock.TryLock(dstUUID, getLockTimeout(result)) {
 		context.m3Client.IncCounter(metrics.GetOutputHostsScope, metrics.ControllerErrTryLockCounter)
-		return response(result.cachedResult, ErrTryLock)
+		return response()
 	}
 
 	// With the lock being held, make sure someone else did not already
@@ -408,7 +410,7 @@ func (mcp *Mcp) GetOutputHosts(ctx thrift.Context, inReq *c.GetOutputHostsReques
 	result = context.resultCache.readOutputHosts(cgUUID, now)
 	if result.cacheHit && !result.refreshCache {
 		context.dstLock.Unlock(dstUUID)
-		return response(result.cachedResult, nil)
+		return response()
 	}
 
 	hostIDs, err := refreshOutputHostsForConsGroup(context, dstUUID, cgUUID, *result, now)
@@ -418,10 +420,10 @@ func (mcp *Mcp) GetOutputHosts(ctx thrift.Context, inReq *c.GetOutputHostsReques
 			context.m3Client.IncCounter(metrics.GetOutputHostsScope, metrics.ControllerErrBadEntityCounter)
 			return nil, err
 		}
-		return response(result.cachedResult, &shared.InternalServiceError{Message: err.Error()})
+		return response()
 	}
 
-	return response(hostIDs, nil)
+	return &c.GetOutputHostsResult_{OutputHostIds: hostIDs}, nil
 }
 
 // GetQueueDepthInfo to return queue depth backlog infor for consumer group

--- a/services/controllerhost/resultcache.go
+++ b/services/controllerhost/resultcache.go
@@ -42,22 +42,25 @@ type (
 		nExtents   int
 		maxExtents int
 		dstType
-		hostIDs []string
+		hostIDs         []string
+		consumeDisabled bool
 	}
 
 	resultCacheReadResult struct {
-		cachedResult []string
-		cacheHit     bool
-		refreshCache bool
+		cachedResult    []string
+		consumeDisabled bool
+		cacheHit        bool
+		refreshCache    bool
 		*resultCacheEntry
 	}
 
 	resultCacheParams struct {
-		dstType    dstType
-		nExtents   int
-		maxExtents int
-		hostIDs    []string
-		expiry     int64
+		dstType         dstType
+		nExtents        int
+		maxExtents      int
+		hostIDs         []string
+		consumeDisabled bool
+		expiry          int64
 	}
 )
 
@@ -108,6 +111,7 @@ func (cache *resultCache) write(key string, write resultCacheParams) {
 	cacheEntry.dstType = write.dstType
 	cacheEntry.expiry = write.expiry
 	cacheEntry.hostIDs = write.hostIDs
+	cacheEntry.consumeDisabled = write.consumeDisabled
 	cacheEntry.nExtents = write.nExtents
 	cacheEntry.maxExtents = write.maxExtents
 	cache.Put(key, cacheEntry)
@@ -135,6 +139,7 @@ func readResultCache(cache *resultCache, key string, svc string, now int64) *res
 
 		return &resultCacheReadResult{
 			cachedResult:     cachedResult,
+			consumeDisabled:  cacheEntry.consumeDisabled,
 			cacheHit:         cacheHit,
 			refreshCache:     refreshCache,
 			resultCacheEntry: cacheEntry,
@@ -142,6 +147,7 @@ func readResultCache(cache *resultCache, key string, svc string, now int64) *res
 	}
 	return &resultCacheReadResult{
 		cachedResult:     cachedResult,
+		consumeDisabled:  false,
 		cacheHit:         cacheHit,
 		refreshCache:     refreshCache,
 		resultCacheEntry: &resultCacheEntry{},

--- a/services/frontendhost/frontend.go
+++ b/services/frontendhost/frontend.go
@@ -1015,13 +1015,13 @@ func (h *Frontend) ReadConsumerGroupHosts(ctx thrift.Context, readRequest *c.Rea
 
 	getOutputHostReq := &controller.GetOutputHostsRequest{DestinationUUID: common.StringPtr(mCGDesc.GetDestinationUUID()), ConsumerGroupUUID: common.StringPtr(mCGDesc.GetConsumerGroupUUID())}
 	getOutputHostResp, err := cClient.GetOutputHosts(ctx, getOutputHostReq)
-	if err != nil || len(getOutputHostResp.GetOutputHostIds()) < 1 {
-		if err != nil {
-			lclLg = lclLg.WithField(common.TagErr, err)
-		}
-
-		lclLg.Error("No hosts returned from controller")
+	if err != nil {
+		lclLg.WithField(common.TagErr, err).Error(`error getting hosts from controller`)
 		return nil, err
+	}
+
+	if len(getOutputHostResp.GetOutputHostIds()) < 1 {
+		return c.NewReadConsumerGroupHostsResult_(), nil
 	}
 
 	outputHostIds := getOutputHostResp.GetOutputHostIds()

--- a/services/replicator/replicator.go
+++ b/services/replicator/replicator.go
@@ -1064,7 +1064,6 @@ func (r *Replicator) SetAckOffset(ctx thrift.Context, request *shared.SetAckOffs
 		return err
 	}
 
-	lcllg.Info(`Ack offset updated in metadata`)
 	return nil
 }
 


### PR DESCRIPTION
Fix a couple of bugs:
1. If we couldn't get active zone from config, default to NOT consume (otherwise we may allow consuming in both zones)
2. For GetOutputHost call, make the empty host a valid case.