### PR TITLE
Delete some useless code

### DIFF
--- a/services/outputhost/messagecache.go
+++ b/services/outputhost/messagecache.go
@@ -261,7 +261,7 @@ type cgMsgCache struct {
 	notifier                 Notifier // this notifier is used to slow down cons connections based on NACKs
 	consumerHealth
 	messageCacheHealth
-	creditNotifyCh     chan int32          // this is the notify ch to notify credits to extents
+	creditNotifyCh     chan<- int32        // this is the notify ch to notify credits to extents
 	creditRequestCh    <-chan string       // read-only channel used by the extents to request credits specifically for that extent.
 	maxOutstandingMsgs int32               // max allowed outstanding messages
 	numAcks            int32               // num acks we received

--- a/services/outputhost/replicaconnection.go
+++ b/services/outputhost/replicaconnection.go
@@ -185,15 +185,6 @@ func (conn *replicaConnection) readMessagesPump() {
 	// lastSeqNum is used to track whether our sequence numbers are
 	// monotonically increasing
 	var lastSeqNum = int64(conn.startingSequence)
-	// readBatchSize is the number of messages to accumulate before
-	// we notify the other pump to ask for credits
-	// this should be less than or equal to the creditBatchSize because we
-	// need to make sure we are listening for credits on the other pump properly
-	readBatchSize := minReadBatchSize
-
-	if readBatchSize < int(conn.initialCredits/10) {
-		readBatchSize = int(conn.initialCredits / 10)
-	}
 
 	for {
 		select {


### PR DESCRIPTION
`readMessagesPump()` has some code to compute `readBatchSize` which is never used later.
