### PR TITLE
Slowdown redeliveries, add timeout metrics

### DIFF
--- a/cmd/tools/common/lib.go
+++ b/cmd/tools/common/lib.go
@@ -733,7 +733,7 @@ func SetAdminCommands(commands *[]cli.Command) {
 "cherami-storehost",      "adminStatus",                    if set to anything other than "enabled", will prevent placement of new extent on this store
 "cherami-storehost",      "minFreeDiskSpaceBytes",          integer, minimum required free disk space in bytes to place a new extent
 "cherami-outputhost",     "messagecachesize",               comma-separated list of "destination/CG_name=value" for message cache size
-"cherami-outputhost",     "redeliveryInterval",             comma-separated list of "destination/CG_name=value" for message redelivery interval
+"cherami-outputhost",     "redeliveryIntervalInMs",         the message redelivery interval in milliseconds
 			`,
 			Subcommands: []cli.Command{
 				{

--- a/cmd/tools/common/lib.go
+++ b/cmd/tools/common/lib.go
@@ -733,6 +733,7 @@ func SetAdminCommands(commands *[]cli.Command) {
 "cherami-storehost",      "adminStatus",                    if set to anything other than "enabled", will prevent placement of new extent on this store
 "cherami-storehost",      "minFreeDiskSpaceBytes",          integer, minimum required free disk space in bytes to place a new extent
 "cherami-outputhost",     "messagecachesize",               comma-separated list of "destination/CG_name=value" for message cache size
+"cherami-outputhost",     "redeliveryInterval",             comma-separated list of "destination/CG_name=value" for message redelivery interval
 			`,
 			Subcommands: []cli.Command{
 				{

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -838,6 +838,8 @@ const (
 	OutputhostCGMessageSentAck
 	// OutputhostCGMessageSentNAck records the count of nack messages
 	OutputhostCGMessageSentNAck
+	// OutputhostCGMessageTimeout records the count of timeout messages
+	OutputhostCGMessageTimeout
 	// OutputhostCGMessagesThrottled records the count of messages throttled
 	OutputhostCGMessagesThrottled
 	// OutputhostCGAckMgrSeqNotFound is the gauge to track acks whose seq number is not found
@@ -1356,6 +1358,7 @@ var dynamicMetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		OutputhostCGMessageRedelivered:    {Counter, "outputhost.message.redelivered.cg"},
 		OutputhostCGMessageSentAck:        {Counter, "outputhost.message.sent-ack.cg"},
 		OutputhostCGMessageSentNAck:       {Counter, "outputhost.message.sent-nack.cg"},
+		OutputhostCGMessageTimeout:        {Counter, "outputhost.message.timeout.cg"},
 		OutputhostCGMessagesThrottled:     {Counter, "outputhost.message.throttled"},
 		OutputhostCGAckMgrSeqNotFound:     {Counter, "outputhost.ackmgr.seq-not-found.cg"},
 		OutputhostCGReplicaReconnect:      {Counter, "outputhost.replica-reconnect.cg"},

--- a/services/outputhost/cgcache.go
+++ b/services/outputhost/cgcache.go
@@ -664,6 +664,17 @@ func (cgCache *consumerGroupCache) getMessageCacheSize(cfg OutputCgConfig, oldSi
 	return cacheSize
 }
 
+//
+func (cgCache *consumerGroupCache) getRedeliveryInterval(cfg OutputCgConfig, oldInterval int32) (interval int32) {
+	logFn := func() bark.Logger {
+		return cgCache.logger
+	}
+	ruleKey := cgCache.destPath + `/` + cgCache.cachedCGDesc.GetConsumerGroupName()
+	interval = int32(common.OverrideValueByPrefix(logFn, ruleKey, cfg.RedeliveryIntervalInMs, int64(oldInterval), `redeliveryIntervalInMs`))
+
+	return interval
+}
+
 // loadConsumerGroupCache loads everything on this cache including the extents and within the cache
 func (cgCache *consumerGroupCache) loadConsumerGroupCache(ctx thrift.Context, exists bool) error {
 	cgCache.extMutex.Lock()

--- a/services/outputhost/config.go
+++ b/services/outputhost/config.go
@@ -39,8 +39,9 @@ type (
 		// "/test/destination//test/cg_1=50,/test/destination//test/cg_2=100"
 		MessageCacheSize []string `name:"messagecachesize" default:"/=10000"`
 
-		// RedeliveryIntervalInMs is used to configure the message redelivery interval.
-		RedeliveryIntervalInMs int `name:"redeliveryIntervalInMs" default:"100"`
+		// RedeliveryIntervalInMs is used to configure the per CG message redelivery interval.
+		// Just like MessageCacheSize above
+		RedeliveryIntervalInMs []string `name:"redeliveryIntervalInMs" default:"/=100"`
 	}
 )
 

--- a/services/outputhost/config.go
+++ b/services/outputhost/config.go
@@ -40,7 +40,7 @@ type (
 		MessageCacheSize []string `name:"messagecachesize" default:"/=10000"`
 
 		// RedeliveryIntervalInMs is used to configure the message redelivery interval.
-		RedeliveryIntervalInMs int32 `name:"redeliveryIntervalInMs" default:"100"`
+		RedeliveryIntervalInMs int `name:"redeliveryIntervalInMs" default:"100"`
 	}
 )
 

--- a/services/outputhost/config.go
+++ b/services/outputhost/config.go
@@ -38,6 +38,9 @@ type (
 		// with different size config as follows:
 		// "/test/destination//test/cg_1=50,/test/destination//test/cg_2=100"
 		MessageCacheSize []string `name:"messagecachesize" default:"/=10000"`
+
+		// RedeliveryIntervalInMs is used to configure the message redelivery interval.
+		RedeliveryIntervalInMs int32 `name:"redeliveryIntervalInMs" default:"100"`
 	}
 )
 

--- a/services/outputhost/messagecache.go
+++ b/services/outputhost/messagecache.go
@@ -266,7 +266,7 @@ type cgMsgCache struct {
 	maxOutstandingMsgs     int32               // max allowed outstanding messages
 	numAcks                int32               // num acks we received
 	cgCache                *consumerGroupCache // just a reference to the cgCache to grant credits to a local extent directly
-	redeliveryIntervalInMs int32               // redelivery ticker interval
+	redeliveryIntervalInMs int                 // redelivery ticker interval
 	shared.ConsumerGroupDescription
 }
 

--- a/services/outputhost/messagecache.go
+++ b/services/outputhost/messagecache.go
@@ -261,12 +261,12 @@ type cgMsgCache struct {
 	notifier                 Notifier // this notifier is used to slow down cons connections based on NACKs
 	consumerHealth
 	messageCacheHealth
-	creditNotifyCh     chan<- int32        // this is the notify ch to notify credits to extents
-	creditRequestCh    <-chan string       // read-only channel used by the extents to request credits specifically for that extent.
-	maxOutstandingMsgs int32               // max allowed outstanding messages
-	numAcks            int32               // num acks we received
-	cgCache            *consumerGroupCache // just a reference to the cgCache to grant credits to a local extent directly
-	redeliveryIntervalInMs   int32         // redelivery ticker interval
+	creditNotifyCh         chan<- int32        // this is the notify ch to notify credits to extents
+	creditRequestCh        <-chan string       // read-only channel used by the extents to request credits specifically for that extent.
+	maxOutstandingMsgs     int32               // max allowed outstanding messages
+	numAcks                int32               // num acks we received
+	cgCache                *consumerGroupCache // just a reference to the cgCache to grant credits to a local extent directly
+	redeliveryIntervalInMs int32               // redelivery ticker interval
 	shared.ConsumerGroupDescription
 }
 
@@ -331,7 +331,7 @@ func (msgCache *cgMsgCache) utilHandleDeliveredMsg(cMsg cacheMsg) {
 	case stateEarlyNACK:
 		//lclLg.WithField("AckID", common.ShortenGUIDString(msg.GetAckId())).Debug("manageMessageDeliveryCache: Early NACKed message (delivering to DLQ)")
 		msgCache.changeState(ackID, stateDelivered, msg, eventCache) // Mark one delivery as complete, eligible for redelivery depending on max deliveries
-		cm.fireTime = msgCache.addTimer(0, ackID)       // Try to redeliver immediately, rather than wait for the lock timeout
+		cm.fireTime = msgCache.addTimer(0, ackID)                    // Try to redeliver immediately, rather than wait for the lock timeout
 	case stateDelivered:
 		break // this happens on redelivery
 	case stateConsumed:

--- a/services/outputhost/messagecache.go
+++ b/services/outputhost/messagecache.go
@@ -990,15 +990,17 @@ func (msgCache *cgMsgCache) updateConn(connID int, event msgEvent) {
 
 func (msgCache *cgMsgCache) refreshCgConfig(oldOutstandingMessages int32) {
 	outstandingMsgs := oldOutstandingMessages
+	redeliveryIntervalInMs := msgCache.redeliveryIntervalInMs
+
 	cfg, err := msgCache.cgCache.getDynamicCgConfig()
 	if err == nil {
 		outstandingMsgs = msgCache.cgCache.getMessageCacheSize(cfg, oldOutstandingMessages)
+		redeliveryIntervalInMs = cfg.RedeliveryIntervalInMs
 	}
 
 	msgCache.maxOutstandingMsgs = outstandingMsgs
 
-	redeliveryIntervalInMs := msgCache.redeliveryIntervalInMs
-	if redeliveryIntervalInMs != cfg.RedeliveryIntervalInMs {
+	if redeliveryIntervalInMs != msgCache.redeliveryIntervalInMs {
 		msgCache.redeliveryTicker = time.NewTicker(time.Duration(redeliveryIntervalInMs) * time.Millisecond)
 		msgCache.redeliveryIntervalInMs = redeliveryIntervalInMs
 	}

--- a/services/outputhost/messagecache.go
+++ b/services/outputhost/messagecache.go
@@ -1031,7 +1031,7 @@ func newMessageDeliveryCache(
 		ackMsgCh:                 cgCache.ackMsgCh,
 		nackMsgCh:                cgCache.nackMsgCh,
 		closeChannel:             make(chan struct{}),
-		redeliveryTicker:         time.NewTicker(defaultRedeliveryIntervalInMs),
+		redeliveryTicker:         time.NewTicker(defaultRedeliveryIntervalInMs * time.Millisecond),
 		ConsumerGroupDescription: cgCache.cachedCGDesc,
 		consumerM3Client:         cgCache.consumerM3Client,
 		m3Client:                 cgCache.m3Client,


### PR DESCRIPTION
Talked with Kiran, set the nack redelivery delay to 25 milliseconds for now. We can tune it later.