### PR TITLE
Refactor the replication connections

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
-hash: b12fd38476eb4ee5e70317142d9f4b93947bb227b65effeab80625d3860a5970
-updated: 2017-08-10T16:40:49.314326452-07:00
+hash: 7d4b0931a902e44d045d9bc610a9c83702861579f0a4fdf3b6e567af2d219a2a
+updated: 2017-08-17T14:58:43.667751163-07:00
 imports:
 - name: github.com/apache/thrift
   version: b2a4d4ae21c789b689dd162deb819665567f481c
   subpackages:
   - lib/go/thrift
 - name: github.com/aws/aws-sdk-go
-  version: cf66c348f82c79de333bd788d4f782c4d623ebad
+  version: 2063d937ea693f6f5c8b213906785ff9e36ba0b6
   subpackages:
   - aws
   - aws/awserr
@@ -52,7 +52,7 @@ imports:
 - name: github.com/cockroachdb/c-snappy
   version: c0cd3c9ce92f195001595e1fbbe66f045daad34f
 - name: github.com/codegangsta/cli
-  version: b99aa811b4c1dd84cc6bccb8499c82c72098085a
+  version: f017f86fccc5a039a98f23311f34fdf78b014f78
 - name: github.com/davecgh/go-spew
   version: adab96458c51a58dc1783b3335dcce5461522e75
   subpackages:
@@ -68,9 +68,9 @@ imports:
 - name: github.com/eapache/queue
   version: 44cc805cf13205b55f69e14bcb69867d1ae92f98
 - name: github.com/go-ini/ini
-  version: 3d73f4b845efdf9989fffd4b4e562727744a34ba
+  version: c787282c39ac1fc618827141a1f762240def08a3
 - name: github.com/gocql/gocql
-  version: 77431609f517cb41ee9afdcdd373561c4d935316
+  version: b9337fa4c59ce1db20300290bd7a9a7063fb6784
   subpackages:
   - internal/lru
   - internal/murmur
@@ -80,7 +80,7 @@ imports:
 - name: github.com/google/uuid
   version: 064e2069ce9c359c118179501254f67d7d37ba24
 - name: github.com/gorilla/websocket
-  version: a91eba7f97777409bc2c443f5534d41dd20c5720
+  version: a69d9f6de432e2c6b296a947d8a5ee88f68522cf
 - name: github.com/hailocab/go-hostpool
   version: e80d13ce29ede4452c43dea11e79b9bc8a15b478
 - name: github.com/jmespath/go-jmespath
@@ -108,7 +108,7 @@ imports:
   version: c01858abb625b73a3af51d0798e4ad42c8147093
   repo: http://github.com/Shopify/sarama
 - name: github.com/sirupsen/logrus
-  version: 181d419aa9e2223811b824e8f0b4af96f9ba9302
+  version: 68806b4b77355d6c8577a2c8bbc6d547a5272491
 - name: github.com/stretchr/objx
   version: 1a9d0bb9f541897e62256577b352fdbc1fb4fd94
 - name: github.com/stretchr/testify
@@ -134,7 +134,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: 98e566b96cbe7142446508e5991a11bc394ab343
+  version: 2cb0e2eeb6570800a2dd86544909bf2693f50e7b
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami
@@ -156,7 +156,7 @@ imports:
   - swim
   - util
 - name: github.com/uber/tchannel-go
-  version: b99c1d7cecb0fdc882bed0098e7cae6ec7459059
+  version: a7ad9ecb640b5f10a0395b38d6319175172b3ab2
   subpackages:
   - hyperbahn
   - hyperbahn/gen-go/hyperbahn
@@ -184,14 +184,14 @@ imports:
   - ipv4
   - ipv6
 - name: golang.org/x/sys
-  version: e42485b6e20ae7d2304ec72e535b103ed350cc02
+  version: 9f7170bcd8e9f4d3691c06401119c46a769a1e03
   subpackages:
   - unix
   - windows
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/validator.v2
-  version: 07ffaad256c8e957050ad83d6472eb97d785013d
+  version: 460c83432a98c35224a6fe352acf8b23e067ad06
 - name: gopkg.in/yaml.v2
