### PR TITLE
Add cassandra port support

### DIFF
--- a/clients/metadata/metadata_cassandra.go
+++ b/clients/metadata/metadata_cassandra.go
@@ -232,6 +232,7 @@ func NewCassandraMetadataService(cfg configure.CommonMetadataConfig, log bark.Lo
 	}
 
 	cluster := newCluster(cfg.GetCassandraHosts())
+	cluster.Port = cfg.GetPort()
 	cluster.Keyspace = cfg.GetKeyspace()
 	cluster.ProtoVersion = cassandraProtoVersion
 

--- a/common/configure/commonmetadataconfig.go
+++ b/common/configure/commonmetadataconfig.go
@@ -51,7 +51,7 @@ func (r *MetadataConfig) GetCassandraHosts() string {
 	return r.CassandraHosts
 }
 
-// GetPort() gets the cassandra host port
+// GetPort gets the cassandra host port
 func (r *MetadataConfig) GetPort() int {
 	return r.Port
 }

--- a/common/configure/commonmetadataconfig.go
+++ b/common/configure/commonmetadataconfig.go
@@ -30,6 +30,7 @@ type Authentication struct {
 // MetadataConfig holds the config info related to our metadata
 type MetadataConfig struct {
 	CassandraHosts string            `yaml:"CassandraHosts"`
+	Port           int               `yaml:"Port"`
 	Keyspace       string            `yaml:"Keyspace"`
 	Authentication Authentication    `yaml:"Authentication"`
 	Consistency    string            `yaml:"Consistency"`
@@ -48,6 +49,11 @@ func NewCommonMetadataConfig() *MetadataConfig {
 // GetCassandraHosts returns the cassandra seed hosts for our cluster
 func (r *MetadataConfig) GetCassandraHosts() string {
 	return r.CassandraHosts
+}
+
+// GetPort() gets the cassandra host port
+func (r *MetadataConfig) GetPort() int {
+	return r.Port
 }
 
 // GetKeyspace returns the keyspace to be used for cherami cluster

--- a/common/configure/interfaces.go
+++ b/common/configure/interfaces.go
@@ -145,6 +145,8 @@ type (
 	CommonMetadataConfig interface {
 		// GetCassandraHosts gets the cassandra seed hosts
 		GetCassandraHosts() string
+		// GetPort() gets the cassandra host port
+		GetPort() int
 		// GetKeyspace returns the keyspace for our cassandra cluster
 		GetKeyspace() string
 		// GetAuthentication returns the authentication info for our cassandra cluster

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -76,6 +76,7 @@ ServiceConfig:
 # MetadataConfig specifies location of the Cassandra and ketspace
 MetadataConfig:
   CassandraHosts: ""
+  Ports: 9042
   Keyspace: "cherami"
   Consistency: "one"
   ClusterName: "base"

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -76,7 +76,7 @@ ServiceConfig:
 # MetadataConfig specifies location of the Cassandra and ketspace
 MetadataConfig:
   CassandraHosts: ""
-  Ports: 9042
+  Port: 9042
   Keyspace: "cherami"
   Consistency: "one"
   ClusterName: "base"

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -26,6 +26,7 @@ DefaultDestinationConfig:
 
 MetadataConfig:
   CassandraHosts: "127.0.0.1"
+  Ports: 9042
   Authentication:
     Enabled: false
     Username:

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -26,7 +26,7 @@ DefaultDestinationConfig:
 
 MetadataConfig:
   CassandraHosts: "127.0.0.1"
-  Ports: 9042
+  Port: 9042
   Authentication:
     Enabled: false
     Username:

--- a/test/integration/base.go
+++ b/test/integration/base.go
@@ -166,7 +166,7 @@ func (tb *testBase) setupSuiteImpl(t *testing.T) {
 	}
 
 	// create the keyspace first
-	err := metadata.CreateKeyspaceNoSession("127.0.0.1", tb.keyspace, 1, true, auth)
+	err := metadata.CreateKeyspaceNoSession("127.0.0.1", 9042, tb.keyspace, 1, true, auth)
 	tb.NoError(err)
 
 	tb.mClient, _ = metadata.NewCassandraMetadataService(&configure.MetadataConfig{

--- a/test/integration/base.go
+++ b/test/integration/base.go
@@ -171,6 +171,7 @@ func (tb *testBase) setupSuiteImpl(t *testing.T) {
 
 	tb.mClient, _ = metadata.NewCassandraMetadataService(&configure.MetadataConfig{
 		CassandraHosts: "127.0.0.1",
+		Port:           9042,
 		Keyspace:       tb.keyspace,
 		Consistency:    "One",
 		Authentication: auth,


### PR DESCRIPTION
The future production cassandra has a different port with default 9042.