### PR TITLE
Extract cliHelper from SetCommonCommands and add authEnabled option

### DIFF
--- a/cmd/tools/admin/main.go
+++ b/cmd/tools/admin/main.go
@@ -24,6 +24,7 @@ import (
 	"os"
 
 	"github.com/codegangsta/cli"
+	"github.com/uber/cherami-client-go/client/cherami"
 	lib "github.com/uber/cherami-server/cmd/tools/common"
 )
 
@@ -37,10 +38,15 @@ func main() {
 	app.Usage = "A command-line tool for cherami developer, including debugging tool"
 	app.Version = "1.2.1"
 
-	lib.SetCommonFlags(&app.Flags)
+	lib.SetCommonFlags(&app.Flags, false)
 	lib.SetAdminFlags(&app.Flags)
 
-	lib.SetCommonCommands(&app.Commands, adminToolService)
+	cliHelper := lib.GetCommonCliHelper()
+
+	lib.SetCommonCommands(&app.Commands, cliHelper, adminToolService, false,
+		func(c *cli.Context) cherami.AuthProvider {
+			return nil
+		})
 	lib.SetAdminCommands(&app.Commands)
 
 	app.Run(os.Args)

--- a/cmd/tools/cli/main.go
+++ b/cmd/tools/cli/main.go
@@ -24,6 +24,7 @@ import (
 	"os"
 
 	"github.com/codegangsta/cli"
+	"github.com/uber/cherami-client-go/client/cherami"
 	lib "github.com/uber/cherami-server/cmd/tools/common"
 )
 
@@ -37,9 +38,14 @@ func main() {
 	app.Usage = "A command-line tool for cherami users"
 	app.Version = "1.1.10"
 
-	lib.SetCommonFlags(&app.Flags)
+	lib.SetCommonFlags(&app.Flags, false)
 
-	lib.SetCommonCommands(&app.Commands, serviceName)
+	cliHelper := lib.GetCommonCliHelper()
+
+	lib.SetCommonCommands(&app.Commands, cliHelper, serviceName, false,
+		func(c *cli.Context) cherami.AuthProvider {
+			return nil
+		})
 
 	app.Run(os.Args)
 }

--- a/cmd/tools/common/lib.go
+++ b/cmd/tools/common/lib.go
@@ -37,6 +37,7 @@ const (
 	strDelaySeconds               = `Delay, in seconds, to defer all messages by`
 )
 
+// GetCommonCliHelper returns the common cli helper for both cli and admin commands
 func GetCommonCliHelper() common.CliHelper {
 	cliHelper := common.NewCliHelper()
 	// SetCanonicalZones. For now just "zone1", "zone2", "z1"

--- a/cmd/tools/common/lib.go
+++ b/cmd/tools/common/lib.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/codegangsta/cli"
+	"github.com/uber/cherami-client-go/client/cherami"
 	"github.com/uber/cherami-server/common"
 	"github.com/uber/cherami-server/tools/admin"
 	toolscommon "github.com/uber/cherami-server/tools/common"
@@ -36,8 +37,24 @@ const (
 	strDelaySeconds               = `Delay, in seconds, to defer all messages by`
 )
 
+func GetCommonCliHelper() common.CliHelper {
+	cliHelper := common.NewCliHelper()
+	// SetCanonicalZones. For now just "zone1", "zone2", "z1"
+	// and "z2" are valid and they map to "zone1" and "zone2"
+	// canonical zones.
+	// We can use this API to set any valid zones
+	cliHelper.SetCanonicalZones(map[string]string{
+		"zone1": "zone1",
+		"zone2": "zone2",
+		"z1":    "zone1",
+		"z2":    "zone2",
+	})
+
+	return cliHelper
+}
+
 // SetCommonFlags sets the common flags for both cli and admin commands
-func SetCommonFlags(flags *[]cli.Flag) {
+func SetCommonFlags(flags *[]cli.Flag, includeAuth bool) {
 	*flags = append(*flags, []cli.Flag{
 		cli.BoolTFlag{
 			Name:  "hyperbahn",
@@ -66,6 +83,26 @@ func SetCommonFlags(flags *[]cli.Flag) {
 			EnvVar: "CHERAMI_FRONTEND_HOSTPORT",
 		},
 	}...)
+
+	if includeAuth {
+		*flags = append(*flags, []cli.Flag{
+			cli.StringFlag{
+				Name:  "user_identity, user",
+				Value: "",
+				Usage: "The user identity to issue the action. Could be a user name or service name. Use empty value for current user.",
+			},
+			cli.StringFlag{
+				Name:  "private_key, pr",
+				Value: "",
+				Usage: "The private key file path for the user identity specified by -user_identity argument. Use empty value for current user.",
+			},
+			cli.StringFlag{
+				Name:  "disable_auth, da",
+				Value: "false",
+				Usage: "Disable authentication in the client.",
+			},
+		}...)
+	}
 }
 
 // SetAdminFlags sets the admin flags
@@ -77,19 +114,14 @@ func SetAdminFlags(flags *[]cli.Flag) {
 }
 
 // SetCommonCommands sets the common commands for both cli and admin commands
-func SetCommonCommands(commands *[]cli.Command, serviceName string) {
-	cliHelper := common.NewCliHelper()
-	// SetCanonicalZones. For now just "zone1", "zone2", "z1"
-	// and "z2" are valid and they map to "zone1" and "zone2"
-	// canonical zones.
-	// We can use this API to set any valid zones
-	cliHelper.SetCanonicalZones(map[string]string{
-		"zone1": "zone1",
-		"zone2": "zone2",
-		"z1":    "zone1",
-		"z2":    "zone2",
-	})
-
+// getAuthProvider is meaningful if and only if authEnabled is true
+func SetCommonCommands(
+	commands *[]cli.Command,
+	cliHelper common.CliHelper,
+	serviceName string,
+	authEnabled bool,
+	getAuthProvider func(*cli.Context) cherami.AuthProvider,
+) {
 	*commands = append(*commands, []cli.Command{
 		{
 			Name:    "create",
@@ -140,7 +172,12 @@ func SetCommonCommands(commands *[]cli.Command, serviceName string) {
 						},
 					},
 					Action: func(c *cli.Context) {
-						toolscommon.CreateDestination(c, cliHelper, serviceName)
+						if authEnabled {
+							authProvider := getAuthProvider(c)
+							toolscommon.CreateDestinationSecure(c, cliHelper, serviceName, authProvider)
+						} else {
+							toolscommon.CreateDestination(c, cliHelper, serviceName)
+						}
 					},
 				},
 				{
@@ -184,7 +221,12 @@ func SetCommonCommands(commands *[]cli.Command, serviceName string) {
 						},
 					},
 					Action: func(c *cli.Context) {
-						toolscommon.CreateConsumerGroup(c, cliHelper, serviceName)
+						if authEnabled {
+							authProvider := getAuthProvider(c)
+							toolscommon.CreateConsumerGroupSecure(c, cliHelper, serviceName, authProvider)
+						} else {
+							toolscommon.CreateConsumerGroup(c, cliHelper, serviceName)
+						}
 					},
 				},
 			},
@@ -278,7 +320,12 @@ func SetCommonCommands(commands *[]cli.Command, serviceName string) {
 						},
 					},
 					Action: func(c *cli.Context) {
-						toolscommon.UpdateDestination(c, cliHelper, serviceName)
+						if authEnabled {
+							authProvider := getAuthProvider(c)
+							toolscommon.UpdateDestinationSecure(c, cliHelper, serviceName, authProvider)
+						} else {
+							toolscommon.UpdateDestination(c, cliHelper, serviceName)
+						}
 					},
 				},
 				{
@@ -320,7 +367,12 @@ func SetCommonCommands(commands *[]cli.Command, serviceName string) {
 						},
 					},
 					Action: func(c *cli.Context) {
-						toolscommon.UpdateConsumerGroup(c, cliHelper, serviceName)
+						if authEnabled {
+							authProvider := getAuthProvider(c)
+							toolscommon.UpdateConsumerGroupSecure(c, cliHelper, serviceName, authProvider)
+						} else {
+							toolscommon.UpdateConsumerGroup(c, cliHelper, serviceName)
+						}
 					},
 				},
 			},
@@ -335,7 +387,12 @@ func SetCommonCommands(commands *[]cli.Command, serviceName string) {
 					Aliases: []string{"d", "dst", "dest"},
 					Usage:   "delete destination <name>",
 					Action: func(c *cli.Context) {
-						toolscommon.DeleteDestination(c, serviceName)
+						if authEnabled {
+							authProvider := getAuthProvider(c)
+							toolscommon.DeleteDestinationSecure(c, serviceName, authProvider)
+						} else {
+							toolscommon.DeleteDestination(c, serviceName)
+						}
 						println("deleted destination: ", c.Args().First())
 					},
 				},
@@ -344,7 +401,12 @@ func SetCommonCommands(commands *[]cli.Command, serviceName string) {
 					Aliases: []string{"c", "cg"},
 					Usage:   "delete consumergroup [<destination_path>|<DLQ_UUID>] <consumer_group_name>",
 					Action: func(c *cli.Context) {
-						toolscommon.DeleteConsumerGroup(c, serviceName)
+						if authEnabled {
+							authProvider := getAuthProvider(c)
+							toolscommon.DeleteConsumerGroupSecure(c, serviceName, authProvider)
+						} else {
+							toolscommon.DeleteConsumerGroup(c, serviceName)
+						}
 						println("deleted consumergroup: ", c.Args()[0], c.Args()[1])
 					},
 				},

--- a/tools/common/lib.go
+++ b/tools/common/lib.go
@@ -905,7 +905,7 @@ func printDest(dest *shared.DestinationDescription) {
 	fmt.Fprintln(os.Stdout, string(outputStr))
 }
 
-// ReadDestinationr return the detail for dest, and also consumer group for this dest
+// ReadDestination return the detail for dest, and also consumer group for this dest
 func ReadDestination(c *cli.Context, serviceName string) {
 	mClient := GetMClient(c, serviceName)
 


### PR DESCRIPTION
This change is to make functions more abstract, e.g. SetCommonCommands, which can be reused in the internal repo.