-  version: 25c4ec802a7d637f88d584ab26798e94ad14c13b
+  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
 testImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
-hash: 7d4b0931a902e44d045d9bc610a9c83702861579f0a4fdf3b6e567af2d219a2a
-updated: 2017-08-17T14:58:43.667751163-07:00
+hash: b12fd38476eb4ee5e70317142d9f4b93947bb227b65effeab80625d3860a5970
+updated: 2017-08-10T16:40:49.314326452-07:00
 imports:
 - name: github.com/apache/thrift
   version: b2a4d4ae21c789b689dd162deb819665567f481c
   subpackages:
   - lib/go/thrift
 - name: github.com/aws/aws-sdk-go
-  version: 2063d937ea693f6f5c8b213906785ff9e36ba0b6
+  version: cf66c348f82c79de333bd788d4f782c4d623ebad
   subpackages:
   - aws
   - aws/awserr
@@ -52,7 +52,7 @@ imports:
 - name: github.com/cockroachdb/c-snappy
   version: c0cd3c9ce92f195001595e1fbbe66f045daad34f
 - name: github.com/codegangsta/cli
-  version: f017f86fccc5a039a98f23311f34fdf78b014f78
+  version: b99aa811b4c1dd84cc6bccb8499c82c72098085a
 - name: github.com/davecgh/go-spew
   version: adab96458c51a58dc1783b3335dcce5461522e75
   subpackages:
@@ -68,9 +68,9 @@ imports:
 - name: github.com/eapache/queue
   version: 44cc805cf13205b55f69e14bcb69867d1ae92f98
 - name: github.com/go-ini/ini
-  version: c787282c39ac1fc618827141a1f762240def08a3
+  version: 3d73f4b845efdf9989fffd4b4e562727744a34ba
 - name: github.com/gocql/gocql
-  version: b9337fa4c59ce1db20300290bd7a9a7063fb6784
+  version: 77431609f517cb41ee9afdcdd373561c4d935316
   subpackages:
   - internal/lru
   - internal/murmur
@@ -80,7 +80,7 @@ imports:
 - name: github.com/google/uuid
   version: 064e2069ce9c359c118179501254f67d7d37ba24
 - name: github.com/gorilla/websocket
-  version: a69d9f6de432e2c6b296a947d8a5ee88f68522cf
+  version: a91eba7f97777409bc2c443f5534d41dd20c5720
 - name: github.com/hailocab/go-hostpool
   version: e80d13ce29ede4452c43dea11e79b9bc8a15b478
 - name: github.com/jmespath/go-jmespath
@@ -108,7 +108,7 @@ imports:
   version: c01858abb625b73a3af51d0798e4ad42c8147093
   repo: http://github.com/Shopify/sarama
 - name: github.com/sirupsen/logrus
-  version: 68806b4b77355d6c8577a2c8bbc6d547a5272491
+  version: 181d419aa9e2223811b824e8f0b4af96f9ba9302
 - name: github.com/stretchr/objx
   version: 1a9d0bb9f541897e62256577b352fdbc1fb4fd94
 - name: github.com/stretchr/testify
@@ -156,7 +156,7 @@ imports:
   - swim
   - util
 - name: github.com/uber/tchannel-go
-  version: a7ad9ecb640b5f10a0395b38d6319175172b3ab2
+  version: b99c1d7cecb0fdc882bed0098e7cae6ec7459059
   subpackages:
   - hyperbahn
   - hyperbahn/gen-go/hyperbahn
@@ -184,14 +184,14 @@ imports:
   - ipv4
   - ipv6
 - name: golang.org/x/sys
-  version: 9f7170bcd8e9f4d3691c06401119c46a769a1e03
+  version: e42485b6e20ae7d2304ec72e535b103ed350cc02
   subpackages:
   - unix
   - windows
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/validator.v2
-  version: 460c83432a98c35224a6fe352acf8b23e067ad06
+  version: 07ffaad256c8e957050ad83d6472eb97d785013d
 - name: gopkg.in/yaml.v2
