### PR TITLE
Outputhost replica stream: write-pump error should not close read-pump

### DIFF
--- a/services/outputhost/replicaconnection.go
+++ b/services/outputhost/replicaconnection.go
@@ -24,8 +24,6 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
-
 	"github.com/uber-common/bark"
 
 	"github.com/uber/cherami-server/common"
@@ -53,7 +51,6 @@ type (
 		call                storeStream.BStoreOpenReadStreamOutCall
 		msgsCh              chan<- *cherami.ConsumerMessage
 		initialCredits      int32
-		cancel              context.CancelFunc
 		closeChannel        chan struct{}
 		connectionsClosedCh chan<- error
 		readMsgsCh          chan int32
@@ -74,22 +71,21 @@ type (
 		// one message at a time, and read on close after the pumps
 		// are done; therefore, these do not require to be protected
 		// for concurrent access
-		sentCreds int64 // total credits sent
-		recvMsgs  int64 // total messages received
+		sentCreds int32 // total credits sent
+		recvMsgs  int32 // total messages received
 
 		// consumerM3Client for metrics per consumer group
 		consumerM3Client metrics.Client
 	}
 )
 
-func newReplicaConnection(stream storeStream.BStoreOpenReadStreamOutCall, extCache *extentCache, cancel context.CancelFunc,
+func newReplicaConnection(stream storeStream.BStoreOpenReadStreamOutCall, extCache *extentCache,
 	replicaConnectionName string, logger bark.Logger, startingSequence common.SequenceNumber) *replicaConnection {
 
 	conn := &replicaConnection{
 		call:                stream,
 		msgsCh:              extCache.msgsCh,
 		initialCredits:      extCache.initialCredits,
-		cancel:              cancel,
 		shutdownWG:          extCache.shutdownWG,
 		closeChannel:        make(chan struct{}),
 		readMsgsCh:          make(chan int32, replicaConnectionCreditsChBuffer),
@@ -141,20 +137,6 @@ func (conn *replicaConnection) close(err error) {
 		}).Info("replConn closed")
 	}
 	conn.lk.Unlock()
-}
-
-func (conn *replicaConnection) sendCreditsToStore(credits int32) error {
-	cFlow := cherami.NewControlFlow()
-	cFlow.Credits = common.Int32Ptr(credits)
-	//conn.logger.WithField(`Credits`,cFlow.GetCredits()).Debug(`Sending credits!!`)
-	err := conn.call.Write(cFlow)
-	if err == nil {
-		err = conn.call.Flush()
-	}
-
-	conn.sentCreds += int64(credits)
-
-	return err
 }
 
 // updateSuccessfulSendToMsgCh updates the local counter and records metric as well
@@ -335,32 +317,32 @@ func (conn *replicaConnection) readMessagesPump() {
 	}
 }
 
-func (conn *replicaConnection) utilSendCredits(credits int32, numMsgsRead *int32, totalCreditsSent *int32) {
-	// conn.logger.WithField(`credits`, credits).Debug(`Sending credits to store.`)
-	if err := conn.sendCreditsToStore(credits); err != nil {
-		conn.logger.WithField(common.TagErr, err).Error(`error writing credits to store`)
-
-		go conn.close(nil)
-	}
-	*numMsgsRead = *numMsgsRead - credits
-	*totalCreditsSent = *totalCreditsSent + credits
-}
-
 func (conn *replicaConnection) writeCreditsPump() {
 	defer conn.waitWG.Done()
 	defer conn.call.Done()
-	if conn.cancel != nil {
-		defer conn.cancel()
+
+	sendCreditsToStore := func(credits int32) (err error) {
+
+		//conn.logger.WithField(`Credits`,cFlow.GetCredits()).Debug(`Sending credits!!`)
+
+		cFlow := cherami.NewControlFlow()
+		cFlow.Credits = common.Int32Ptr(credits)
+		if err = conn.call.Write(cFlow); err != nil {
+			conn.logger.WithField(common.TagErr, err).Error(`error writing credits to store`)
+			return
+		}
+
+		err = conn.call.Flush()
+		conn.sentCreds += credits
+		return
 	}
 
-	totalCreditsSent := conn.initialCredits
-
-	// send initial credits to the store.. so that we can
-	// actually start reading
+	// send initial credits to the store.. so that we can actually start reading
 	conn.logger.WithField(`initialCredits`, conn.initialCredits).Info(`writeCreditsPump: sending initial credits to store`)
-	if err := conn.sendCreditsToStore(conn.initialCredits); err != nil {
-		conn.logger.WithField(common.TagErr, err).Error(`error writing initial credits to store`)
+	if err := sendCreditsToStore(conn.initialCredits); err != nil {
+		conn.logger.WithField(common.TagErr, err).Error(`writeCreditsPump: error writing initial credits to store`)
 
+		// if sending of initial credits failed, then close this connection
 		go conn.close(nil)
 		return
 	}
@@ -382,20 +364,26 @@ func (conn *replicaConnection) writeCreditsPump() {
 		if numMsgsRead > creditBatchSize {
 			select {
 			case credits := <-conn.creditNotifyCh: // this is the common credit channel from redelivery cache
-				conn.utilSendCredits(credits, &numMsgsRead, &totalCreditsSent)
+				if err := sendCreditsToStore(credits); err != nil {
+					return
+				}
+				numMsgsRead -= credits
 			case credits := <-conn.localCreditCh: // this is the local credits channel only for this connection
-				conn.utilSendCredits(credits, &numMsgsRead, &totalCreditsSent)
+				if err := sendCreditsToStore(credits); err != nil {
+					return
+				}
+				numMsgsRead -= credits
 			case msgsRead := <-conn.readMsgsCh:
 				numMsgsRead += msgsRead
 			case <-creditRequestTicker.C:
 				// if we didn't get any credits for a long time and we are starving for
 				// credits, then request some credits
-				if numMsgsRead >= totalCreditsSent {
-					conn.logger.Warn("WritecreditsPump starving for credits: requesting more")
+				if numMsgsRead >= conn.sentCreds {
+					conn.logger.Warn("writeCreditsPump: starving for credits, requesting more")
 					conn.extCache.requestCredits()
 				}
 			case <-conn.closeChannel:
-				conn.logger.Info("WriteCreditsPump closing due to connection closed.")
+				conn.logger.Info("writeCreditsPump: connection closed")
 				return
 			}
 		} else {
@@ -405,9 +393,12 @@ func (conn *replicaConnection) writeCreditsPump() {
 			// we should listen on the local credits ch, just in case we requested for some credits
 			// above and we are just getting it now
 			case credits := <-conn.localCreditCh:
-				conn.utilSendCredits(credits, &numMsgsRead, &totalCreditsSent)
+				if err := sendCreditsToStore(credits); err != nil {
+					return
+				}
+				numMsgsRead -= credits
 			case <-conn.closeChannel:
-				conn.logger.Info("WriteCreditsPump closing due to connection closed.")
+				conn.logger.Info("writeCreditsPump: connection closed")
 				return
 			}
 		}


### PR DESCRIPTION
When the store reaches the end of the extent, it closes the stream and the underlying connection -- the outputhost is expected to drain out the connection before closing out. Unfortunately, in that time, if the outputhost write-credits-pump attempts to write out credits, it would fail since the connection is closed -- and in response to that, it triggers a stoppage of the read-pump, as well, before it drains out messages in the stream. This would cause outputhost to connect to a new replica to re-read the "tail" of the messages.

This change fixes that behaviour -- so a write-pump failure does not cause the read-pump to close. The read-pump would close when it has drained out the connection and it encounters a network error.