### PR TITLE
Bug fix: update is_multi_zone field in metadata for update destination request

### DIFF
--- a/clients/metadata/metadata_cassandra.go
+++ b/clients/metadata/metadata_cassandra.go
@@ -371,6 +371,7 @@ const (
 
 	sqlUpdateDstByUUID = `UPDATE ` + tableDestinations + ` SET ` +
 		columnDestination + `=` + sqlDstType +
+		`, ` + columnIsMultiZone + ` = ? ` +
 		` WHERE ` + columnUUID + `=?`
 
 	sqlUpdateDstDLQCursors = `UPDATE ` + tableDestinations + ` SET ` +
@@ -380,6 +381,7 @@ const (
 
 	sqlUpdateDstByPath = `UPDATE ` + tableDestinationsByPath + ` SET ` +
 		columnDestination + `=` + sqlDstType +
+		`, ` + columnIsMultiZone + ` = ? ` +
 		` WHERE ` + columnPath + `=? and ` + columnDirectoryUUID + `=?`
 
 	sqlDeleteDst = `DELETE FROM ` + tableDestinationsByPath +
@@ -746,6 +748,7 @@ func (s *CassandraMetadataService) UpdateDestination(ctx thrift.Context, updateR
 		updateRequest.GetChecksumOption(),
 		isMultiZone,
 		marshalDstZoneConfigs(updateRequest.GetZoneConfigs()),
+		isMultiZone,
 		updateRequest.GetDestinationUUID())
 
 	batch.Query(
@@ -760,6 +763,7 @@ func (s *CassandraMetadataService) UpdateDestination(ctx thrift.Context, updateR
 		updateRequest.GetChecksumOption(),
 		isMultiZone,
 		marshalDstZoneConfigs(updateRequest.GetZoneConfigs()),
+		isMultiZone,
 		existing.GetPath(),
 		directoryUUID)
 
@@ -829,6 +833,7 @@ func (s *CassandraMetadataService) DeleteDestination(ctx thrift.Context, deleteR
 		existing.GetChecksumOption(),
 		existing.GetIsMultiZone(),
 		marshalDstZoneConfigs(existing.GetZoneConfigs()),
+		existing.GetIsMultiZone(),
 		existing.GetDestinationUUID())
 	batch.Query(sqlDeleteDst, directoryUUID, existing.GetPath())
 	if err = s.session.ExecuteBatch(batch); err != nil {
@@ -1705,6 +1710,7 @@ func (s *CassandraMetadataService) DeleteConsumerGroup(ctx thrift.Context, reque
 			dlqDstDesc.GetChecksumOption(),
 			dlqDstDesc.IsMultiZone,
 			marshalDstZoneConfigs(dlqDstDesc.ZoneConfigs),
+			dlqDstDesc.IsMultiZone,
 			dlqDstDesc.GetDestinationUUID())
 	}
 

--- a/services/controllerhost/controllerhost_test.go
+++ b/services/controllerhost/controllerhost_test.go
@@ -1108,6 +1108,10 @@ func (s *McpSuite) TestMultiZoneDestConfigUpdate() {
 		Path:        common.StringPtr(destPath),
 		IsMultiZone: common.BoolPtr(false),
 	}
+	listReq := &shared.ListDestinationsByUUIDRequest{
+		MultiZoneOnly:            common.BoolPtr(true),
+		ValidateAgainstPathTable: common.BoolPtr(true),
+	}
 
 	// issue create request
 	destDesc, err := s.mcp.CreateDestination(nil, createReq)
@@ -1124,6 +1128,9 @@ func (s *McpSuite) TestMultiZoneDestConfigUpdate() {
 	s.NotNil(destDesc)
 	s.Equal(destPath, destDesc.GetPath())
 	s.False(destDesc.GetIsMultiZone())
+	listRes, err := s.mClient.ListDestinationsByUUID(nil, listReq)
+	s.NoError(err)
+	s.False(ListDestResultContains(listRes, destUUID))
 
 	/*********update to a multi-zone destination, expect to fail because path exists in remote but uuid is different*****************/
 	var zoneConfigs []*shared.DestinationZoneConfig
@@ -1153,6 +1160,9 @@ func (s *McpSuite) TestMultiZoneDestConfigUpdate() {
 	s.Error(err)
 	assert.IsType(s.T(), &shared.BadRequestError{}, err)
 	s.Nil(destDesc)
+	listRes, err = s.mClient.ListDestinationsByUUID(nil, listReq)
+	s.NoError(err)
+	s.False(ListDestResultContains(listRes, destUUID))
 
 	/*********update to a multi-zone destination, expect to fail because ReadDestinationInRemoteZone returns an random error*****************/
 	// ReadDestinationInRemoteZone returns a random error
@@ -1165,6 +1175,9 @@ func (s *McpSuite) TestMultiZoneDestConfigUpdate() {
 	destDesc, err = s.mcp.UpdateDestination(nil, updateReq)
 	s.Error(err)
 	s.Nil(destDesc)
+	listRes, err = s.mClient.ListDestinationsByUUID(nil, listReq)
+	s.NoError(err)
+	s.False(ListDestResultContains(listRes, destUUID))
 
 	/*********update to a multi-zone destination, expect to succeed (same uuid exists in remote already)*****************/
 	// uuid exists in remote already
@@ -1197,6 +1210,9 @@ func (s *McpSuite) TestMultiZoneDestConfigUpdate() {
 	s.Equal(destPath, destDesc.GetPath())
 	s.True(common.AreDestinationZoneConfigsEqual(zoneConfigs, destDesc.GetZoneConfigs()))
 	s.True(destDesc.GetIsMultiZone())
+	listRes, err = s.mClient.ListDestinationsByUUID(nil, listReq)
+	s.NoError(err)
+	s.True(ListDestResultContains(listRes, destUUID))
 
 	/*********update to a multi-zone destination, expect to succeed (path doesn't exist in remote)*****************/
 	zoneConfigs[0].AllowConsume = common.BoolPtr(!zoneConfigs[0].GetAllowConsume()) // flip some config
@@ -1229,6 +1245,18 @@ func (s *McpSuite) TestMultiZoneDestConfigUpdate() {
 	s.Equal(destPath, destDesc.GetPath())
 	s.True(common.AreDestinationZoneConfigsEqual(zoneConfigs, destDesc.GetZoneConfigs()))
 	s.True(destDesc.GetIsMultiZone())
+	listRes, err = s.mClient.ListDestinationsByUUID(nil, listReq)
+	s.NoError(err)
+	s.True(ListDestResultContains(listRes, destUUID))
+}
+
+func ListDestResultContains(result *shared.ListDestinationsResult_, uuid string) bool {
+	for _, dest := range result.GetDestinations() {
+		if dest.GetDestinationUUID() == uuid {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *McpSuite) TestCreateConsumerGroup() {


### PR DESCRIPTION
We have two is_multi_zone field in destinations table, one in the destination type, another in a column in destinations. The bug is we only update the first field, which causes ListDestinations call to not return the mz destination after it's upgraded, because ListDestinations filters on the second filed.

CREATE TYPE destination (
    uuid uuid,
    path text,
    type int,
    status int,
    consumed_messages_retention int,
    unconsumed_messages_retention int,
    owner_email text,
    checksum_option int,
    is_multi_zone boolean,
    zone_configs list<frozen<destination_zone_config>>,
    schema_version int
);

CREATE TABLE destinations (
    uuid uuid PRIMARY KEY,
    is_multi_zone boolean,
    destination frozen<destination>,
)