### PR TITLE
support updating zone configs for multi-zone dest and cg

### DIFF
--- a/clients/metadata/metadata_cassandra.go
+++ b/clients/metadata/metadata_cassandra.go
@@ -1533,6 +1533,13 @@ func updateCGDescIfChanged(req *shared.UpdateConsumerGroupRequest, cgDesc *share
 		isChanged = true
 		cgDesc.ActiveZone = common.StringPtr(req.GetActiveZone())
 	}
+
+	if req.IsSetZoneConfigs() && !common.AreCgZoneConfigsEqual(cgDesc.GetZoneConfigs(), req.GetZoneConfigs()) {
+		isChanged = true
+		cgDesc.ZoneConfigs = req.GetZoneConfigs()
+		cgDesc.IsMultiZone = common.BoolPtr(true)
+	}
+
 	return isChanged
 }
 

--- a/clients/metadata/metadata_cassandra.go
+++ b/clients/metadata/metadata_cassandra.go
@@ -726,6 +726,12 @@ func (s *CassandraMetadataService) UpdateDestination(ctx thrift.Context, updateR
 	if !updateRequest.IsSetChecksumOption() {
 		updateRequest.ChecksumOption = common.InternalChecksumOptionPtr(existing.GetChecksumOption())
 	}
+	isMultiZone := existing.GetIsMultiZone()
+	if !updateRequest.IsSetZoneConfigs() {
+		updateRequest.ZoneConfigs = existing.GetZoneConfigs()
+	} else {
+		isMultiZone = true
+	}
 	batch := s.session.NewBatch(gocql.LoggedBatch) // Consider switching to unlogged
 
 	batch.Query(
@@ -738,8 +744,8 @@ func (s *CassandraMetadataService) UpdateDestination(ctx thrift.Context, updateR
 		updateRequest.GetUnconsumedMessagesRetention(),
 		updateRequest.GetOwnerEmail(),
 		updateRequest.GetChecksumOption(),
-		existing.GetIsMultiZone(),
-		marshalDstZoneConfigs(existing.GetZoneConfigs()),
+		isMultiZone,
+		marshalDstZoneConfigs(updateRequest.GetZoneConfigs()),
 		updateRequest.GetDestinationUUID())
 
 	batch.Query(
@@ -752,8 +758,8 @@ func (s *CassandraMetadataService) UpdateDestination(ctx thrift.Context, updateR
 		updateRequest.GetUnconsumedMessagesRetention(),
 		updateRequest.GetOwnerEmail(),
 		updateRequest.GetChecksumOption(),
-		existing.GetIsMultiZone(),
-		marshalDstZoneConfigs(existing.GetZoneConfigs()),
+		isMultiZone,
+		marshalDstZoneConfigs(updateRequest.GetZoneConfigs()),
 		existing.GetPath(),
 		directoryUUID)
 
@@ -794,6 +800,10 @@ func (s *CassandraMetadataService) UpdateDestination(ctx thrift.Context, updateR
 	if updateRequest.IsSetChecksumOption() {
 		existing.ChecksumOption = common.InternalChecksumOptionPtr(updateRequest.GetChecksumOption())
 	}
+	if updateRequest.IsSetZoneConfigs() {
+		existing.ZoneConfigs = updateRequest.GetZoneConfigs()
+	}
+	existing.IsMultiZone = common.BoolPtr(isMultiZone)
 	return existing, nil
 }
 

--- a/cmd/tools/admin/main.go
+++ b/cmd/tools/admin/main.go
@@ -43,7 +43,7 @@ func main() {
 	})
 	app.Name = "cherami"
 	app.Usage = "A command-line tool for cherami developer, including debugging tool"
-	app.Version = "1.2.0"
+	app.Version = "1.2.1"
 	app.Flags = []cli.Flag{
 		cli.BoolTFlag{
 			Name:  "hyperbahn",

--- a/cmd/tools/admin/main.go
+++ b/cmd/tools/admin/main.go
@@ -309,10 +309,13 @@ func main() {
 							Value: "",
 							Usage: "The updated owner's email",
 						},
+						cli.StringSliceFlag{
+							Name:  "zone_config, zc",
+							Usage: "Zone configs for multi_zone destinations. Format for each zone should be \"ZoneName,AllowPublish,AllowConsume,ReplicaCount\". For example: \"zone1,true,true,3\"",
+						},
 					},
 					Action: func(c *cli.Context) {
-
-						admin.UpdateDestination(c)
+						admin.UpdateDestination(c, cliHelper)
 					},
 				},
 				{
@@ -345,9 +348,18 @@ func main() {
 							Value: "",
 							Usage: "The updated owner's email",
 						},
+						cli.StringFlag{
+							Name:  "active_zone, az",
+							Value: "",
+							Usage: "The updated active zone",
+						},
+						cli.StringSliceFlag{
+							Name:  "zone_config, zc",
+							Usage: "Zone configs for multi_zone consumer group. Format for each zone should be \"ZoneName,PreferedActiveZone\". For example: \"zone1,false\"",
+						},
 					},
 					Action: func(c *cli.Context) {
-						admin.UpdateConsumerGroup(c)
+						admin.UpdateConsumerGroup(c, cliHelper)
 					},
 				},
 			},

