### PR TITLE
storehost tests: enable stdout logging at specific level

### DIFF
--- a/services/storehost/base_test.go
+++ b/services/storehost/base_test.go
@@ -52,9 +52,9 @@ import (
 )
 
 // var runShort = flag.Bool("short", false, "do a short run") // "-short" to do a short run (already defined by package 'suite')
-var runLong = flag.Bool("long", false, "do a long run")                       // "-long" to do a long run
-var runVeryVerbose = flag.Bool("vv", false, "run very verbosely")             // "-vv" run with more output
-var enablePerMessageLogs = flag.Bool("msg", false, "enable per message logs") // "-msg" enable per message logs (requires '-vv')
+var runLong = flag.Bool("long", false, "do a long run")                                                     // "-long" to do a long run
+var runVeryVerbose = flag.String("vv", "", "run (very) verbosely, enabling stdout logs at specified level") // "-vv" run with more output
+var enablePerMessageLogs = flag.Bool("msg", false, "enable per message logs")                               // "-msg" enable per message logs (requires '-vv')
 
 var testStore = ManyRocks
 var testDestinationUUID = "00000000-0000-0000-0000-000000000000"
@@ -108,48 +108,6 @@ func (s *StoreHostSuite) RunLong() bool {
 	return *runLong
 }
 
-type CommonAppConfigOverride struct {
-	*configure.AppConfig
-	level  string
-	stdout bool
-}
-
-func NewCommonAppConfigOverride(appCfg *configure.AppConfig, level string, stdout bool) *CommonAppConfigOverride {
-
-	return &CommonAppConfigOverride{
-		AppConfig: appCfg,
-		// AppConfig: configure.NewCommonAppConfig().(*configure.AppConfig),
-		level:  level,
-		stdout: stdout,
-	}
-}
-
-func (t *CommonAppConfigOverride) GetLoggingConfig() interface{} {
-
-	logCfg := configure.NewCommonLogConfig()
-
-	logCfg.Level = t.level
-	logCfg.Stdout = t.stdout
-
-	return logCfg
-}
-
-type CommonConfigureOverride struct {
-	configure.Configure // *configure.CommonConfigure
-}
-
-func NewCommonConfigureOverride(level string, stdout bool) *CommonConfigureOverride {
-
-	cfg := configure.NewCommonConfigure()
-	// FIXME: following causes a panic -- needs some refactoring in the
-	// 'configure' package to get this to work
-	// cfg.AppConfig = NewCommonAppConfigOverride(cfg.AppConfig, level, stdout) // replace AppConfig
-
-	return &CommonConfigureOverride{
-		Configure: cfg,
-	}
-}
-
 // SetupSuite will run once before any of the tests in the suite are run
 func (s *StoreHostSuite) SetupSuite() {
 
@@ -157,21 +115,22 @@ func (s *StoreHostSuite) SetupSuite() {
 
 	s.TestCluster.SetupTestCluster()
 
-	var commonConfigure configure.Configure
+	s.cfg = common.SetupServerConfig(configure.NewCommonConfigure())
 
-	if *runVeryVerbose {
-		commonConfigure = NewCommonConfigureOverride("debug", true) // debug level logs to stdout
+	if *runVeryVerbose != "" {
 
-		log.SetLevel(log.DebugLevel) // test logs at debug level
-		log.SetOutput(os.Stdout)     // test output to stdout
-	} else {
-		commonConfigure = NewCommonConfigureOverride("error", false) // error level logs; no stdout
+		log.SetOutput(os.Stdout) // test output to stdout
 
-		log.SetLevel(log.ErrorLevel) // test logs at error level
-		log.SetOutput(os.Stdout)     // test output to stdout
+		// enable logs at specified level
+		switch *runVeryVerbose {
+		case "debug":
+			log.SetLevel(log.DebugLevel)
+		case "info":
+			log.SetLevel(log.InfoLevel)
+		case "error":
+			log.SetLevel(log.ErrorLevel)
+		}
 	}
-
-	s.cfg = common.SetupServerConfig(commonConfigure)
 
 	testBaseDir, _ := ioutil.TempDir("", "storehost-test")
 	s.testBase = newTestBase(testBaseDir)

--- a/services/storehost/base_test.go
+++ b/services/storehost/base_test.go
@@ -52,9 +52,9 @@ import (
 )
 
 // var runShort = flag.Bool("short", false, "do a short run") // "-short" to do a short run (already defined by package 'suite')
-var runLong = flag.Bool("long", false, "do a long run")                                                     // "-long" to do a long run
-var runVeryVerbose = flag.String("vv", "", "run (very) verbosely, enabling stdout logs at specified level") // "-vv" run with more output
-var enablePerMessageLogs = flag.Bool("msg", false, "enable per message logs")                               // "-msg" enable per message logs (requires '-vv')
+var runLong = flag.Bool("long", false, "do a long run")                             // "-long" to do a long run
+var logLevel = flag.String("log", "", "enabling stdout logging at specified level") // "-log=<level>" to enable log level
+var enablePerMessageLogs = flag.Bool("msg", false, "enable per message logs")       // "-msg" enable per message logs (requires '-vv')
 
 var testStore = ManyRocks
 var testDestinationUUID = "00000000-0000-0000-0000-000000000000"
@@ -117,12 +117,12 @@ func (s *StoreHostSuite) SetupSuite() {
 
 	s.cfg = common.SetupServerConfig(configure.NewCommonConfigure())
 
-	if *runVeryVerbose != "" {
+	if *logLevel != "" {
 
 		log.SetOutput(os.Stdout) // test output to stdout
 
 		// enable logs at specified level
-		switch *runVeryVerbose {
+		switch *logLevel {
 		case "debug":
 			log.SetLevel(log.DebugLevel)
 		case "info":


### PR DESCRIPTION
This enables logging when testing, as needed. Instead of having to modify the "config/base.yaml" each time to set logging to stdout and level, etc .. this enables us to do it by simply passing in a "-log=<level>" arg to "go test".