### PR TITLE
Metadata client: increase Cassandra read consistency to 2

### DIFF
--- a/clients/metadata/metadata_cassandra.go
+++ b/clients/metadata/metadata_cassandra.go
@@ -194,7 +194,7 @@ func NewCassandraMetadataService(cfg configure.CommonMetadataConfig) (*Cassandra
 	cluster.ProtoVersion = cassandraProtoVersion
 
 	cms := new(CassandraMetadataService)
-	cms.lowConsLevel = gocql.One
+	cms.lowConsLevel = gocql.Two
 	cms.midConsLevel = gocql.Two
 	cms.highConsLevel = gocql.ParseConsistency(cfg.GetConsistency())
 	cms.clusterName = cfg.GetClusterName()


### PR DESCRIPTION
Increase the Cassandra read consistency used within our metadata client to "2" .. in order to support adding a new host.