### PR TITLE
Replicator: don't keep the conn object forever

### DIFF
--- a/services/replicator/outconn.go
+++ b/services/replicator/outconn.go
@@ -25,6 +25,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/pborman/uuid"
 	"github.com/uber-common/bark"
 	"github.com/uber/cherami-server/common"
 	"github.com/uber/cherami-server/common/metrics"
@@ -37,6 +38,7 @@ type (
 	outConnection struct {
 		startTime int64
 		extUUID   string
+		connUUID  string
 		stream    storeStream.BStoreOpenReadStreamOutCall
 		msgsCh    chan *store.ReadMessageContent
 
@@ -73,6 +75,7 @@ func newOutConnection(extUUID string, destPath string, stream storeStream.BStore
 	conn := &outConnection{
 		startTime:           time.Now().UnixNano(),
 		extUUID:             extUUID,
+		connUUID:            uuid.New(),
 		stream:              stream,
 		msgsCh:              make(chan *store.ReadMessageContent, msgBufferSize),
 		logger:              localLogger,

--- a/services/replicator/replicator.go
+++ b/services/replicator/replicator.go
@@ -53,16 +53,18 @@ type (
 		logger   bark.Logger
 		m3Client metrics.Client
 		common.SCommon
-		hostIDHeartbeater         common.HostIDHeartbeater
-		AppConfig                 configure.CommonAppConfig
-		uconfigClient             dconfig.Client
-		metaClient                metadata.TChanMetadataService
-		allZones                  map[string][]string
-		localZone                 string
-		authoritativeZone         string
-		tenancy                   string
-		defaultAuthoritativeZone  string
-		replicatorclientFactory   ClientFactory
+		hostIDHeartbeater        common.HostIDHeartbeater
+		AppConfig                configure.CommonAppConfig
+		uconfigClient            dconfig.Client
+		metaClient               metadata.TChanMetadataService
+		allZones                 map[string][]string
+		localZone                string
+		authoritativeZone        string
+		tenancy                  string
+		defaultAuthoritativeZone string
+		replicatorclientFactory  ClientFactory
+
+		// for debug via admin API only
 		remoteReplicatorConn      map[string]*outConnection
 		remoteReplicatorConnMutex sync.RWMutex
 		storehostConn             map[string]*outConnection

--- a/services/replicator/replicator.go
+++ b/services/replicator/replicator.go
@@ -253,6 +253,7 @@ func (r *Replicator) OpenReplicationReadStreamHandler(w http.ResponseWriter, req
 	outConn := newOutConnection(extUUID, destDesc.GetPath(), outStream, r.logger, r.m3Client, metrics.OpenReplicationReadScope)
 	outConn.open()
 	r.addStoreHostConn(outConn)
+	defer r.removeStoreHostConn(outConn)
 
 	inConn := newInConnection(extUUID, destDesc.GetPath(), inStream, outConn.msgsCh, r.logger, r.m3Client, metrics.OpenReplicationReadScope, metrics.OpenReplicationReadPerDestScope)
 	inConn.open()
@@ -260,7 +261,7 @@ func (r *Replicator) OpenReplicationReadStreamHandler(w http.ResponseWriter, req
 	go r.manageInOutConn(inConn, outConn)
 	<-inConn.closeChannel
 	<-outConn.closeChannel
-	r.removeStoreHostConn(outConn)
+
 	return
 }
 
@@ -333,6 +334,7 @@ func (r *Replicator) OpenReplicationRemoteReadStreamHandler(w http.ResponseWrite
 	outConn := newOutConnection(extUUID, destDesc.GetPath(), outStream, r.logger, r.m3Client, metrics.OpenReplicationRemoteReadScope)
 	outConn.open()
 	r.addRemoteReplicatorConn(outConn)
+	defer r.removeRemoteReplicatorConn(outConn)
 
 	inConn := newInConnection(extUUID, destDesc.GetPath(), inStream, outConn.msgsCh, r.logger, r.m3Client, metrics.OpenReplicationRemoteReadScope, metrics.OpenReplicationRemoteReadPerDestScope)
 	inConn.open()
@@ -340,7 +342,7 @@ func (r *Replicator) OpenReplicationRemoteReadStreamHandler(w http.ResponseWrite
 	go r.manageInOutConn(inConn, outConn)
 	<-inConn.closeChannel
 	<-outConn.closeChannel
-	r.removeRemoteReplicatorConn(outConn)
+
 	return
 }
 

--- a/services/replicator/replicator.go
+++ b/services/replicator/replicator.go
@@ -250,7 +250,7 @@ func (r *Replicator) OpenReplicationReadStreamHandler(w http.ResponseWriter, req
 
 	outConn := newOutConnection(extUUID, destDesc.GetPath(), outStream, r.logger, r.m3Client, metrics.OpenReplicationReadScope)
 	outConn.open()
-	r.addStoreHostConn(extUUID, outConn)
+	r.addStoreHostConn(outConn)
 
 	inConn := newInConnection(extUUID, destDesc.GetPath(), inStream, outConn.msgsCh, r.logger, r.m3Client, metrics.OpenReplicationReadScope, metrics.OpenReplicationReadPerDestScope)
 	inConn.open()
@@ -258,6 +258,7 @@ func (r *Replicator) OpenReplicationReadStreamHandler(w http.ResponseWriter, req
 	go r.manageInOutConn(inConn, outConn)
 	<-inConn.closeChannel
 	<-outConn.closeChannel
+	r.removeStoreHostConn(outConn)
 	return
 }
 
@@ -329,7 +330,7 @@ func (r *Replicator) OpenReplicationRemoteReadStreamHandler(w http.ResponseWrite
 
 	outConn := newOutConnection(extUUID, destDesc.GetPath(), outStream, r.logger, r.m3Client, metrics.OpenReplicationRemoteReadScope)
 	outConn.open()
-	r.addRemoteReplicatorConn(extUUID, outConn)
+	r.addRemoteReplicatorConn(outConn)
 
 	inConn := newInConnection(extUUID, destDesc.GetPath(), inStream, outConn.msgsCh, r.logger, r.m3Client, metrics.OpenReplicationRemoteReadScope, metrics.OpenReplicationRemoteReadPerDestScope)
 	inConn.open()
@@ -337,6 +338,7 @@ func (r *Replicator) OpenReplicationRemoteReadStreamHandler(w http.ResponseWrite
 	go r.manageInOutConn(inConn, outConn)
 	<-inConn.closeChannel
 	<-outConn.closeChannel
+	r.removeRemoteReplicatorConn(outConn)
 	return
 }
 
@@ -1306,24 +1308,28 @@ func (r *Replicator) createExtentRemoteCall(zone string, logger bark.Logger, cre
 	return nil
 }
 
-func (r *Replicator) addRemoteReplicatorConn(extUUID string, conn *outConnection) {
+func (r *Replicator) addRemoteReplicatorConn(conn *outConnection) {
 	r.remoteReplicatorConnMutex.Lock()
 	defer r.remoteReplicatorConnMutex.Unlock()
-	if existingConn, ok := r.remoteReplicatorConn[extUUID]; ok {
-		existingConn.close()
-		delete(r.remoteReplicatorConn, extUUID)
-	}
-	r.remoteReplicatorConn[extUUID] = conn
+	r.remoteReplicatorConn[conn.connUUID] = conn
 }
 
-func (r *Replicator) addStoreHostConn(extUUID string, conn *outConnection) {
+func (r *Replicator) removeRemoteReplicatorConn(conn *outConnection) {
+	r.remoteReplicatorConnMutex.Lock()
+	defer r.remoteReplicatorConnMutex.Unlock()
+	delete(r.remoteReplicatorConn, conn.connUUID)
+}
+
+func (r *Replicator) addStoreHostConn(conn *outConnection) {
 	r.storehostConnMutex.Lock()
 	defer r.storehostConnMutex.Unlock()
-	if existingConn, ok := r.storehostConn[extUUID]; ok {
-		existingConn.close()
-		delete(r.storehostConn, extUUID)
-	}
-	r.storehostConn[extUUID] = conn
+	r.storehostConn[conn.connUUID] = conn
+}
+
+func (r *Replicator) removeStoreHostConn(conn *outConnection) {
+	r.storehostConnMutex.Lock()
+	defer r.storehostConnMutex.Unlock()
+	delete(r.storehostConn, conn.connUUID)
 }
 
 func (r *Replicator) createRemoteReplicationReadStream(extUUID string, destUUID string, request *common.OpenReplicationRemoteReadStreamRequest) (stream storeStream.BStoreOpenReadStreamOutCall, err error) {


### PR DESCRIPTION
remoteReplicatorConn(similar for storehostConn) is a map we use to do dedups against incoming requests. For example, if there's already a connection for ext1, then we receive a new request for the same extent, we close the existing connection for ext1, remove the connection from the map, then creates a new connection and store the new connection in the map.
The problem is if there's no duplicate connection(as in the common case), we never delete the connection from the map, which causes memory leak

In fact the dedup in replicator is not needed, as we're already doing dedup in store host side. But the map is still useful for the admin API, so I repurposed the map to only be used by the admin API, and the connection will be deleted from the map at the end of the API call(as soon as the connection is closed)