### PR TITLE
(cli) fix 'show destination' -showcg flag naming 

### DIFF
--- a/cmd/tools/cli/main.go
+++ b/cmd/tools/cli/main.go
@@ -195,7 +195,7 @@ func main() {
 					Usage:   "show destination <name>",
 					Flags: []cli.Flag{
 						cli.BoolFlag{
-							Name:  "show_cg, cg",
+							Name:  "showcg, cg",
 							Usage: "show consumer groups for the destination",
 						},
 					},


### PR DESCRIPTION
another minor regression of the earlier change .. where i had changed this to "show_cg"; but the code looks for "showcg" flag .. so reverting the name change. 