### PR TITLE
fix sirupsen repo name

### DIFF
--- a/benchmark/base_test.go
+++ b/benchmark/base_test.go
@@ -52,7 +52,7 @@ import (
 	"github.com/uber/tchannel-go/thrift"
 	"golang.org/x/net/context"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/benchmark/e2ebench_test.go
+++ b/benchmark/e2ebench_test.go
@@ -29,7 +29,7 @@ import (
 
 	"testing"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 func BenchmarkE2E(b *testing.B) {

--- a/benchmark/inputbench_test.go
+++ b/benchmark/inputbench_test.go
@@ -23,8 +23,8 @@ package benchmark
 import (
 	"testing"
 
-	log "github.com/Sirupsen/logrus"
 	_ "github.com/apache/thrift/lib/go/thrift"
+	log "github.com/sirupsen/logrus"
 )
 
 func BenchmarkInputhostWrite(b *testing.B) {

--- a/benchmark/outputbench_test.go
+++ b/benchmark/outputbench_test.go
@@ -29,7 +29,7 @@ import (
 
 	"testing"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 func BenchmarkOutputRead(b *testing.B) {

--- a/benchmark/storebench_test.go
+++ b/benchmark/storebench_test.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/pborman/uuid"
 
-	log "github.com/Sirupsen/logrus"
 	_ "github.com/apache/thrift/lib/go/thrift"
+	log "github.com/sirupsen/logrus"
 	"github.com/uber/cherami-server/common"
 	"github.com/uber/cherami-thrift/.generated/go/cherami"
 

--- a/clients/metadata/metadata_cassandra.go
+++ b/clients/metadata/metadata_cassandra.go
@@ -32,9 +32,9 @@ import (
 	m "github.com/uber/cherami-thrift/.generated/go/metadata"
 	"github.com/uber/cherami-thrift/.generated/go/shared"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/gocql/gocql"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 	"github.com/uber/tchannel-go/thrift"
 )
 

--- a/clients/metadata/metadata_cassandra_test.go
+++ b/clients/metadata/metadata_cassandra_test.go
@@ -40,7 +40,7 @@ import (
 	m "github.com/uber/cherami-thrift/.generated/go/metadata"
 	"github.com/uber/cherami-thrift/.generated/go/shared"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type CassandraSuite struct {

--- a/clients/metadata/util.go
+++ b/clients/metadata/util.go
@@ -30,8 +30,8 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/gocql/gocql"
+	log "github.com/sirupsen/logrus"
 	"github.com/uber/cherami-server/common"
 	"github.com/uber/cherami-server/common/configure"
 	m "github.com/uber/cherami-thrift/.generated/go/metadata"

--- a/cmd/servicecmd/servicestartcmd.go
+++ b/cmd/servicecmd/servicestartcmd.go
@@ -26,7 +26,7 @@ import (
 	"os"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/uber/cherami-server/clients/metadata"
 	"github.com/uber/cherami-server/common"

--- a/common/cassandra_helpers.go
+++ b/common/cassandra_helpers.go
@@ -27,8 +27,8 @@ import (
 	"bytes"
 	"os/exec"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/gocql/gocql"
+	log "github.com/sirupsen/logrus"
 )
 
 // NewCassandraCluster creates a cassandra cluster given comma separated list of clusterHosts

--- a/common/configure/commonconfigure.go
+++ b/common/configure/commonconfigure.go
@@ -30,8 +30,8 @@ import (
 	"path"
 	"runtime"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 	"github.com/uber/tchannel-go"
 	"gopkg.in/validator.v2"
 	"gopkg.in/yaml.v2"

--- a/common/configure/commonkafkaconfig.go
+++ b/common/configure/commonkafkaconfig.go
@@ -21,7 +21,7 @@
 package configure
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"strings"

--- a/common/configure/commonlogconfig.go
+++ b/common/configure/commonlogconfig.go
@@ -24,7 +24,7 @@ import (
 	"io/ioutil"
 	"sync/atomic"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/uber-common/bark"
 )
 

--- a/common/configure/commonserviceconfig.go
+++ b/common/configure/commonserviceconfig.go
@@ -24,8 +24,8 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/Sirupsen/logrus"
-	log "github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/uber-common/bark"
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/thrift"

--- a/common/dconfig/configmgr_test.go
+++ b/common/dconfig/configmgr_test.go
@@ -25,7 +25,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-common/bark"

--- a/common/dconfigclient/generate.go
+++ b/common/dconfigclient/generate.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"regexp"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // SetterInt is the setter function to generate the handler function

--- a/common/loadreporter_test.go
+++ b/common/loadreporter_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-common/bark"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/uber/cherami-thrift/.generated/go/controller"
 

--- a/common/mockloadreporterdaemonfactory.go
+++ b/common/mockloadreporterdaemonfactory.go
@@ -23,7 +23,7 @@ package common
 import (
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/uber-common/bark"

--- a/common/rp_cluster_test.go
+++ b/common/rp_cluster_test.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 	"github.com/uber/ringpop-go"
 	"github.com/uber/ringpop-go/discovery/statichosts"
 	"github.com/uber/ringpop-go/swim"

--- a/common/rpm_test.go
+++ b/common/rpm_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-common/bark"

--- a/common/service.go
+++ b/common/service.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/uber-common/bark"
 	"github.com/uber/cherami-server/common/configure"
 	dconfig "github.com/uber/cherami-server/common/dconfigclient"

--- a/common/util.go
+++ b/common/util.go
@@ -39,7 +39,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/uber-common/bark"
 	"github.com/uber/cherami-server/common/configure"
 	"github.com/uber/cherami-server/common/metrics"

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-common/bark"

--- a/distance/dist_test.go
+++ b/distance/dist_test.go
@@ -25,7 +25,7 @@ import (
 	"os"
 	"testing"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
-hash: 2f20f18dc05bba2ae1b835bd4c5c5fa5ca0d3f3c0c33480b24a02c1ec40ba8b3
-updated: 2017-05-30T13:19:52.826558958-07:00
+hash: 99fbfa8922daa2961cd392fe0fc2b6bd9dc2d9290c7f6d802940eabece0b4648
+updated: 2017-06-14T21:48:57.887822262-07:00
 imports:
 - name: github.com/apache/thrift
-  version: 2d65c2365f19f637bc732222e71d78727bf0b709
+  version: b8ee72de5bf9318d50846852082325d0f932682b
   subpackages:
   - lib/go/thrift
 - name: github.com/aws/aws-sdk-go
-  version: baba9e786eae5ba978f2007f8e718557b29157c8
+  version: 8a972b4459c2f2582b06f3e2d74448987cc6e19f
   subpackages:
   - aws
   - aws/awserr
@@ -24,6 +24,7 @@ imports:
   - aws/request
   - aws/session
   - aws/signer/v4
+  - internal/shareddefaults
   - private/protocol
   - private/protocol/query
   - private/protocol/query/queryutil
@@ -37,9 +38,9 @@ imports:
 - name: github.com/benbjohnson/clock
   version: 7dc76406b6d3c05b5f71a86293cbcf3c4ea03b19
 - name: github.com/bsm/sarama-cluster
-  version: 2ae74ad075d4f088751b8c074f7e88c1020d7687
+  version: 5efe630369ab4ed5cc4cedeadd61b4d1b2523169
 - name: github.com/cactus/go-statsd-client
-  version: d8eabe07bc70ff9ba6a56836cde99d1ea3d005f7
+  version: 1139cdac1a56e404b5382e3a3503a2c587d2c0c3
   subpackages:
   - statsd
 - name: github.com/cockroachdb/c-jemalloc
@@ -51,15 +52,15 @@ imports:
 - name: github.com/cockroachdb/c-snappy
   version: c0cd3c9ce92f195001595e1fbbe66f045daad34f
 - name: github.com/codegangsta/cli
-  version: 8ba6f23b6e36d03666a14bd9421f5e3efcb59aca
+  version: cf33a9befefdd6c6ea1a236ab6d546e797a62cbf
 - name: github.com/davecgh/go-spew
   version: 346938d642f2ec3594ed81d874461961cd0faa76
   subpackages:
   - spew
 - name: github.com/dgryski/go-farm
-  version: 83948bc0eb076b6b72c28abe5282fa8cf5240db6
+  version: e2d0fe22b456fa0a35cd883ba355ecfcf1881490
 - name: github.com/eapache/go-resiliency
-  version: b86b1ec0dd4209a588dc1285cdd471e73525c0b3
+  version: b1fe83b5b03f624450823b751b662259ffc6af70
   subpackages:
   - breaker
 - name: github.com/eapache/go-xerial-snappy
@@ -67,9 +68,9 @@ imports:
 - name: github.com/eapache/queue
   version: 44cc805cf13205b55f69e14bcb69867d1ae92f98
 - name: github.com/go-ini/ini
-  version: e7fea39b01aea8d5671f6858f0532f56e8bff3a5
+  version: d3de07a94d22b4a0972deb4b96d790c2c0ce8333
 - name: github.com/gocql/gocql
-  version: 66628b367ca6d68ca135881f4d947bdf20d915b9
+  version: 3e8b36f5e9e52cdeb265f385808c504a53db55fc
   subpackages:
   - internal/lru
   - internal/murmur
@@ -79,22 +80,20 @@ imports:
 - name: github.com/google/uuid
   version: 064e2069ce9c359c118179501254f67d7d37ba24
 - name: github.com/gorilla/websocket
-  version: 3ab3a8b8831546bd18fd182c20687ca853b2bb13
+  version: a91eba7f97777409bc2c443f5534d41dd20c5720
 - name: github.com/hailocab/go-hostpool
   version: e80d13ce29ede4452c43dea11e79b9bc8a15b478
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
-- name: github.com/klauspost/crc32
-  version: 1bab8b35b6bb565f92cbc97939610af9369f942a
 - name: github.com/opentracing/opentracing-go
-  version: eaa2524c1b95618f98127d9c4149d28b852397b4
+  version: eaaf4e1eeb7a5373b38e70901270c83577dc6fb9
   subpackages:
   - ext
   - log
 - name: github.com/pborman/uuid
-  version: 1b00554d822231195d1babd97ff4a781231955c9
+  version: e790cca94e6cc75c7064b1332e63811d4aae1a53
 - name: github.com/pierrec/lz4
-  version: f5b77fd73d83122495309c0f459b810f83cc291f
+  version: 5a3d2245f97fc249850e7802e3c01fad02a1c316
 - name: github.com/pierrec/xxHash
   version: 5a004441f897722c627870a981d02b29924215fa
   subpackages:
@@ -106,14 +105,14 @@ imports:
 - name: github.com/rcrowley/go-metrics
   version: 1f30fe9094a513ce4c700b9a54458bbb0c96996c
 - name: github.com/Shopify/sarama
-  version: 0fb560e5f7fbcaee2f75e3c34174320709f69944
+  version: c01858abb625b73a3af51d0798e4ad42c8147093
   repo: http://github.com/Shopify/sarama
-- name: github.com/Sirupsen/logrus
-  version: 10f801ebc38b33738c9d17d50860f484a0988ff5
+- name: github.com/sirupsen/logrus
+  version: 85b1699d505667d13f8ac4478c1debbf85d6c5de
 - name: github.com/stretchr/objx
   version: 1a9d0bb9f541897e62256577b352fdbc1fb4fd94
 - name: github.com/stretchr/testify
-  version: 4d4bfba8f1d1027c4fdbe371823030df51419987
+  version: f6abca593680b2315d2075e0f5e2a9751e3f431a
   subpackages:
   - assert
   - mock
@@ -122,11 +121,11 @@ imports:
 - name: github.com/tecbot/gorocksdb
   version: 17991d3138a879b166adebf86f7c84da3c1517a7
 - name: github.com/uber-common/bark
-  version: 8841a0f8e7ca869284ccb29c08a14cf3f4310f46
+  version: a2ce12437502dbd1511a6ab87745ed01ba138dbb
 - name: github.com/uber-go/atomic
-  version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
+  version: 0506d69f5564c56e25797bf7183c28921d4c6360
 - name: github.com/uber/cherami-client-go
-  version: 7a6f6147da201fd682cd8f22dc07e9289c939e5c
+  version: af231855dc60abc8332dd3ac0279e9baa4cc0524
   subpackages:
   - client/cherami
   - common
@@ -145,7 +144,7 @@ imports:
   - .generated/go/shared
   - .generated/go/store
 - name: github.com/uber/ringpop-go
-  version: 8b1085ca9b31007b996e411f2cb88256b2fedd12
+  version: 8b703dfdab59e2a17e5479e62f8d456286ba50c7
   subpackages:
   - discovery
   - discovery/statichosts
@@ -170,17 +169,17 @@ imports:
   - trand
   - typed
 - name: golang.org/x/net
-  version: d212a1ef2de2f5d441c327b8f26cf3ea3ea9f265
+  version: ddf80d0970594e2e4cccf5a98861cad3d9eaa4cd
   subpackages:
   - context
 - name: golang.org/x/sys
-  version: f3918c30c5c2cb527c0b071a27c35120a6c0719a
+  version: 0b25a408a50076fbbcae6b7ac0ea5fbb0b085e79
   subpackages:
   - unix
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/validator.v2
-  version: 0a9835d809fb647a62611d30cb792e0b5dd65b11
+  version: 07ffaad256c8e957050ad83d6472eb97d785013d
 - name: gopkg.in/yaml.v2
   version: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,6 @@
 package: github.com/uber/cherami-server
 import:
-- package: github.com/Sirupsen/logrus
+- package: github.com/sirupsen/logrus
 - package: github.com/apache/thrift
   subpackages:
   - lib/go/thrift
@@ -30,8 +30,8 @@ import:
 - package: github.com/cockroachdb/c-rocksdb
   version: 09d6d520b61160d194c06768ed85415cd8abee57
 - package: github.com/uber-common/bark
+  version: fix-logrus-8841a0f
 - package: github.com/uber/cherami-client-go
-  version: v1.21.0-rc1
   subpackages:
   - client/cherami
   - common
@@ -39,7 +39,6 @@ import:
   - common/websocket
   - stream
 - package: github.com/uber/cherami-thrift
-  version: v1.21.0-rc1
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami
@@ -49,7 +48,7 @@ import:
   - .generated/go/shared
   - .generated/go/store
 - package: github.com/uber/ringpop-go
-  version: = 0.7.0
+  version: v0.7.0.fix.sirupsen
   subpackages:
   - discovery
   - discovery/statichosts

--- a/services/controllerhost/dfdd_test.go
+++ b/services/controllerhost/dfdd_test.go
@@ -25,8 +25,8 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-common/bark"

--- a/services/controllerhost/event_pipeline_test.go
+++ b/services/controllerhost/event_pipeline_test.go
@@ -31,8 +31,8 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-common/bark"

--- a/services/controllerhost/extentmon_test.go
+++ b/services/controllerhost/extentmon_test.go
@@ -28,8 +28,8 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-common/bark"

--- a/services/controllerhost/loadreport_test.go
+++ b/services/controllerhost/loadreport_test.go
@@ -26,8 +26,8 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-common/bark"

--- a/services/frontendhost/frontend_test.go
+++ b/services/frontendhost/frontend_test.go
@@ -39,8 +39,8 @@ import (
 	"github.com/uber/cherami-thrift/.generated/go/controller"
 	"github.com/uber/cherami-thrift/.generated/go/shared"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/services/outputhost/messagecache_test.go
+++ b/services/outputhost/messagecache_test.go
@@ -26,8 +26,8 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-common/bark"

--- a/services/storehost/base_test.go
+++ b/services/storehost/base_test.go
@@ -43,8 +43,8 @@ import (
 	"github.com/uber/cherami-thrift/.generated/go/metadata"
 	"github.com/uber/cherami-thrift/.generated/go/store"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/services/storehost/storehost_test.go
+++ b/services/storehost/storehost_test.go
@@ -32,8 +32,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 	"github.com/uber/cherami-server/common"
 	"github.com/uber/cherami-thrift/.generated/go/cherami"
 	"github.com/uber/cherami-thrift/.generated/go/store"

--- a/storage/manyrocks/manyrocks.go
+++ b/storage/manyrocks/manyrocks.go
@@ -36,7 +36,7 @@ import (
 	"github.com/uber/cherami-server/common"
 	s "github.com/uber/cherami-server/storage"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 const rocksdbNotExistError = "does not exist (create_if_missing is false)"

--- a/storage/manyrocks/manyrocks_test.go
+++ b/storage/manyrocks/manyrocks_test.go
@@ -26,8 +26,8 @@ import (
 	"os"
 	"testing"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-common/bark"
 	"github.com/uber/cherami-server/storage"

--- a/test/integration/base.go
+++ b/test/integration/base.go
@@ -29,8 +29,8 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber/cherami-server/clients/metadata"

--- a/test/integration/failure_test.go
+++ b/test/integration/failure_test.go
@@ -28,8 +28,8 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	_ "github.com/apache/thrift/lib/go/thrift"
+	log "github.com/sirupsen/logrus"
 
 	"testing"
 

--- a/test/mocks/controllerhost/mockcontrollerhost.go
+++ b/test/mocks/controllerhost/mockcontrollerhost.go
@@ -102,7 +102,7 @@ func (m *MockControllerHost) CreateRemoteZoneExtent(ctx thrift.Context, createRe
 }
 
 // CreateRemoteZoneExtent is the mock for corresponding ControllerHost API
-func (m *MockControllerHost) CreateRemoteZoneConsumerGroupExtent(ctx thrift.Context, createRequest *shared.CreateConsumerGroupExtentRequest) (error) {
+func (m *MockControllerHost) CreateRemoteZoneConsumerGroupExtent(ctx thrift.Context, createRequest *shared.CreateConsumerGroupExtentRequest) error {
 	args := m.Called(ctx, createRequest)
 	return args.Error(0)
 }

--- a/test/storagetest/base_test.go
+++ b/test/storagetest/base_test.go
@@ -26,8 +26,8 @@ import (
 	"sort"
 	"testing"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber/cherami-server/storage"
 )

--- a/tools/cassandra/backup.go
+++ b/tools/cassandra/backup.go
@@ -32,8 +32,8 @@ import (
 	"regexp"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/uber/cherami-server/tools/awscloud"
 )

--- a/tools/cassandra/backupTool.go
+++ b/tools/cassandra/backupTool.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/uber/cherami-server/common/configure"
 )

--- a/tools/cassandra/cron.go
+++ b/tools/cassandra/cron.go
@@ -25,7 +25,7 @@ import (
 	"os"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/uber/cherami-server/common/configure"
 )

--- a/tools/cassandra/restore.go
+++ b/tools/cassandra/restore.go
@@ -28,7 +28,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/uber/cherami-server/tools/awscloud"
 )

--- a/tools/cassandra/updatetask.go
+++ b/tools/cassandra/updatetask.go
@@ -29,7 +29,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type (

--- a/tools/store/consistency.go
+++ b/tools/store/consistency.go
@@ -29,8 +29,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
+	log "github.com/sirupsen/logrus"
 	"github.com/tecbot/gorocksdb"
 	"github.com/uber-common/bark"
 	"github.com/uber/cherami-server/common"


### PR DESCRIPTION
Everything is straightforward except ringpop.

We locked ringpop at v0.7.0 as there's some breaking change with later releases(not breaking interface, but functionality wise breaking, as there're some test failure if we bring in latest ringpop). 
Because of that, we also locked github.com/uber-common/bark to commit 8841a0f8e7ca869284ccb29c08a14cf3f4310f46 since ringpop v0.7.0 is not compatible with the latest bark interface.

As a temporary solution(without introducing the latest ringpop, which might cause functionality issue), I created hotfix branches on top of the version we locked down: fix-logrus-8841a0f and v0.7.0.fix.sirupsen for these two branches.

Opened https://github.com/uber/cherami-server/issues/225 to track the progress to upgrade to latest ringpop and bark.

