### PR TITLE
Introduce consumer-group "deleting" status

### DIFF
--- a/common/metadata.go
+++ b/common/metadata.go
@@ -28,7 +28,6 @@ import (
 
 // IsDLQDestination checks whether a destination is dlq type
 func IsDLQDestination(dstDesc *shared.DestinationDescription) bool {
-	// Other destination types have paths that start with '/'; DLQ starts with 'D'
 	return dstDesc != nil && IsDLQDestinationPath(dstDesc.GetPath())
 }
 

--- a/common/metadata/metaMetrics.go
+++ b/common/metadata/metaMetrics.go
@@ -498,6 +498,21 @@ func (m *metadataMetricsMgr) DeleteConsumerGroup(ctx thrift.Context, request *sh
 	return err
 }
 
+func (m *metadataMetricsMgr) DeleteConsumerGroupUUID(ctx thrift.Context, request *m.DeleteConsumerGroupUUIDRequest) (err error) {
+
+	m.m3.IncCounter(metrics.MetadataDeleteConsumerGroupUUIDScope, metrics.MetadataRequests)
+	sw := m.m3.StartTimer(metrics.MetadataDeleteConsumerGroupUUIDScope, metrics.MetadataLatency)
+	defer sw.Stop()
+
+	err = m.meta.DeleteConsumerGroupUUID(ctx, request)
+
+	if err != nil {
+		m.m3.IncCounter(metrics.MetadataDeleteConsumerGroupUUIDScope, metrics.MetadataFailures)
+	}
+
+	return err
+}
+
 func (m *metadataMetricsMgr) DeleteDestination(ctx thrift.Context, request *shared.DeleteDestinationRequest) (err error) {
 
 	m.m3.IncCounter(metrics.MetadataDeleteDestinationScope, metrics.MetadataRequests)

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -181,6 +181,8 @@ const (
 	MetadataCreateServiceConfigScope
 	// MetadataDeleteConsumerGroupScope defines scope for an operation on metadata
 	MetadataDeleteConsumerGroupScope
+	// MetadataDeleteConsumerGroupUUIDScope defines scope for an operation on metadata
+	MetadataDeleteConsumerGroupUUIDScope
 	// MetadataDeleteDestinationScope defines scope for an operation on metadata
 	MetadataDeleteDestinationScope
 	// MetadataDeleteDestinationUUIDScope defines scope for an operation on metadata
@@ -502,6 +504,7 @@ var scopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		MetadataCreateHostInfoScope:                    {operation: "MetadataCreateHostInfo"},
 		MetadataCreateServiceConfigScope:               {operation: "MetadataCreateServiceConfig"},
 		MetadataDeleteConsumerGroupScope:               {operation: "MetadataDeleteConsumerGroup"},
+		MetadataDeleteConsumerGroupUUIDScope:           {operation: "MetadataDeleteConsumerGroupUUID"},
 		MetadataDeleteDestinationScope:                 {operation: "MetadataDeleteDestination"},
 		MetadataDeleteDestinationUUIDScope:             {operation: "MetadataDeleteDestinationUUID"},
 		MetadataDeleteHostInfoScope:                    {operation: "MetadataDeleteHostInfo"},

--- a/glide.lock
+++ b/glide.lock
@@ -121,7 +121,7 @@ imports:
 - name: github.com/tecbot/gorocksdb
   version: 17991d3138a879b166adebf86f7c84da3c1517a7
 - name: github.com/uber-common/bark
-  version: a2ce12437502dbd1511a6ab87745ed01ba138dbb
+  version: 11c68f25ea004a3f36e3c6ad90236835a4bd0971
 - name: github.com/uber-go/atomic
   version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
 - name: github.com/uber/cherami-client-go

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 9a67e8f4d4283f7adbdb55678b4e7e6d5e7354ef9995481d8cd2cf020005bc54
-updated: 2017-09-19T11:29:54.862014684-07:00
+hash: 79cc68755e2fff0a68ef84580fb09717f455ded83f2f6dd5a2cc55e808eaf241
+updated: 2017-09-21T11:34:49.462678076-07:00
 imports:
 - name: github.com/apache/thrift
   version: b2a4d4ae21c789b689dd162deb819665567f481c
@@ -134,7 +134,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: 5dea82cadfcd8b5faf7ba53c2d29fcd09860cfed
+  version: 45b0a9da65195b298b3967360a1a069907d5266a
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: c07e04468cb56c800bfd46dc5e2539d5efd3f013f975fa6ffccb2d343a30c566
-updated: 2017-09-07T11:44:24.153193919-07:00
+hash: 9a67e8f4d4283f7adbdb55678b4e7e6d5e7354ef9995481d8cd2cf020005bc54
+updated: 2017-09-19T11:29:54.862014684-07:00
 imports:
 - name: github.com/apache/thrift
   version: b2a4d4ae21c789b689dd162deb819665567f481c
@@ -40,7 +40,7 @@ imports:
 - name: github.com/bsm/sarama-cluster
   version: 5efe630369ab4ed5cc4cedeadd61b4d1b2523169
 - name: github.com/cactus/go-statsd-client
-  version: ce77ca9ecdee1c3ffd097e32f9bb832825ccb203
+  version: ad551ee7f9f3465fb1ce1695899c612f7808a06a
   subpackages:
   - statsd
 - name: github.com/cockroachdb/c-jemalloc
@@ -54,7 +54,7 @@ imports:
 - name: github.com/codegangsta/cli
   version: cf33a9befefdd6c6ea1a236ab6d546e797a62cbf
 - name: github.com/davecgh/go-spew
-  version: a476722483882dd40b8111f0eb64e1d7f43f56e4
+  version: adab96458c51a58dc1783b3335dcce5461522e75
   subpackages:
   - spew
 - name: github.com/dgryski/go-farm
@@ -112,7 +112,7 @@ imports:
 - name: github.com/stretchr/objx
   version: 1a9d0bb9f541897e62256577b352fdbc1fb4fd94
 - name: github.com/stretchr/testify
-  version: 890a5c3458b43e6104ff5da8dfa139d013d77544
+  version: 05e8a0eda380579888eb53c394909df027f06991
   subpackages:
   - assert
   - mock
@@ -134,7 +134,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: 98e566b96cbe7142446508e5991a11bc394ab343
+  version: 5dea82cadfcd8b5faf7ba53c2d29fcd09860cfed
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami
@@ -172,7 +172,7 @@ imports:
   - trand
   - typed
 - name: golang.org/x/net
-  version: 66aacef3dd8a676686c7ae3716979581e8b03c47
+  version: ab5485076ff3407ad2d02db054635913f017b0ed
   subpackages:
   - bpf
   - context

--- a/glide.yaml
+++ b/glide.yaml
@@ -40,7 +40,6 @@ import:
   - common/websocket
   - stream
 - package: github.com/uber/cherami-thrift
-  version: 45b0a9da65195b298b3967360a1a069907d5266a
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/glide.yaml
+++ b/glide.yaml
@@ -40,7 +40,7 @@ import:
   - common/websocket
   - stream
 - package: github.com/uber/cherami-thrift
-  version: v1.25.0-rc0
+  version: 5dea82cadfcd8b5faf7ba53c2d29fcd09860cfed
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/glide.yaml
+++ b/glide.yaml
@@ -40,7 +40,7 @@ import:
   - common/websocket
   - stream
 - package: github.com/uber/cherami-thrift
-  version: 5dea82cadfcd8b5faf7ba53c2d29fcd09860cfed
+  version: 45b0a9da65195b298b3967360a1a069907d5266a
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/services/controllerhost/consumer.go
+++ b/services/controllerhost/consumer.go
@@ -55,6 +55,8 @@ func validatCGStatus(cgDesc *shared.ConsumerGroupDescription) error {
 	switch cgDesc.GetStatus() {
 	case shared.ConsumerGroupStatus_ENABLED:
 		return nil
+	case shared.ConsumerGroupStatus_DELETING:
+		return ErrConsumerGroupNotExists
 	case shared.ConsumerGroupStatus_DELETED:
 		return ErrConsumerGroupNotExists
 	default:

--- a/services/controllerhost/extentmon.go
+++ b/services/controllerhost/extentmon.go
@@ -280,6 +280,8 @@ func (monitor *extentStateMonitor) runIterator() {
 			if monitor.isShutdown() {
 				break
 			}
+
+			// skip 'deleted' consumer-groups, but include those in 'deleting' state
 			if cgDesc.GetStatus() == shared.ConsumerGroupStatus_DELETED {
 				continue
 			}
@@ -430,7 +432,8 @@ func (monitor *extentStateMonitor) handleDestination(dstDesc *shared.Destination
 
 func (monitor *extentStateMonitor) deleteConsumerGroup(dstDesc *shared.DestinationDescription, cgDesc *shared.ConsumerGroupDescription) {
 
-	if cgDesc.GetStatus() == shared.ConsumerGroupStatus_DELETED {
+	if cgDesc.GetStatus() == shared.ConsumerGroupStatus_DELETING ||
+		cgDesc.GetStatus() == shared.ConsumerGroupStatus_DELETED {
 		return
 	}
 

--- a/services/outputhost/cgcache.go
+++ b/services/outputhost/cgcache.go
@@ -544,7 +544,8 @@ func (cgCache *consumerGroupCache) refreshCgCache(ctx thrift.Context) error {
 		return errRD
 	}
 
-	if dstDesc.GetStatus() == shared.DestinationStatus_DELETING || dstDesc.GetStatus() == shared.DestinationStatus_DELETED {
+	if dstDesc.GetStatus() == shared.DestinationStatus_DELETING ||
+		dstDesc.GetStatus() == shared.DestinationStatus_DELETED {
 		cgCache.logger.Info("destination deleted; unloading all extents")
 		go cgCache.unloadConsumerGroupCache()
 		return ErrCgUnloaded
@@ -566,7 +567,8 @@ func (cgCache *consumerGroupCache) refreshCgCache(ctx thrift.Context) error {
 		return errRCG
 	}
 
-	if cgDesc.GetStatus() == shared.ConsumerGroupStatus_DELETED {
+	if cgDesc.GetStatus() == shared.ConsumerGroupStatus_DELETING ||
+		cgDesc.GetStatus() == shared.ConsumerGroupStatus_DELETED {
 		// If the consumer group is deleted, drain all connections
 		// and unload all the extent from cache. This is the only
 		// way, async clean happens in response to a DELETE

--- a/services/replicator/metadataReconciler.go
+++ b/services/replicator/metadataReconciler.go
@@ -307,7 +307,7 @@ func (r *metadataReconciler) reconcileCg(localCgs []*shared.ConsumerGroupDescrip
 				remoteCg.GetStatus() == shared.ConsumerGroupStatus_DELETED {
 				// case #1: cg gets deleted in remote, but not deleted in local. Delete the cg locally
 				if !(localCg.GetStatus() == shared.ConsumerGroupStatus_DELETING ||
-					ocalCg.GetStatus() == shared.ConsumerGroupStatus_DELETED) {
+					localCg.GetStatus() == shared.ConsumerGroupStatus_DELETED) {
 					lclLg.Info(`Found deleted cg from remote but not deleted locally`)
 					deleteRequest := &shared.DeleteConsumerGroupRequest{
 						DestinationUUID:   common.StringPtr(remoteCg.GetDestinationUUID()),

--- a/services/replicator/metadataReconciler.go
+++ b/services/replicator/metadataReconciler.go
@@ -303,9 +303,9 @@ func (r *metadataReconciler) reconcileCg(localCgs []*shared.ConsumerGroupDescrip
 		})
 		localCg, ok := localCgsSet[remoteCg.GetConsumerGroupUUID()]
 		if ok {
-			if remoteCg.GetStatus() == shared.ConsumerGroupStatus_DELETED {
+			if remoteCg.GetStatus() == shared.ConsumerGroupStatus_DELETING {
 				// case #1: cg gets deleted in remote, but not deleted in local. Delete the cg locally
-				if !(localCg.GetStatus() == shared.ConsumerGroupStatus_DELETED) {
+				if !(localCg.GetStatus() == shared.ConsumerGroupStatus_DELETING) {
 					lclLg.Info(`Found deleted cg from remote but not deleted locally`)
 					deleteRequest := &shared.DeleteConsumerGroupRequest{
 						DestinationUUID:   common.StringPtr(remoteCg.GetDestinationUUID()),
@@ -333,7 +333,7 @@ func (r *metadataReconciler) reconcileCg(localCgs []*shared.ConsumerGroupDescrip
 			replicatorReconcileCgFoundMissingCount = replicatorReconcileCgFoundMissingCount + 1
 
 			// If the missing ConsumerGroup is in deleted status, we don't need to create the ConsumerGroup locally
-			if remoteCg.GetStatus() == shared.ConsumerGroupStatus_DELETED {
+			if remoteCg.GetStatus() == shared.ConsumerGroupStatus_DELETING {
 				lclLg.Info(`Found missing ConsumerGroup from remote but in deleted state`)
 				continue
 			}

--- a/services/replicator/metadataReconciler.go
+++ b/services/replicator/metadataReconciler.go
@@ -303,9 +303,11 @@ func (r *metadataReconciler) reconcileCg(localCgs []*shared.ConsumerGroupDescrip
 		})
 		localCg, ok := localCgsSet[remoteCg.GetConsumerGroupUUID()]
 		if ok {
-			if remoteCg.GetStatus() == shared.ConsumerGroupStatus_DELETING {
+			if remoteCg.GetStatus() == shared.ConsumerGroupStatus_DELETING ||
+				remoteCg.GetStatus() == shared.ConsumerGroupStatus_DELETED {
 				// case #1: cg gets deleted in remote, but not deleted in local. Delete the cg locally
-				if !(localCg.GetStatus() == shared.ConsumerGroupStatus_DELETING) {
+				if !(localCg.GetStatus() == shared.ConsumerGroupStatus_DELETING ||
+					ocalCg.GetStatus() == shared.ConsumerGroupStatus_DELETED) {
 					lclLg.Info(`Found deleted cg from remote but not deleted locally`)
 					deleteRequest := &shared.DeleteConsumerGroupRequest{
 						DestinationUUID:   common.StringPtr(remoteCg.GetDestinationUUID()),
@@ -333,7 +335,8 @@ func (r *metadataReconciler) reconcileCg(localCgs []*shared.ConsumerGroupDescrip
 			replicatorReconcileCgFoundMissingCount = replicatorReconcileCgFoundMissingCount + 1
 
 			// If the missing ConsumerGroup is in deleted status, we don't need to create the ConsumerGroup locally
-			if remoteCg.GetStatus() == shared.ConsumerGroupStatus_DELETING {
+			if remoteCg.GetStatus() == shared.ConsumerGroupStatus_DELETING ||
+				remoteCg.GetStatus() == shared.ConsumerGroupStatus_DELETED {
 				lclLg.Info(`Found missing ConsumerGroup from remote but in deleted state`)
 				continue
 			}

--- a/services/replicator/replicator_test.go
+++ b/services/replicator/replicator_test.go
@@ -1319,7 +1319,7 @@ func (s *ReplicatorSuite) TestCgMetadataReconcileLocalMissingRemoteDeleted() {
 	var remoteCgs []*shared.ConsumerGroupDescription
 	remoteCgs = append(remoteCgs, &shared.ConsumerGroupDescription{
 		ConsumerGroupUUID: common.StringPtr(missingCgUUID),
-		Status:            common.InternalConsumerGroupStatusPtr(shared.ConsumerGroupStatus_DELETED),
+		Status:            common.InternalConsumerGroupStatusPtr(shared.ConsumerGroupStatus_DELETING),
 	})
 	reconciler.reconcileCg(localCgs, remoteCgs)
 	s.mockMeta.AssertExpectations(s.T())
@@ -1353,7 +1353,7 @@ func (s *ReplicatorSuite) TestCgMetadataReconcileRemoteDeleted() {
 		ConsumerGroupUUID: common.StringPtr(cgUUID),
 		ConsumerGroupName: common.StringPtr(cgName),
 		DestinationUUID:   common.StringPtr(destUUID),
-		Status:            common.InternalConsumerGroupStatusPtr(shared.ConsumerGroupStatus_DELETED),
+		Status:            common.InternalConsumerGroupStatusPtr(shared.ConsumerGroupStatus_DELETING),
 	})
 	reconciler.reconcileCg(localCgs, remoteCgs)
 	s.mockMeta.AssertExpectations(s.T())
@@ -1374,14 +1374,14 @@ func (s *ReplicatorSuite) TestCgMetadataReconcileRemoteLocalDeleted() {
 		ConsumerGroupUUID: common.StringPtr(cgUUID),
 		ConsumerGroupName: common.StringPtr(cgName),
 		DestinationUUID:   common.StringPtr(destUUID),
-		Status:            common.InternalConsumerGroupStatusPtr(shared.ConsumerGroupStatus_DELETED),
+		Status:            common.InternalConsumerGroupStatusPtr(shared.ConsumerGroupStatus_DELETING),
 	})
 	var remoteCgs []*shared.ConsumerGroupDescription
 	remoteCgs = append(remoteCgs, &shared.ConsumerGroupDescription{
 		ConsumerGroupUUID: common.StringPtr(cgUUID),
 		ConsumerGroupName: common.StringPtr(cgName),
 		DestinationUUID:   common.StringPtr(destUUID),
-		Status:            common.InternalConsumerGroupStatusPtr(shared.ConsumerGroupStatus_DELETED),
+		Status:            common.InternalConsumerGroupStatusPtr(shared.ConsumerGroupStatus_DELETING),
 	})
 	reconciler.reconcileCg(localCgs, remoteCgs)
 	s.mockMeta.AssertExpectations(s.T())

--- a/test/mocks/metadata/TChanMetadataService.go
+++ b/test/mocks/metadata/TChanMetadataService.go
@@ -188,6 +188,20 @@ func (_m *TChanMetadataService) DeleteConsumerGroup(ctx thrift.Context, deleteRe
 	return r0
 }
 
+// DeleteConsumerGroupUUID provides a mock function with given fields: ctx, deleteRequest
+func (_m *TChanMetadataService) DeleteConsumerGroupUUID(ctx thrift.Context, deleteRequest *metadata.DeleteConsumerGroupUUIDRequest) error {
+	ret := _m.Called(ctx, deleteRequest)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.DeleteConsumerGroupUUIDRequest) error); ok {
+		r0 = rf(ctx, deleteRequest)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // DeleteDestination provides a mock function with given fields: ctx, deleteRequest
 func (_m *TChanMetadataService) DeleteDestination(ctx thrift.Context, deleteRequest *shared.DeleteDestinationRequest) error {
 	ret := _m.Called(ctx, deleteRequest)

--- a/test/mocks/metadata/TChanMetadataServiceClient.go
+++ b/test/mocks/metadata/TChanMetadataServiceClient.go
@@ -174,6 +174,20 @@ func (_m *TChanMetadataServiceClient) DeleteConsumerGroup(ctx thrift.Context, de
 	return r0
 }
 
+// DeleteConsumerGroupUUID provides a mock function with given fields: ctx, deleteRequest
+func (_m *TChanMetadataServiceClient) DeleteConsumerGroupUUID(ctx thrift.Context, deleteRequest *metadata.DeleteConsumerGroupUUIDRequest) error {
+	ret := _m.Called(ctx, deleteRequest)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.DeleteConsumerGroupUUIDRequest) error); ok {
+		r0 = rf(ctx, deleteRequest)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // DeleteDestination provides a mock function with given fields: ctx, deleteRequest
 func (_m *TChanMetadataServiceClient) DeleteDestination(ctx thrift.Context, deleteRequest *shared.DeleteDestinationRequest) error {
 	ret := _m.Called(ctx, deleteRequest)

--- a/test/mocks/metadata/TChanMetadataServiceServer.go
+++ b/test/mocks/metadata/TChanMetadataServiceServer.go
@@ -128,6 +128,20 @@ func (_m *TChanMetadataServiceServer) DeleteConsumerGroup(ctx thrift.Context, de
 	return r0
 }
 
+// DeleteConsumerGroupUUID provides a mock function with given fields: ctx, deleteRequest
+func (_m *TChanMetadataServiceServer) DeleteConsumerGroupUUID(ctx thrift.Context, deleteRequest *metadata.DeleteConsumerGroupUUIDRequest) error {
+	ret := _m.Called(ctx, deleteRequest)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(thrift.Context, *metadata.DeleteConsumerGroupUUIDRequest) error); ok {
+		r0 = rf(ctx, deleteRequest)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // DeleteDestination provides a mock function with given fields: ctx, deleteRequest
 func (_m *TChanMetadataServiceServer) DeleteDestination(ctx thrift.Context, deleteRequest *shared.DeleteDestinationRequest) error {
 	ret := _m.Called(ctx, deleteRequest)


### PR DESCRIPTION
This diff handles adding a "deleting" (pre-delete) status to consumer-group. The actual deletion of the consumer-group would be done in Retention Manager for now .. and I will do that in a separate diff.