--- a/cmd/tools/cli/main.go
+++ b/cmd/tools/cli/main.go
@@ -53,7 +53,7 @@ func main() {
 	})
 	app.Name = "cherami"
 	app.Usage = "A command-line tool for cherami users"
-	app.Version = "1.1.9"
+	app.Version = "1.1.10"
 	app.Flags = []cli.Flag{
 		cli.BoolTFlag{
 			Name:  "hyperbahn",

--- a/cmd/tools/cli/main.go
+++ b/cmd/tools/cli/main.go
@@ -265,9 +265,13 @@ func main() {
 							Value: cliHelper.GetDefaultOwnerEmail(),
 							Usage: "The updated owner's email",
 						},
+						cli.StringSliceFlag{
+							Name:  "zone_config, zc",
+							Usage: "Zone configs for multi_zone destinations. Format for each zone should be \"ZoneName,AllowPublish,AllowConsume,ReplicaCount\". For example: \"zone1,true,true,3\"",
+						},
 					},
 					Action: func(c *cli.Context) {
-						lib.UpdateDestination(c)
+						lib.UpdateDestination(c, cliHelper)
 					},
 				},
 				{
@@ -305,9 +309,13 @@ func main() {
 							Value: "",
 							Usage: "The updated active zone",
 						},
+						cli.StringSliceFlag{
+							Name:  "zone_config, zc",
+							Usage: "Zone configs for multi_zone consumer group. Format for each zone should be \"ZoneName,PreferedActiveZone\". For example: \"zone1,false\"",
+						},
 					},
 					Action: func(c *cli.Context) {
-						lib.UpdateConsumerGroup(c)
+						lib.UpdateConsumerGroup(c, cliHelper)
 					},
 				},
 			},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -455,6 +455,8 @@ const (
 	ReplicatorSetAckOffsetInRemoteScope
 	// ReplicatorReadDestinationInRemoteZoneScope represents replicator ReadDestinationInRemoteZone API
 	ReplicatorReadDestinationInRemoteZoneScope
+	// ReplicatorReadCgInRemoteZoneScope represents replicator ReadConsumerGroupInRemoteZone API
+	ReplicatorReadCgInRemoteZoneScope
 	// ReplicatorReconcileScope represents replicator's reconcile process
 	ReplicatorReconcileScope
 )
