### PR TITLE
[prototype] size-capped channel

### DIFF
--- a/common/sizedCh/sizedCh.go
+++ b/common/sizedCh/sizedCh.go
@@ -1,0 +1,93 @@
+package sizedCh
+
+import (
+	"sync"
+	"sync/atomic"
+	"unsafe"
+)
+
+type SizedCh struct {
+	readerCh, bufferCh, readerCh chan Message
+	totalSize                    int64
+	availSize                    int64
+	mu                           sync.Mutex
+	cond                         *sync.Cond
+}
+
+const (
+	readerChSize = 16
+	writerChSize = 16
+	bufChSize    = 10000
+)
+
+type Message interface {
+	Size() int
+}
+
+func New(size int) (*SizedCh, <-chan Message, chan<- Message) {
+
+	t := &SizedCh{
+		readerCh: make(chan unsafe.Pointer, readChSize),
+		writerCh: make(chan unsafe.Pointer, writeChSize),
+		bufferCh: make(chan unsafe.Pointer, bufChSize),
+	}
+
+	go t.readPump()
+	go t.writePump()
+
+	return t, t.readerCh, t.writerCh
+}
+
+func (t *SizedCh) Increase(size int) (newSize int) {
+
+	return int(atomic.AddInt64(&t.totalSize, int64(size)))
+}
+
+func (t *SizedCh) Close() {
+
+	close(t.writerCh)
+}
+
+func (t *SizedCh) readPump() {
+
+	defer close(t.bufferCh)
+
+	for msg := range t.writerCh {
+
+		msgSize := int64(msg.Size())
+
+		for {
+			availSize := atomic.LoadInt64(&t.availSize)
+
+			if msgSize > availSize {
+
+				t.cond.L.Lock()
+
+				for msgSize > availSize {
+					t.cond.Wait()
+					availSize = atomic.LoadInt64(&t.availSize)
+				}
+
+				t.cond.L.Unlock()
+			}
+
+			if atomic.CompareAndSwapInt64(&t.availSize, availSize, availSize-msgSize) {
+				break
+			}
+		}
+
+		t.bufferCh <- msg
+	}
+}
+
+func (t *SizedCh) writePump() {
+
+	defer close(t.readerCh)
+
+	for msg := range t.bufferCh {
+
+		readerCh <- msg
+		atomic.AddInt64(availSize, msgSize)
+		t.cond.Signal()
+	}
+}

