### PR TITLE
allow UpdateConsumerGroup API to update active zone for a multi_zone cg

### DIFF
--- a/clients/metadata/metadata_cassandra.go
+++ b/clients/metadata/metadata_cassandra.go
@@ -1492,6 +1492,7 @@ func (s *CassandraMetadataService) ReadConsumerGroupByUUID(ctx thrift.Context, r
 func updateCGDescIfChanged(req *shared.UpdateConsumerGroupRequest, cgDesc *shared.ConsumerGroupDescription) bool {
 	isChanged := false
 
+	// Note: for any updatable property here, we also need to reconcile it in replicator
 	if req.IsSetLockTimeoutSeconds() && req.GetLockTimeoutSeconds() != cgDesc.GetLockTimeoutSeconds() {
 		isChanged = true
 		cgDesc.LockTimeoutSeconds = common.Int32Ptr(req.GetLockTimeoutSeconds())
@@ -1515,6 +1516,11 @@ func updateCGDescIfChanged(req *shared.UpdateConsumerGroupRequest, cgDesc *share
 	if req.IsSetOwnerEmail() && req.GetOwnerEmail() != cgDesc.GetOwnerEmail() {
 		isChanged = true
 		cgDesc.OwnerEmail = common.StringPtr(req.GetOwnerEmail())
+	}
+
+	if req.IsSetActiveZone() && req.GetActiveZone() != cgDesc.GetActiveZone() {
+		isChanged = true
+		cgDesc.ActiveZone = common.StringPtr(req.GetActiveZone())
 	}
 	return isChanged
 }

--- a/clients/metadata/metadata_cassandra_test.go
+++ b/clients/metadata/metadata_cassandra_test.go
@@ -1673,6 +1673,7 @@ func assertConsumerGroupsEqual(s *CassandraSuite, expected, got *shared.Consumer
 	s.Equal(expected.GetSkipOlderMessagesSeconds(), got.GetSkipOlderMessagesSeconds(), "Wrong SkipOlderMessagesSeconds")
 	s.Equal(expected.GetOwnerEmail(), got.GetOwnerEmail(), "Wrong OwnerEmail")
 	s.Equal(expected.GetDeadLetterQueueDestinationUUID(), got.GetDeadLetterQueueDestinationUUID(), "Wrong DeadLetterQueueDestinationUUID")
+	s.Equal(expected.GetActiveZone(), got.GetActiveZone(), "Wrong ActiveZone")
 }
 
 func (s *CassandraSuite) TestDeleteConsumerGroupDeletesDLQ() {
@@ -1835,11 +1836,18 @@ func (s *CassandraSuite) TestConsumerGroupCRUD() {
 			OwnerEmail:               common.StringPtr("consumer_test@uber.com"),
 		}
 
+		if pass % 2 == 0 {
+			updateReq.ActiveZone = common.StringPtr(`zone2`)
+		} else {
+			updateReq.ActiveZone = common.StringPtr(``)
+		}
+
 		expectedCG.Status = common.InternalConsumerGroupStatusPtr(shared.ConsumerGroupStatus_DISABLED)
 		expectedCG.LockTimeoutSeconds = common.Int32Ptr(updateReq.GetLockTimeoutSeconds())
 		expectedCG.MaxDeliveryCount = common.Int32Ptr(updateReq.GetMaxDeliveryCount())
 		expectedCG.SkipOlderMessagesSeconds = common.Int32Ptr(updateReq.GetSkipOlderMessagesSeconds())
 		expectedCG.OwnerEmail = common.StringPtr(updateReq.GetOwnerEmail())
+		expectedCG.ActiveZone = common.StringPtr(updateReq.GetActiveZone())
 
 		gotCG = nil
 		gotCG, err = s.client.UpdateConsumerGroup(nil, updateReq)

--- a/clients/metadata/metadata_cassandra_test.go
+++ b/clients/metadata/metadata_cassandra_test.go
@@ -1836,7 +1836,7 @@ func (s *CassandraSuite) TestConsumerGroupCRUD() {
 			OwnerEmail:               common.StringPtr("consumer_test@uber.com"),
 		}
 
-		if pass % 2 == 0 {
+		if pass%2 == 0 {
 			updateReq.ActiveZone = common.StringPtr(`zone2`)
 		} else {
 			updateReq.ActiveZone = common.StringPtr(``)

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1060,6 +1060,8 @@ const (
 	ReplicatorReconcileCgFail
 	// ReplicatorReconcileCgFoundMissing indicates the reconcile for cg found a missing cg
 	ReplicatorReconcileCgFoundMissing
+	// ReplicatorReconcileCgFoundUpdated indicates the reconcile for cg found a updated cg
+	ReplicatorReconcileCgFoundUpdated
 	// ReplicatorReconcileDestExtentRun indicates the reconcile for dest extent runs
 	ReplicatorReconcileDestExtentRun
 	// ReplicatorReconcileDestExtentFail indicates the reconcile for dest extent fails
@@ -1251,6 +1253,7 @@ var metricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ReplicatorReconcileCgRun:                                {Gauge, "replicator.reconcile.cg.run"},
 		ReplicatorReconcileCgFail:                               {Gauge, "replicator.reconcile.cg.fail"},
 		ReplicatorReconcileCgFoundMissing:                       {Gauge, "replicator.reconcile.cg.foundmissing"},
+		ReplicatorReconcileCgFoundUpdated:                       {Gauge, "replicator.reconcile.cg.foundupdated"},
 		ReplicatorReconcileDestExtentRun:                        {Gauge, "replicator.reconcile.destextent.run"},
 		ReplicatorReconcileDestExtentFail:                       {Gauge, "replicator.reconcile.destextent.fail"},
 		ReplicatorReconcileDestExtentFoundMissing:               {Gauge, "replicator.reconcile.destextent.foundmissing"},

--- a/glide.lock
+++ b/glide.lock
@@ -2,9 +2,7 @@ hash: 95b094ac76b3329e6ad38bb6314377db13aa5d0a7f29f4a74b54f00502e17ad4
 updated: 2017-04-17T10:59:50.30170527-07:00
 imports:
 - name: github.com/apache/thrift
-  repo: git://git.apache.org/thrift.git
-  vcs: git
-  version: b2a4d4ae21c789b689dd162deb819665567f481c
+  version: 2d65c2365f19f637bc732222e71d78727bf0b709
   subpackages:
   - lib/go/thrift
 - name: github.com/aws/aws-sdk-go
@@ -135,7 +133,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: 96831195ae16ae217142cdac0dd9d05dae9dab39
+  version: 5ee4a84768ccabe0469c7c02c66b28d206e2c34f
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/glide.lock
+++ b/glide.lock
@@ -2,7 +2,9 @@ hash: 95b094ac76b3329e6ad38bb6314377db13aa5d0a7f29f4a74b54f00502e17ad4
 updated: 2017-04-17T10:59:50.30170527-07:00
 imports:
 - name: github.com/apache/thrift
-  version: 2d65c2365f19f637bc732222e71d78727bf0b709
+  repo: git://git.apache.org/thrift.git
+  vcs: git
+  version: b2a4d4ae21c789b689dd162deb819665567f481c
   subpackages:
   - lib/go/thrift
 - name: github.com/aws/aws-sdk-go
@@ -133,7 +135,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: 491bc3af350b3cdc0780c6f99ca9fd0a82aeb850
+  version: 96831195ae16ae217142cdac0dd9d05dae9dab39
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,9 +2,6 @@ package: github.com/uber/cherami-server
 import:
 - package: github.com/Sirupsen/logrus
 - package: github.com/apache/thrift
-  repo: git://git.apache.org/thrift.git
-  vcs: git
-  version: ^0.9.3
   subpackages:
   - lib/go/thrift
 - package: github.com/aws/aws-sdk-go

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,6 +2,9 @@ package: github.com/uber/cherami-server
 import:
 - package: github.com/Sirupsen/logrus
 - package: github.com/apache/thrift
+  repo: git://git.apache.org/thrift.git
+  vcs: git
+  version: ^0.9.3
   subpackages:
   - lib/go/thrift
 - package: github.com/aws/aws-sdk-go

--- a/services/replicator/metadataReconciler.go
+++ b/services/replicator/metadataReconciler.go
@@ -390,7 +390,7 @@ func (r *metadataReconciler) reconcileCg(localCgs []*shared.ConsumerGroupDescrip
 	// We don't need to handle this because deleted cg will still be in the uuid table for 30 days, so it should be covered by case #1
 
 	r.m3Client.UpdateGauge(metrics.ReplicatorReconcileScope, metrics.ReplicatorReconcileCgFoundMissing, replicatorReconcileCgFoundMissingCount)
-	r.m3Client.UpdateGauge(metrics.ReplicatorReconcileScope, metrics.ReplicatorReconcileCgFoundUp
+	r.m3Client.UpdateGauge(metrics.ReplicatorReconcileScope, metrics.ReplicatorReconcileCgFoundUpdated, replicatorReconcileCgFoundUpdatedCount)
 }
 
 func (r *metadataReconciler) compareAndUpdateCg(remoteCg *shared.ConsumerGroupDescription, localCg *shared.ConsumerGroupDescription, logger bark.Logger, replicatorReconcileCgFoundUpdatedCount *int64) {

--- a/services/replicator/metadataReconciler.go
+++ b/services/replicator/metadataReconciler.go
@@ -335,7 +335,7 @@ func (r *metadataReconciler) reconcileCg(localCgs []*shared.ConsumerGroupDescrip
 				continue
 			}
 
-			// case #2: destination exists in both remote and local, try to compare the property to see if anything gets updated
+			// case #2: cg exists in both remote and local, try to compare the property to see if anything gets updated
 			updateRequest := &shared.UpdateConsumerGroupRequest{}
 			cgUpdated := false
 

--- a/services/replicator/replicator_test.go
+++ b/services/replicator/replicator_test.go
@@ -1303,6 +1303,49 @@ func (s *ReplicatorSuite) TestCgMetadataReconcileRemoteLocalDeleted() {
 	s.mockMeta.AssertExpectations(s.T())
 }
 
+// cg is updated in remote zone. Expect a update request is generated
+func (s *ReplicatorSuite) TestCgMetadataReconcileRemoteUpdate() {
+	localZone := `zone2`
+	cgUUID := uuid.New()
+	destUUID := uuid.New()
+	destPath := `dest`
+	cgName := `cg`
+	updatedActiveZone := `z1`
+	originalActiveZone := `z2`
+
+	repliator, _ := NewReplicator("replicator-test", s.mockService, s.mockMeta, s.mockReplicatorClientFactory, s.cfg)
+	reconciler, _ := NewMetadataReconciler(repliator.metaClient, repliator, localZone, repliator.logger, repliator.m3Client).(*metadataReconciler)
+
+	// setup mock
+	mockReplicator := new(mockreplicator.MockTChanReplicator)
+	mockReplicator.On("ReadDestination", mock.Anything, mock.Anything).Return(&shared.DestinationDescription{Path: common.StringPtr(destPath)}, nil)
+	s.mockReplicatorClientFactory.On("GetReplicatorClient", mock.Anything).Return(mockReplicator, nil)
+
+	s.mockMeta.On("UpdateConsumerGroup", mock.Anything, mock.Anything).Return(shared.NewConsumerGroupDescription(), nil).Run(func(args mock.Arguments) {
+		req := args.Get(1).(*shared.UpdateConsumerGroupRequest)
+		s.Equal(destPath, req.GetDestinationPath())
+		s.Equal(cgName, req.GetConsumerGroupName())
+		s.Equal(updatedActiveZone, req.GetActiveZone())
+	})
+
+	var localCgs []*shared.ConsumerGroupDescription
+	localCgs = append(localCgs, &shared.ConsumerGroupDescription{
+		ConsumerGroupUUID: common.StringPtr(cgUUID),
+		ConsumerGroupName: common.StringPtr(cgName),
+		DestinationUUID:   common.StringPtr(destUUID),
+		ActiveZone:        common.StringPtr(originalActiveZone),
+	})
+	var remoteCgs []*shared.ConsumerGroupDescription
+	remoteCgs = append(remoteCgs, &shared.ConsumerGroupDescription{
+		ConsumerGroupUUID: common.StringPtr(cgUUID),
+		ConsumerGroupName: common.StringPtr(cgName),
+		DestinationUUID:   common.StringPtr(destUUID),
+		ActiveZone:        common.StringPtr(updatedActiveZone),
+	})
+	reconciler.reconcileCg(localCgs, remoteCgs)
+	s.mockMeta.AssertExpectations(s.T())
+}
+
 // local zone is missing one destination extent compared to remote. Expect to create the missing destination extent
 func (s *ReplicatorSuite) TestDestExtentMetadataReconcileLocalMissing() {
 	localZone := `zone2`


### PR DESCRIPTION
as title. the patch includes both fast path and slow path(reconciliation) to update active zone for a multi_zone cg.

related thrift change: https://github.com/uber/cherami-thrift/pull/21