@@ -580,27 +582,29 @@ var scopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 
 	// Replicator operation tag values as seen by the Metrics backend
 	Replicator: {
-		OpenReplicationRemoteReadScope:      {operation: "OpenReplicationRemoteReadStream"},
-		OpenReplicationReadScope:            {operation: "OpenReplicationReadStream"},
-		ReplicatorCreateDestUUIDScope:       {operation: "ReplicatorCreateDestinationUUID"},
-		ReplicatorCreateRmtDestUUIDScope:    {operation: "ReplicatorCreateRemoteDestinationUUID"},
-		ReplicatorUpdateDestScope:           {operation: "ReplicatorUpdateDestination"},
-		ReplicatorUpdateRmtDestScope:        {operation: "ReplicatorUpdateRemoteDestination"},
-		ReplicatorDeleteDestScope:           {operation: "ReplicatorDeleteDestination"},
-		ReplicatorDeleteRmtDestScope:        {operation: "ReplicatorDeleteRemoteDestination"},
-		ReplicatorCreateCgUUIDScope:         {operation: "ReplicatorCreateConsumerGroupUUID"},
-		ReplicatorCreateRmtCgUUIDScope:      {operation: "ReplicatorCreateRemoteConsumerGroupUUID"},
-		ReplicatorUpdateCgScope:             {operation: "ReplicatorUpdateConsumerGroup"},
-		ReplicatorUpdateRmtCgScope:          {operation: "ReplicatorUpdateRemoteConsumerGroup"},
-		ReplicatorDeleteCgScope:             {operation: "ReplicatorDeleteConsumerGroup"},
-		ReplicatorDeleteRmtCgScope:          {operation: "ReplicatorDeleteRemoteConsumerGroup"},
-		ReplicatorCreateExtentScope:         {operation: "ReplicatorCreateExtent"},
-		ReplicatorCreateRmtExtentScope:      {operation: "ReplicatorCreateRemoteExtent"},
-		ReplicatorCreateCgExtentScope:       {operation: "ReplicatorCreateConsumerGroupExtent"},
-		ReplicatorCreateRmtCgExtentScope:    {operation: "ReplicatorCreateRemoteConsumerGroupExtent"},
-		ReplicatorSetAckOffsetScope:         {operation: "SetAckOffset"},
-		ReplicatorSetAckOffsetInRemoteScope: {operation: "SetAckOffsetInRemote"},
-		ReplicatorReconcileScope:            {operation: "ReplicatorReconcile"},
+		OpenReplicationRemoteReadScope:             {operation: "OpenReplicationRemoteReadStream"},
+		OpenReplicationReadScope:                   {operation: "OpenReplicationReadStream"},
+		ReplicatorCreateDestUUIDScope:              {operation: "ReplicatorCreateDestinationUUID"},
+		ReplicatorCreateRmtDestUUIDScope:           {operation: "ReplicatorCreateRemoteDestinationUUID"},
+		ReplicatorUpdateDestScope:                  {operation: "ReplicatorUpdateDestination"},
+		ReplicatorUpdateRmtDestScope:               {operation: "ReplicatorUpdateRemoteDestination"},
+		ReplicatorDeleteDestScope:                  {operation: "ReplicatorDeleteDestination"},
+		ReplicatorDeleteRmtDestScope:               {operation: "ReplicatorDeleteRemoteDestination"},
+		ReplicatorCreateCgUUIDScope:                {operation: "ReplicatorCreateConsumerGroupUUID"},
+		ReplicatorCreateRmtCgUUIDScope:             {operation: "ReplicatorCreateRemoteConsumerGroupUUID"},
+		ReplicatorUpdateCgScope:                    {operation: "ReplicatorUpdateConsumerGroup"},
+		ReplicatorUpdateRmtCgScope:                 {operation: "ReplicatorUpdateRemoteConsumerGroup"},
+		ReplicatorDeleteCgScope:                    {operation: "ReplicatorDeleteConsumerGroup"},
+		ReplicatorDeleteRmtCgScope:                 {operation: "ReplicatorDeleteRemoteConsumerGroup"},
+		ReplicatorCreateExtentScope:                {operation: "ReplicatorCreateExtent"},
+		ReplicatorCreateRmtExtentScope:             {operation: "ReplicatorCreateRemoteExtent"},
+		ReplicatorCreateCgExtentScope:              {operation: "ReplicatorCreateConsumerGroupExtent"},
+		ReplicatorCreateRmtCgExtentScope:           {operation: "ReplicatorCreateRemoteConsumerGroupExtent"},
+		ReplicatorSetAckOffsetScope:                {operation: "SetAckOffset"},
+		ReplicatorSetAckOffsetInRemoteScope:        {operation: "SetAckOffsetInRemote"},
+		ReplicatorReadDestinationInRemoteZoneScope: {operation: "ReadDestinationInRemoteZone"},
+		ReplicatorReadCgInRemoteZoneScope:          {operation: "ReadConsumerGroupInRemoteZone"},
+		ReplicatorReconcileScope:                   {operation: "ReplicatorReconcile"},
 	},
 
 	// Controller operation tag values as seen by the Metrics backend

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -453,6 +453,8 @@ const (
 	ReplicatorSetAckOffsetScope
 	// ReplicatorSetAckOffsetInRemoteScope represents replicator SetAckOffsetInRemote API
 	ReplicatorSetAckOffsetInRemoteScope
+	// ReplicatorReadDestinationInRemoteZoneScope represents replicator ReadDestinationInRemoteZone API
+	ReplicatorReadDestinationInRemoteZoneScope
 	// ReplicatorReconcileScope represents replicator's reconcile process
 	ReplicatorReconcileScope
 )