--- a/common/sizedCh/sizedCh.go
+++ b/common/sizedCh/sizedCh.go
@@ -1,3 +1,4 @@
+// sizedCh implements a size-capped channel
 package sizedCh
 
 import (
@@ -5,35 +6,71 @@ import (
 	"sync/atomic"
 )
 
+// SizedCh holds the context for the size-capped channel
 type SizedCh struct {
-	writerCh  chan Message
-	bufferCh  chan Message
-	readerCh  chan Message
-	totalSize int64
-	availSize int64
-	mu        sync.Mutex
-	cond      *sync.Cond
+	availSize int64        // available size in the channel; updated atomically
+	writerCh  chan Message // channel the writer end puts messages into
+	bufferCh  chan Message // internal channel that holds the buffered messages
+	readerCh  chan Message // channel the reader end reads messages from
+	cond      *sync.Cond   // conditional variable used to sleep/wake-up
+	mu        sync.Mutex   // mutex to use for the conditional-variable
 }
 
 const (
-	readerChSize = 16
-	writerChSize = 16
+	// should be '0' ideally, so the writer blocks as soon as the internal buffer
+	// is full (ie, has no capacity); increase to improve performance.
+	writerChSize = 32
+	readerChSize = 32
 	bufferChSize = 10000
 )
 
+// Message is the interface that every object passed via the channel should implement
 type Message interface {
-	Size() int
+	Len() int
 }
 
-func New(size int) (*SizedCh, <-chan Message, chan<- Message) {
+type SetOpt func(t *SizedCh)
+
+func ReaderChSize(size int) SetOpt {
+
+	return func(t *SizedCh) {
+		close(t.readerCh)
+		t.readerCh = make(chan Message, size)
+	}
+}
+
+func WriterChSize(size int) SetOpt {
+
+	return func(t *SizedCh) {
+		close(t.writerCh)
+		t.writerCh = make(chan Message, size)
+	}
+}
+
+func BufferChSize(size int) SetOpt {
+
+	return func(t *SizedCh) {
+		close(t.bufferCh)
+		t.bufferCh = make(chan Message, size)
+	}
+}
+
+// New creates a new size-capped channel, and returns corresponding
+// channels for the reader and writer for the channel.
+func New(size int, setOpts ...SetOpt) (*SizedCh, <-chan Message, chan<- Message) {
 
 	t := &SizedCh{
-		readerCh: make(chan Message, readerChSize),
-		writerCh: make(chan Message, writerChSize),
-		bufferCh: make(chan Message, bufferChSize),
+		availSize: int64(size),
+		readerCh:  make(chan Message, readerChSize),
+		writerCh:  make(chan Message, writerChSize),
+		bufferCh:  make(chan Message, bufferChSize),
 	}
 
 	t.cond = sync.NewCond(&t.mu)
+
+	for _, setOpt := range setOpts {
+		setOpt(t)
+	}
 
 	go t.readPump()
 	go t.writePump()
@@ -41,59 +78,81 @@ func New(size int) (*SizedCh, <-chan Message, chan<- Message) {
 	return t, t.readerCh, t.writerCh
 }
 
+// Increase increases the 'size' of the channel; the size can be
+// negative to reduce the size. Returns the new size of the channel.
 func (t *SizedCh) Increase(size int) (newSize int) {
 
-	return int(atomic.AddInt64(&t.totalSize, int64(size)))
+	return int(atomic.AddInt64(&t.availSize, int64(size)))
 }
 
+// Close closes the sized channel. Just like with go-channels, the caller would
+// be able to read and drain out any existing messages buffered in the channel.
 func (t *SizedCh) Close() {
 
 	close(t.writerCh)
 }
 
+// read pump reads from the 'writer' channel and writes out into the internal
+// 'buffer' channel if the message size fits.
 func (t *SizedCh) readPump() {
 
+	// when done, close the buffer channel
 	defer close(t.bufferCh)
 
 	for msg := range t.writerCh {
 
-		msgSize := int64(msg.Size())
+		// find message size
+		msgSize := int64(msg.Len())
 
+		// check if there's space in the buffer; wait if not
 		for {
 			availSize := atomic.LoadInt64(&t.availSize)
 
+			// if the msg does not readily fit into the available space,
+			// then sleep and wait until space is made available (when
+			// messages are read out).
 			if msgSize > availSize {
-
-				// if msg-size larger than available-size, then sleep
 
 				t.cond.L.Lock()
 
+				// sleep until there's space available in the buffer
 				for msgSize > availSize {
-					t.cond.Wait()
+
+					t.cond.Wait() // sleep on conditional-variable
 					availSize = atomic.LoadInt64(&t.availSize)
 				}
 
 				t.cond.L.Unlock()
 			}
 
-			// msg-size fits into available-size; atomically c-a-s availSize
+			// msg-size fits into available-size; atomically update available size
 			if atomic.CompareAndSwapInt64(&t.availSize, availSize, availSize-msgSize) {
 				break
 			}
 		}
 
-		t.bufferCh <- msg // we should never block here! blocking here indicates bufferCh needs to be larger
+		// we should ideally never block below! if we do block, that
+		// indicates that there are lots of tiny msgs being sent and
+		// we should probably increase the size of 'bufferCh'.
+		t.bufferCh <- msg
 	}
 }
 
+// write pump reads from the internal 'buffer' channel and writes out into the
+// 'reader' channel. every time a message is drained out, we updated the
+// 'availSize' appropriately and send a signal over the conditional-variable
+// to wake up the publisher, in case it is stuck.
 func (t *SizedCh) writePump() {
 
+	// when done, close the 'reader' channel; for the reader this would
+	// make it seem to behave like a go-channel would, where it can drain
+	// out until the end.
 	defer close(t.readerCh)
 
 	for msg := range t.bufferCh {
 
 		t.readerCh <- msg
-		atomic.AddInt64(&t.availSize, int64(msg.Size()))
+		atomic.AddInt64(&t.availSize, int64(msg.Len()))
 		t.cond.Signal()
 	}
 }

--- a/common/szChan/szChan.go
+++ b/common/szChan/szChan.go
@@ -56,6 +56,7 @@ func New(size int, setOpts ...SetOptFunc) (*SzChan, <-chan Message, chan<- Messa
 	return t, t.readerCh, t.writerCh
 }
 
+// SetOptFunc is used to override various options on the object
 type SetOptFunc func(t *SzChan)
 
 // ReaderChSize can be used to override the default readerChSize

--- a/common/szChan/szChan.go
+++ b/common/szChan/szChan.go
@@ -19,10 +19,11 @@ type SzChan struct {
 }
 
 const (
-	// should be '0' ideally, so the writer blocks as soon as the internal buffer
-	// is full (ie, has no capacity); increase to improve performance.
+	// these should ideally be '0', so the writer blocks as soon as the internal
+	// buffer is full (ie, has no capacity); increase to improve performance.
 	writerChSize = 32
 	readerChSize = 32
+
 	bufferChSize = 10000
 )
 


### PR DESCRIPTION
Prototype implementation of a size-capped channel (szChan). This could be useful in 'outputhost' where we want to move to size-based restriction .. as opposed to how it is done currently, based on message counts. This will enable us to more gracefully handle super-large message sizes, etc.

When you create a size-capped channel, you specify the 'capacity' in size/bytes .. and it returns two go-channels, one for sending (writer) into it the size-capped channel and another for receiving (reader) from it. Each time a message is sent to the szChan it buffers it and keeps a tally of the buffered-size -- if that exceeds the capacity, it would block sends, until space is made .. by reading out messages from it.

Bonus: Unlike count-capped go-channels, you can change the capacity of the size-based channel dynamically!

NB: Since there isn't a means to 'peek' into a go-channel, we would need to read out a message before being able to determine whether it would fit or not. So the channel would block on the message _after_ the one that makes it go beyond capacity. But this should not matter when there's a a continuous stream of messages. Also note, to improve performance, you can also fine-tune the 'buffer'/capacity of the reader/writer channels.
