### PR TITLE
Fix path-regex to allow for number only strings

### DIFF
--- a/common/resolver.go
+++ b/common/resolver.go
@@ -127,13 +127,13 @@ func (r *resolverImpl) cachePut(key string, value string) {
 // so names like /./. aren't valid
 
 // PathRegex regex for destination path
-var PathRegex = regexp.MustCompile(`^/[\w.]*[a-zA-Z][\w.]*/[\w.]*[[:alnum:]][\w.]*$`)
+var PathRegex = regexp.MustCompile(`^/[\w.]*[[:alnum:]][\w.]*/[\w.]*[[:alnum:]][\w.]*$`)
 
 // PathDLQRegex regex for dlq destination path
-var PathDLQRegex = regexp.MustCompile(`^/[\w.]*[a-zA-Z][\w.]*/[\w.]*[[:alnum:]][\w.]*.dlq$`)
+var PathDLQRegex = regexp.MustCompile(`^/[\w.]*[[:alnum:]][\w.]*/[\w.]*[[:alnum:]][\w.]*.dlq$`)
 
 // PathRegexAllowUUID For special destinations (e.g. Dead letter queues) we allow a string UUID as path
-var PathRegexAllowUUID, _ = regexp.Compile(`^(/[\w.]*[a-zA-Z][\w.]*/[\w.]*[[:alnum:]][\w.]*|[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12})$`)
+var PathRegexAllowUUID, _ = regexp.Compile(`^(/[\w.]*[[:alnum:]][\w.]*/[\w.]*[[:alnum:]][\w.]*|[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12})$`)
 
 // ConsumerGroupRegex regex for consumer group path
 var ConsumerGroupRegex = PathRegex

--- a/common/resolver.go
+++ b/common/resolver.go
@@ -127,13 +127,13 @@ func (r *resolverImpl) cachePut(key string, value string) {
 // so names like /./. aren't valid
 
 // PathRegex regex for destination path
-var PathRegex = regexp.MustCompile(`^/[\w.]*[a-zA-Z][\w.]*/[\w.]*[a-zA-Z][\w.]*$`)
+var PathRegex = regexp.MustCompile(`^/[\w.]*[a-zA-Z][\w.]*/[\w.]*[[:alnum:]][\w.]*$`)
 
 // PathDLQRegex regex for dlq destination path
-var PathDLQRegex = regexp.MustCompile(`^/[\w.]*[a-zA-Z][\w.]*/[\w.]*[a-zA-Z][\w.]*.dlq$`)
+var PathDLQRegex = regexp.MustCompile(`^/[\w.]*[a-zA-Z][\w.]*/[\w.]*[[:alnum:]][\w.]*.dlq$`)
 
 // PathRegexAllowUUID For special destinations (e.g. Dead letter queues) we allow a string UUID as path
-var PathRegexAllowUUID, _ = regexp.Compile(`^(/[\w.]*[a-zA-Z][\w.]*/[\w.]*[a-zA-Z][\w.]*|[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12})$`)
+var PathRegexAllowUUID, _ = regexp.Compile(`^(/[\w.]*[a-zA-Z][\w.]*/[\w.]*[[:alnum:]][\w.]*|[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12})$`)
 
 // ConsumerGroupRegex regex for consumer group path
 var ConsumerGroupRegex = PathRegex


### PR DESCRIPTION
Our internal canaries use a shortened-uuid to in the latter part of the path to create destinations/CGs. Occasionally, when this results in a pure numeric string, the create destination/cg fails .. because our regular expressions that validate paths seem to (incorrectly?) enforce there is at least one 'alphabetic' character in each part of the path -- while our comment seems to indicate that we are only trying to enforce each part has at least one non-symbolic character.