--- a/common/util.go
+++ b/common/util.go
@@ -831,3 +831,27 @@ func AreDestinationZoneConfigsEqual(left []*shared.DestinationZoneConfig, right 
 	}
 	return true
 }
+
+// AreCgZoneConfigsEqual determines whether two zone configs have the same content
+func AreCgZoneConfigsEqual(left []*shared.ConsumerGroupZoneConfig, right []*shared.ConsumerGroupZoneConfig) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for _, l := range left {
+		zone := l.GetZone()
+		foundMatch := false
+		for _, r := range right {
+			if r.GetZone() == zone {
+				foundMatch = true
+				if l.GetVisible() != r.GetVisible() {
+					return false
+				}
+				break
+			}
+		}
+		if !foundMatch {
+			return false
+		}
+	}
+	return true
+}

--- a/common/util.go
+++ b/common/util.go
@@ -45,6 +45,7 @@ import (
 	"github.com/uber/cherami-server/common/metrics"
 	"github.com/uber/cherami-thrift/.generated/go/admin"
 	"github.com/uber/cherami-thrift/.generated/go/cherami"
+	"github.com/uber/cherami-thrift/.generated/go/shared"
 	"github.com/uber/ringpop-go"
 	"github.com/uber/ringpop-go/discovery/statichosts"
 	"github.com/uber/ringpop-go/swim"
@@ -802,4 +803,31 @@ func IsKafkaPhantomInput(inputUUID string) bool {
 func AreKafkaPhantomStores(storeUUIDs []string) bool {
 
 	return len(storeUUIDs) == 1 && storeUUIDs[0] == KafkaPhantomExtentStorehost
+}
+
+// AreDestinationZoneConfigsEqual determines whether two zone configs have the same content
+func AreDestinationZoneConfigsEqual(left []*shared.DestinationZoneConfig, right []*shared.DestinationZoneConfig) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for _, l := range left {
+		zone := l.GetZone()
+		foundMatch := false
+		for _, r := range right {
+			if r.GetZone() == zone {
+				foundMatch = true
+				if l.GetAllowConsume() != r.GetAllowConsume() ||
+					l.GetAllowPublish() != r.GetAllowPublish() ||
+					l.GetAlwaysReplicateTo() != r.GetAlwaysReplicateTo() ||
+					l.GetRemoteExtentReplicaNum() != r.GetRemoteExtentReplicaNum() {
+					return false
+				}
+				break
+			}
+		}
+		if !foundMatch {
+			return false
+		}
+	}
+	return true
 }

--- a/common/util.go
+++ b/common/util.go
@@ -814,7 +814,7 @@ func AreDestinationZoneConfigsEqual(left []*shared.DestinationZoneConfig, right 
 		zone := l.GetZone()
 		foundMatch := false
 		for _, r := range right {
-			if r.GetZone() == zone {
+			if strings.EqualFold(r.GetZone(), zone) {
 				foundMatch = true
 				if l.GetAllowConsume() != r.GetAllowConsume() ||
 					l.GetAllowPublish() != r.GetAllowPublish() ||
@@ -841,7 +841,7 @@ func AreCgZoneConfigsEqual(left []*shared.ConsumerGroupZoneConfig, right []*shar
 		zone := l.GetZone()
 		foundMatch := false
 		for _, r := range right {
-			if r.GetZone() == zone {
+			if strings.EqualFold(r.GetZone(), zone) {
 				foundMatch = true
 				if l.GetVisible() != r.GetVisible() {
 					return false

--- a/glide.lock
+++ b/glide.lock
@@ -135,7 +135,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: 4060dc94e386e1146e130e63070d1a7235b26666
+  version: d090177faf12b66a3147be46b9e57b6508fa7132
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/glide.lock
+++ b/glide.lock
@@ -135,7 +135,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: d090177faf12b66a3147be46b9e57b6508fa7132
+  version: a85500412e14c4a0089c981fd4cc0497b8282ea3
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/glide.lock
+++ b/glide.lock
@@ -135,7 +135,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: be4d5fc25dbf54affd1d8be5bf49bd3fc0440330
+  version: 4060dc94e386e1146e130e63070d1a7235b26666
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/services/controllerhost/controllerhost.go
+++ b/services/controllerhost/controllerhost.go
@@ -868,13 +868,13 @@ func (mcp *Mcp) UpdateDestination(ctx thrift.Context, updateRequest *shared.Upda
 
 	if updateRequest.IsSetZoneConfigs() {
 		valid, err := mcp.ValidateDestZoneConfig(ctx, lclLg, updateRequest)
+		if err != nil {
+			context.m3Client.IncCounter(metrics.ControllerUpdateDestinationScope, metrics.ControllerFailures)
+			lclLg.WithField(common.TagErr, err).Error("UpdateDestination: ValidateDestZoneConfig returned error")
+			return nil, err
+		}
 		if !valid {
 			context.m3Client.IncCounter(metrics.ControllerUpdateDestinationScope, metrics.ControllerFailures)
-			if err != nil {
-				lclLg.WithField(common.TagErr, err).Error("UpdateDestination: ValidateDestZoneConfigUpdateRequest returned error")
-				return nil, err
-			}
-
 			lclLg.Error("UpdateDestination: zone config validation failed")
 			return nil, &shared.BadRequestError{Message: "zone config validation failed"}
 		}
@@ -1056,13 +1056,13 @@ func (mcp *Mcp) UpdateConsumerGroup(ctx thrift.Context, updateRequest *shared.Up
 
 	if updateRequest.IsSetZoneConfigs() {
 		valid, err := mcp.ValidateCgZoneConfig(ctx, lclLg, updateRequest)
+		if err != nil {
+			context.m3Client.IncCounter(metrics.ControllerUpdateConsumerGroupScope, metrics.ControllerFailures)
+			lclLg.WithField(common.TagErr, err).Error("UpdateConsumerGroup: ValidateCgZoneConfig returned error")
+			return nil, err
+		}
 		if !valid {
 			context.m3Client.IncCounter(metrics.ControllerUpdateConsumerGroupScope, metrics.ControllerFailures)
-			if err != nil {
-				lclLg.WithField(common.TagErr, err).Error("UpdateConsumerGroup: ValidateCgZoneConfigUpdateRequest returned error")
-				return nil, err
-			}
-
 			lclLg.Error("UpdateConsumerGroup: zone config validation failed")
 			return nil, &shared.BadRequestError{Message: "zone config validation failed"}
 		}

--- a/services/controllerhost/controllerhost_test.go
+++ b/services/controllerhost/controllerhost_test.go
@@ -1103,7 +1103,6 @@ func (s *McpSuite) TestMultiZoneDestCUD() {
 }
 
 func (s *McpSuite) TestMultiZoneDestConfigUpdate() {
-	/*********TEST CREATION*****************/
 	destPath := s.generateName("/cherami/mcp-test")
 	createReq := &shared.CreateDestinationRequest{
 		Path:        common.StringPtr(destPath),
@@ -1341,7 +1340,6 @@ func (s *McpSuite) TestDeleteConsumerGroup() {
 }
 
 func (s *McpSuite) TestMultiZoneCgConfigUpdate() {
-	/*********TEST CREATION*****************/
 	destPath := s.generateName("/cherami/mcp-test")
 	cgName := s.generateName("/cherami/mcp-test-cg")
 	_, err := s.createDestination(destPath, shared.DestinationType_PLAIN)

--- a/services/frontendhost/frontend.go
+++ b/services/frontendhost/frontend.go
@@ -264,6 +264,12 @@ func convertUpdateDestRequestToInternal(updateRequest *c.UpdateDestinationReques
 	if updateRequest.IsSetChecksumOption() {
 		internalUpdateRequest.ChecksumOption = common.InternalChecksumOptionPtr(shared.ChecksumOption(updateRequest.GetChecksumOption()))
 	}
+	if updateRequest.IsSetZoneConfigs() {
+		internalUpdateRequest.ZoneConfigs = make([]*shared.DestinationZoneConfig, 0, len(updateRequest.GetZoneConfigs().GetConfigs()))
+		for _, destZoneCfg := range updateRequest.GetZoneConfigs().GetConfigs() {
+			internalUpdateRequest.ZoneConfigs = append(internalUpdateRequest.ZoneConfigs, convertDestZoneConfigToInternal(destZoneCfg))
+		}
+	}
 	return internalUpdateRequest
 }
 

--- a/services/frontendhost/frontend.go
+++ b/services/frontendhost/frontend.go
@@ -414,6 +414,12 @@ func convertUpdateCGRequestToInternal(updateRequest *c.UpdateConsumerGroupReques
 	if updateRequest.IsSetActiveZone() {
 		internalUpdateRequest.ActiveZone = common.StringPtr(updateRequest.GetActiveZone())
 	}
+	if updateRequest.IsSetZoneConfigs() {
+		internalUpdateRequest.ZoneConfigs = make([]*shared.ConsumerGroupZoneConfig, 0, len(updateRequest.GetZoneConfigs().GetConfigs()))
+		for _, cgZoneCfg := range updateRequest.GetZoneConfigs().GetConfigs() {
+			internalUpdateRequest.ZoneConfigs = append(internalUpdateRequest.ZoneConfigs, convertCGZoneConfigToInternal(cgZoneCfg))
+		}
+	}
 	return internalUpdateRequest
 }
 

--- a/services/replicator/metadataReconciler.go
+++ b/services/replicator/metadataReconciler.go
@@ -409,6 +409,10 @@ func (r *metadataReconciler) compareAndUpdateCg(remoteCg *shared.ConsumerGroupDe
 		updateRequest.ActiveZone = common.StringPtr(remoteCg.GetActiveZone())
 		cgUpdated = true
 	}
+	if !common.AreCgZoneConfigsEqual(localCg.GetZoneConfigs(), remoteCg.GetZoneConfigs()) {
+		updateRequest.ZoneConfigs = remoteCg.GetZoneConfigs()
+		cgUpdated = true
+	}
 
 	if cgUpdated {
 		logger.Info(`Found cg gets updated in remote but not in local`)

--- a/services/replicator/metadataReconciler.go
+++ b/services/replicator/metadataReconciler.go
@@ -225,6 +225,11 @@ func (r *metadataReconciler) reconcileDest(localDests []*shared.DestinationDescr
 				destUpdated = true
 			}
 
+			if !common.AreDestinationZoneConfigsEqual(localDest.GetZoneConfigs(), remoteDest.GetZoneConfigs()) {
+				updateRequest.ZoneConfigs = remoteDest.GetZoneConfigs()
+				destUpdated = true
+			}
+
 			if destUpdated {
 				r.logger.WithField(common.TagDst, common.FmtDst(remoteDest.GetDestinationUUID())).Info(`Found destination gets updated in remote but not in local`)
 				ctx, cancel := thrift.NewContext(localReplicatorCallTimeOut)

--- a/services/replicator/replicator.go
+++ b/services/replicator/replicator.go
@@ -1171,6 +1171,22 @@ func (r *Replicator) ReadDestination(ctx thrift.Context, getRequest *shared.Read
 	return r.metaClient.ReadDestination(ctx, getRequest)
 }
 
+// ReadDestinationInRemoteZone reads a destination in remote zone
+func (r *Replicator) ReadDestinationInRemoteZone(ctx thrift.Context, getRequest *shared.ReadDestinationInRemoteZoneRequest) (*shared.DestinationDescription, error) {
+	// acquire remote zone replicator thrift client
+	client, err := r.replicatorclientFactory.GetReplicatorClient(getRequest.GetZone())
+	if err != nil {
+		r.m3Client.IncCounter(metrics.ReplicatorReadDestinationInRemoteZoneScope, metrics.ReplicatorFailures)
+		r.logger.WithField(common.TagErr, err).Error(`Get remote replicator client failed`)
+		return nil, err
+	}
+
+	// send to remote zone replicator
+	ctx, cancel := thrift.NewContext(remoteReplicatorCallTimeOut)
+	defer cancel()
+	return client.ReadDestination(ctx, getRequest.GetRequest())
+}
+
 // ListConsumerGroups list consumer groups
 func (r *Replicator) ListConsumerGroups(ctx thrift.Context, getRequest *shared.ListConsumerGroupRequest) (*shared.ListConsumerGroupResult_, error) {
 	return r.metaClient.ListConsumerGroups(ctx, getRequest)

--- a/services/replicator/replicator.go
+++ b/services/replicator/replicator.go
@@ -1187,6 +1187,27 @@ func (r *Replicator) ReadDestinationInRemoteZone(ctx thrift.Context, getRequest 
 	return client.ReadDestination(ctx, getRequest.GetRequest())
 }
 
+// ReadConsumerGroup reads a cg
+func (r *Replicator) ReadConsumerGroup(ctx thrift.Context, getRequest *shared.ReadConsumerGroupRequest) (*shared.ConsumerGroupDescription, error) {
+	return r.metaClient.ReadConsumerGroup(ctx, getRequest)
+}
+
+// ReadConsumerGroupInRemoteZone reads a cg in remote zone
+func (r *Replicator) ReadConsumerGroupInRemoteZone(ctx thrift.Context, getRequest *shared.ReadConsumerGroupInRemoteRequest) (*shared.ConsumerGroupDescription, error) {
+	// acquire remote zone replicator thrift client
+	client, err := r.replicatorclientFactory.GetReplicatorClient(getRequest.GetZone())
+	if err != nil {
+		r.m3Client.IncCounter(metrics.ReplicatorReadCgInRemoteZoneScope, metrics.ReplicatorFailures)
+		r.logger.WithField(common.TagErr, err).Error(`Get remote replicator client failed`)
+		return nil, err
+	}
+
+	// send to remote zone replicator
+	ctx, cancel := thrift.NewContext(remoteReplicatorCallTimeOut)
+	defer cancel()
+	return client.ReadConsumerGroup(ctx, getRequest.GetRequest())
+}
+
 // ListConsumerGroups list consumer groups
 func (r *Replicator) ListConsumerGroups(ctx thrift.Context, getRequest *shared.ListConsumerGroupRequest) (*shared.ListConsumerGroupResult_, error) {
 	return r.metaClient.ListConsumerGroups(ctx, getRequest)

--- a/test/mocks/replicator/MockTChanReplicator.go
+++ b/test/mocks/replicator/MockTChanReplicator.go
@@ -456,3 +456,25 @@ func (m *MockTChanReplicator) SetAckOffsetInRemote(ctx thrift.Context, request *
 
 	return r0
 }
+
+func (m *MockTChanReplicator) ReadDestinationInRemoteZone(ctx thrift.Context, listRequest *shared.ReadDestinationInRemoteZoneRequest) (*shared.DestinationDescription, error) {
+	ret := m.Called(ctx, listRequest)
+
+	var r0 *shared.DestinationDescription
+	if rf, ok := ret.Get(0).(func(thrift.Context, *shared.ReadDestinationInRemoteZoneRequest) *shared.DestinationDescription); ok {
+		r0 = rf(ctx, listRequest)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*shared.DestinationDescription)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, *shared.ReadDestinationInRemoteZoneRequest) error); ok {
+		r1 = rf(ctx, listRequest)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/test/mocks/replicator/MockTChanReplicator.go
+++ b/test/mocks/replicator/MockTChanReplicator.go
@@ -361,6 +361,28 @@ func (m *MockTChanReplicator) ReadDestination(ctx thrift.Context, listRequest *s
 	return r0, r1
 }
 
+func (m *MockTChanReplicator) ReadDestinationInRemoteZone(ctx thrift.Context, listRequest *shared.ReadDestinationInRemoteZoneRequest) (*shared.DestinationDescription, error) {
+	ret := m.Called(ctx, listRequest)
+
+	var r0 *shared.DestinationDescription
+	if rf, ok := ret.Get(0).(func(thrift.Context, *shared.ReadDestinationInRemoteZoneRequest) *shared.DestinationDescription); ok {
+		r0 = rf(ctx, listRequest)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*shared.DestinationDescription)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, *shared.ReadDestinationInRemoteZoneRequest) error); ok {
+		r1 = rf(ctx, listRequest)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 func (m *MockTChanReplicator) ListConsumerGroups(ctx thrift.Context, listRequest *shared.ListConsumerGroupRequest) (*shared.ListConsumerGroupResult_, error) {
 	ret := m.Called(ctx, listRequest)
 
@@ -457,20 +479,42 @@ func (m *MockTChanReplicator) SetAckOffsetInRemote(ctx thrift.Context, request *
 	return r0
 }
 
-func (m *MockTChanReplicator) ReadDestinationInRemoteZone(ctx thrift.Context, listRequest *shared.ReadDestinationInRemoteZoneRequest) (*shared.DestinationDescription, error) {
+func (m *MockTChanReplicator) ReadConsumerGroup(ctx thrift.Context, listRequest *shared.ReadConsumerGroupRequest) (*shared.ConsumerGroupDescription, error) {
 	ret := m.Called(ctx, listRequest)
 
-	var r0 *shared.DestinationDescription
-	if rf, ok := ret.Get(0).(func(thrift.Context, *shared.ReadDestinationInRemoteZoneRequest) *shared.DestinationDescription); ok {
+	var r0 *shared.ConsumerGroupDescription
+	if rf, ok := ret.Get(0).(func(thrift.Context, *shared.ReadConsumerGroupRequest) *shared.ConsumerGroupDescription); ok {
 		r0 = rf(ctx, listRequest)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*shared.DestinationDescription)
+			r0 = ret.Get(0).(*shared.ConsumerGroupDescription)
 		}
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(thrift.Context, *shared.ReadDestinationInRemoteZoneRequest) error); ok {
+	if rf, ok := ret.Get(1).(func(thrift.Context, *shared.ReadConsumerGroupRequest) error); ok {
+		r1 = rf(ctx, listRequest)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+func (m *MockTChanReplicator) ReadConsumerGroupInRemoteZone(ctx thrift.Context, listRequest *shared.ReadConsumerGroupInRemoteRequest) (*shared.ConsumerGroupDescription, error) {
+	ret := m.Called(ctx, listRequest)
+
+	var r0 *shared.ConsumerGroupDescription
+	if rf, ok := ret.Get(0).(func(thrift.Context, *shared.ReadConsumerGroupInRemoteRequest) *shared.ConsumerGroupDescription); ok {
+		r0 = rf(ctx, listRequest)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*shared.ConsumerGroupDescription)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, *shared.ReadConsumerGroupInRemoteRequest) error); ok {
 		r1 = rf(ctx, listRequest)
 	} else {
 		r1 = ret.Error(1)

--- a/tools/admin/lib.go
+++ b/tools/admin/lib.go
@@ -56,10 +56,10 @@ func CreateDestinationSecure(c *cli.Context, cliHelper common.CliHelper, authPro
 }
 
 // UpdateDestination updates properties of a destination
-func UpdateDestination(c *cli.Context) {
+func UpdateDestination(c *cli.Context, cliHelper common.CliHelper) {
 	cClient := toolscommon.GetCClient(c, adminToolService)
 	mClient := toolscommon.GetMClient(c, adminToolService)
-	toolscommon.UpdateDestination(c, cClient, mClient)
+	toolscommon.UpdateDestination(c, cClient, mClient, cliHelper)
 }
 
 // CreateConsumerGroup creates a consumer group
@@ -75,9 +75,10 @@ func CreateConsumerGroupSecure(c *cli.Context, cliHelper common.CliHelper, authP
 }
 
 // UpdateConsumerGroup updates properties of a consumer group
-func UpdateConsumerGroup(c *cli.Context) {
+func UpdateConsumerGroup(c *cli.Context, cliHelper common.CliHelper) {
 	cClient := toolscommon.GetCClient(c, adminToolService)
-	toolscommon.UpdateConsumerGroup(c, cClient)
+	mClient := toolscommon.GetMClient(c, adminToolService)
+	toolscommon.UpdateConsumerGroup(c, cClient, mClient, cliHelper)
 }
 
 // ReadDestination reads a destination

--- a/tools/cli/lib.go
+++ b/tools/cli/lib.go
@@ -49,10 +49,10 @@ func CreateDestinationSecure(c *cli.Context, cliHelper scommon.CliHelper, authPr
 }
 
 // UpdateDestination updates the destination
-func UpdateDestination(c *cli.Context) {
+func UpdateDestination(c *cli.Context, cliHelper scommon.CliHelper) {
 	mClient := common.GetMClient(c, serviceName)
 	cClient := common.GetCClient(c, serviceName)
-	common.UpdateDestination(c, cClient, mClient)
+	common.UpdateDestination(c, cClient, mClient, cliHelper)
 }
 
 // CreateConsumerGroup creates the CG
@@ -68,9 +68,10 @@ func CreateConsumerGroupSecure(c *cli.Context, cliHelper scommon.CliHelper, auth
 }
 
 // UpdateConsumerGroup updates the CG
-func UpdateConsumerGroup(c *cli.Context) {
+func UpdateConsumerGroup(c *cli.Context, cliHelper scommon.CliHelper) {
 	cClient := common.GetCClient(c, serviceName)
-	common.UpdateConsumerGroup(c, cClient)
+	mClient := common.GetMClient(c, serviceName)
+	common.UpdateConsumerGroup(c, cClient, mClient, cliHelper)
 }
 
 // ReadDestination is used to get info about the destination


### PR DESCRIPTION
This patch adds support for upgrading a regular destination or consumer group to a multi-zone one.
related thrift change in: https://github.com/uber/cherami-thrift/pull/23