### PR TITLE
Change some kafka related variable names to fix lint error

### DIFF
--- a/services/outputhost/cgcache.go
+++ b/services/outputhost/cgcache.go
@@ -272,7 +272,7 @@ func newConsumerGroupCache(destPath string, cgDesc shared.ConsumerGroupDescripti
 		hostMetrics:              h.hostMetrics,
 		cgMetrics:                load.NewCGMetrics(),
 		cfgMgr:                   h.cfgMgr,
-		kafkaMessageConverterFactory: h.kStreamFactory,
+		kafkaMessageConverterFactory: h.kafkaStreamFactory,
 	}
 
 	cgCache.consumerM3Client = metrics.NewClientWithTags(h.m3Client, metrics.Outputhost, cgCache.getConsumerGroupTags())

--- a/services/outputhost/kafkaStream.go
+++ b/services/outputhost/kafkaStream.go
@@ -43,12 +43,12 @@ var (
 type kafkaStream struct {
 	creditSemaphore common.UnboundedSemaphore
 	kafkaMsgsCh     <-chan *s.ConsumerMessage
-	kConverter      KafkaMessageConverter
+	converter       KafkaMessageConverter
 	logger          bark.Logger
 	seqNo           int64
 }
 
-// KafkakMessageConverterConfig is used to config customized converter
+// KafkaMessageConverterConfig is used to config customized converter
 type KafkaMessageConverterConfig struct {
 	// Destination and ConsumerGroup are not needed currently, but may in the future
 	// Destination *cherami.DestinationDescription
@@ -94,7 +94,7 @@ func (k *kafkaStream) Read() (*store.ReadMessageContent, error) {
 		return nil, errKafkaClosed
 	}
 	k.creditSemaphore.Acquire(1) // TODO: Size-based credits
-	return k.kConverter(m), nil
+	return k.converter(m), nil
 }
 
 // ResponseHeaders returns the response headers sent from the server. This will block until server headers have been received.
@@ -111,10 +111,10 @@ func OpenKafkaStream(c <-chan *s.ConsumerMessage, kafkaMessageConverter KafkaMes
 	k := &kafkaStream{
 		kafkaMsgsCh: c,
 		logger:      logger,
-		kConverter:  kafkaMessageConverter,
+		converter:   kafkaMessageConverter,
 	}
-	if k.kConverter == nil {
-		k.kConverter = k.getDefaultKafkaMessageConverter()
+	if k.converter == nil {
+		k.converter = k.getDefaultKafkaMessageConverter()
 	}
 	return k
 }

--- a/services/outputhost/outputhost.go
+++ b/services/outputhost/outputhost.go
@@ -68,31 +68,31 @@ var thisOutputHost *OutputHost
 type (
 	// OutputHost is the main server class for OutputHosts
 	OutputHost struct {
-		logger            bark.Logger
-		loadShutdownRef   int32
-		cgMutex           sync.RWMutex
-		cgCache           map[string]*consumerGroupCache
-		shutdownWG        sync.WaitGroup
-		cacheTimeout      time.Duration
-		metaClient        metadata.TChanMetadataService
-		frontendClient    ccherami.TChanBFrontend
-		hostIDHeartbeater common.HostIDHeartbeater
-		loadReporter      common.LoadReporterDaemon
-		shutdownCh        chan struct{}
-		unloadCacheCh     chan string
-		m3Client          metrics.Client
-		dClient           dconfig.Client
-		numConsConn       int32                  // number of active pubConnection
-		ackMgrMap         map[uint32]*ackManager // map of all the ack managers on this output
-		ackMgrMutex       sync.RWMutex           // mutex protecting the above map
-		sessionID         uint16
-		ackMgrIDGen       common.HostAckIDGenerator // this is the interface used to generate ackIDs for this host
-		ackMgrLoadCh      chan ackMgrLoadMsg
-		ackMgrUnloadCh    chan uint32
-		hostMetrics       *load.HostMetrics
-		cfgMgr            cassDconfig.ConfigManager
-		kafkaCfg          configure.CommonKafkaConfig
-		kStreamFactory    KafkaMessageConverterFactory
+		logger             bark.Logger
+		loadShutdownRef    int32
+		cgMutex            sync.RWMutex
+		cgCache            map[string]*consumerGroupCache
+		shutdownWG         sync.WaitGroup
+		cacheTimeout       time.Duration
+		metaClient         metadata.TChanMetadataService
+		frontendClient     ccherami.TChanBFrontend
+		hostIDHeartbeater  common.HostIDHeartbeater
+		loadReporter       common.LoadReporterDaemon
+		shutdownCh         chan struct{}
+		unloadCacheCh      chan string
+		m3Client           metrics.Client
+		dClient            dconfig.Client
+		numConsConn        int32                  // number of active pubConnection
+		ackMgrMap          map[uint32]*ackManager // map of all the ack managers on this output
+		ackMgrMutex        sync.RWMutex           // mutex protecting the above map
+		sessionID          uint16
+		ackMgrIDGen        common.HostAckIDGenerator // this is the interface used to generate ackIDs for this host
+		ackMgrLoadCh       chan ackMgrLoadMsg
+		ackMgrUnloadCh     chan uint32
+		hostMetrics        *load.HostMetrics
+		cfgMgr             cassDconfig.ConfigManager
+		kafkaCfg           configure.CommonKafkaConfig
+		kafkaStreamFactory KafkaMessageConverterFactory
 		common.SCommon
 	}
 
@@ -787,7 +787,7 @@ func NewOutputHost(
 			bs.cacheTimeout = opts.CacheIdleTimeout
 		}
 		if opts.KStreamFactory != nil {
-			bs.kStreamFactory = opts.KStreamFactory
+			bs.kafkaStreamFactory = opts.KStreamFactory
 		}
 	}
 


### PR DESCRIPTION
To fix:
➜  cherami-server git:(fix_lint) > make lint
./services/outputhost/kafkaStream.go:46:2: don't use leading k in Go names; struct field kConverter should be converter
./services/outputhost/kafkaStream.go:51:1: comment on exported type KafkaMessageConverterConfig should be of the form "KafkaMessageConverterConfig ..." (with optional leading article)
Found 2 lint suggestions; failing.
./services/outputhost/outputhost.go:95:3: don't use leading k in Go names; struct field kStreamFactory should be streamFactory
Found 1 lint suggestions; failing.
make: *** [lint] Error 1