### PR TITLE
Handle merged DLQ extents for KFC destinations

### DIFF
--- a/services/storehost/modes.go
+++ b/services/storehost/modes.go
@@ -55,6 +55,10 @@ func getModeForDestinationType(destType cherami.DestinationType) Mode {
 
 	case cherami.DestinationType_LOG:
 		return Log
+
+	case cherami.DestinationType_KAFKA:
+		return AppendOnly
+
 	default:
 		return Mode(0)
 	}


### PR DESCRIPTION
Read-stream request for DLQ extents "merged" into the main destination, have a destination-type of "kafka", that storehost does not currently recognize, and so fails these request. These cg-extents therefore get stalled.