-  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
+  version: 25c4ec802a7d637f88d584ab26798e94ad14c13b
 testImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -134,7 +134,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: 2cb0e2eeb6570800a2dd86544909bf2693f50e7b
+  version: 98e566b96cbe7142446508e5991a11bc394ab343
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/services/replicator/inconn.go
+++ b/services/replicator/inconn.go
@@ -150,7 +150,11 @@ func (conn *inConnection) writeMsgsStream() {
 			}
 		} else {
 			select {
-			case msg := <-conn.msgCh:
+			case msg, ok := <-conn.msgCh:
+				if !ok {
+					conn.logger.Info("msg channel closed")
+					return
+				}
 				if err := conn.stream.Write(msg); err != nil {
 					conn.logger.Error("write msg failed")
 					return

--- a/services/replicator/inconn.go
+++ b/services/replicator/inconn.go
@@ -44,8 +44,8 @@ type (
 		metricsScope        int
 		perDestMetricsScope int
 
-		creditsCh            chan int32    // channel to pass credits from readCreditsStream to writeMsgsStream
-		creditFlowExpiration time.Time     // credit expiration is used to close the stream if we don't receive any credit for some period of time
+		creditsCh            chan int32 // channel to pass credits from readCreditsStream to writeMsgsStream
+		creditFlowExpiration time.Time  // credit expiration is used to close the stream if we don't receive any credit for some period of time
 
 		wg sync.WaitGroup
 	}
@@ -86,7 +86,7 @@ func (conn *inConnection) open() {
 	conn.logger.Info("in connection opened")
 }
 
-func (conn *inConnection) Done() {
+func (conn *inConnection) WaitUntilDone() {
 	conn.wg.Wait()
 }
 

--- a/services/replicator/outconn.go
+++ b/services/replicator/outconn.go
@@ -49,7 +49,7 @@ type (
 		lastMsgReplicatedTime int64
 		totalMsgReplicated    int32
 
-		readMsgCountChannel chan int32    // channel to pass read msg count from readMsgStream to writeCreditsStream in order to issue more credits
+		readMsgCountChannel chan int32 // channel to pass read msg count from readMsgStream to writeCreditsStream in order to issue more credits
 
 		wg sync.WaitGroup
 	}
@@ -91,8 +91,8 @@ func (conn *outConnection) open() {
 	conn.logger.Info("out connection opened")
 }
 
-func (conn *outConnection) Done() {
-	conn.wg.Done()
+func (conn *outConnection) WaitUntilDone() {
+	conn.wg.Wait()
 }
 
 func (conn *outConnection) writeCreditsStream() {

--- a/services/replicator/replicator.go
+++ b/services/replicator/replicator.go
@@ -158,14 +158,13 @@ func (r *Replicator) Start(thriftService []thrift.TChanServer) {
 func (r *Replicator) Stop() {
 	r.hostIDHeartbeater.Stop()
 	for _, conn := range r.remoteReplicatorConn {
-		conn.close()
+		conn.shutdown()
 	}
 	for _, conn := range r.storehostConn {
-		conn.close()
+		conn.shutdown()
 	}
 	r.metadataReconciler.Stop()
 	r.SCommon.Stop()
-
 }
 
 // RegisterWSHandler is the implementation of WSService interface


### PR DESCRIPTION
**Problem to solve**
1. FD leak caused by client side not draining from the read stream. (related fixes: https://github.com/uber/cherami-server/pull/265, https://github.com/uber/cherami-server/pull/266)
2. Bug on shutdown path that is causing sealed message not made to store.

**Design philosophies**
read pump reads from stream, write pump writes to stream
read pump communicate with write pump using an internal channel. Read pump writes to the internal channel, and write pump reads from it
Graceful shutdown sequence:
 1. read pump gets a read error (remote shuts down the connection)
 2. read pump closes the internal channel, then exits
 3. write pump detects the internal channel is closed
 4. write pump calls stream.Done(), and exits

**Other changes**
Removed the error handling cases in OutConn.go since same error handling is also done in store. Now replicator serves as a proxy only.

