### PR TITLE
RetMgr: Handle cleanup of consumer-groups and consumer-group extents

### DIFF
--- a/clients/metadata/metadata_cassandra.go
+++ b/clients/metadata/metadata_cassandra.go
@@ -1208,6 +1208,7 @@ const (
 	sqlInsertCGByUUID = `INSERT INTO ` + tableConsumerGroups +
 		`(` +
 		columnUUID + `, ` +
+		columnDestinationUUID + `, ` +
 		columnIsMultiZone + `, ` +
 		columnConsumerGroup +
 		`) VALUES (?, ?,` + sqlCGValue + `)`
@@ -1242,7 +1243,7 @@ const (
 		` WHERE ` + columnDestinationUUID + `=?`
 
 	sqlUpdateCGByUUID = `UPDATE ` + tableConsumerGroups +
-		` SET ` + columnIsMultiZone + ` = ?, ` + columnConsumerGroup + `= ` + sqlCGValue +
+		` SET ` + columnDestinationUUID + ` = ?, ` + columnIsMultiZone + ` = ?, ` + columnConsumerGroup + `= ` + sqlCGValue +
 		` WHERE ` + columnUUID + `=?`
 
 	sqlUpdateCGByName = `UPDATE ` + tableConsumerGroupsByName +
@@ -1313,6 +1314,7 @@ func (s *CassandraMetadataService) CreateConsumerGroupUUID(ctx thrift.Context, r
 
 	err = s.session.Query(sqlInsertCGByUUID,
 		cgUUID,
+		dstUUID,
 		createRequest.GetIsMultiZone(),
 		cgUUID,
 		dstUUID,
@@ -1630,6 +1632,7 @@ func (s *CassandraMetadataService) UpdateConsumerGroup(ctx thrift.Context, reque
 
 	batch.Query(sqlUpdateCGByUUID,
 		// Value columns
+		newCG.GetDestinationUUID(),
 		newCG.GetIsMultiZone(),
 		newCG.GetConsumerGroupUUID(),
 		newCG.GetDestinationUUID(),
@@ -1773,6 +1776,7 @@ func (s *CassandraMetadataService) DeleteConsumerGroup(ctx thrift.Context, reque
 
 	batch.Query(sqlUpdateCGByUUID,
 		// Value columns
+		existingCG.GetDestinationUUID(),
 		existingCG.GetIsMultiZone(),
 		existingCG.GetConsumerGroupUUID(),
 		existingCG.GetDestinationUUID(),
@@ -1841,6 +1845,7 @@ func (s *CassandraMetadataService) DeleteConsumerGroupUUID(ctx thrift.Context, r
 
 	query := s.session.Query(sqlDeleteCGByUUIDWithTTL,
 		existing.GetConsumerGroupUUID(),
+		existing.GetDestinationUUID(),
 		existing.GetIsMultiZone(),
 		existing.GetConsumerGroupUUID(),
 		existing.GetDestinationUUID(),

--- a/clients/metadata/metadata_cassandra.go
+++ b/clients/metadata/metadata_cassandra.go
@@ -3394,7 +3394,10 @@ func (s *CassandraMetadataService) UpdateStoreExtentReplicaStats(ctx thrift.Cont
 		)
 	}
 	if err := s.session.ExecuteBatch(batch); err != nil {
-		s.log.WithField(common.TagExt, request.GetExtentUUID()).Error("UpdateExtentReplicaStats failed")
+		s.log.WithFields(bark.Fields{
+			common.TagExt: request.GetExtentUUID(),
+			common.TagErr: err,
+		}).Error("UpdateExtentReplicaStats failed")
 		return &shared.InternalServiceError{
 			Message: "UpdateStoreExtentReplicaStats: %v" + err.Error(),
 		}

--- a/clients/metadata/metadata_cassandra.go
+++ b/clients/metadata/metadata_cassandra.go
@@ -1189,7 +1189,7 @@ const (
 		columnZoneConfigs + `: ?, ` +
 		columnOptions + `: ? }`
 
-	cqlConsumerGroupType = columnConsumerGroup + `.` + columnUUID + "," +
+	sqlConsumerGroupType = columnConsumerGroup + `.` + columnUUID + "," +
 		columnConsumerGroup + `.` + columnDestinationUUID + "," +
 		columnConsumerGroup + `.` + columnName + "," +
 		columnConsumerGroup + `.` + columnStartFrom + "," +
@@ -1222,23 +1222,23 @@ const (
 		`) VALUES (?, ?, ?, ` + sqlCGValue + `) IF NOT EXISTS`
 
 	sqlGetCGByName = `SELECT  ` +
-		cqlConsumerGroupType +
+		sqlConsumerGroupType +
 		` FROM ` + tableConsumerGroupsByName +
 		` WHERE ` + columnDestinationUUID + `=? and ` + columnName + `=?`
 
 	sqlGetCG = `SELECT  ` +
-		cqlConsumerGroupType +
+		sqlConsumerGroupType +
 		` FROM ` + tableConsumerGroups
 
 	sqlGetCGByUUID = sqlGetCG + ` WHERE ` + columnUUID + `=?`
 
 	sqlListCGsByDestUUID = `SELECT  ` +
-		cqlConsumerGroupType +
+		sqlConsumerGroupType +
 		` FROM ` + tableConsumerGroupsByName +
 		` WHERE ` + columnDestinationUUID + `=?`
 
 	sqlListCGsUUID = `SELECT  ` +
-		cqlConsumerGroupType +
+		sqlConsumerGroupType +
 		` FROM ` + tableConsumerGroups +
 		` WHERE ` + columnDestinationUUID + `=?`
 

--- a/clients/metadata/metadata_cassandra.go
+++ b/clients/metadata/metadata_cassandra.go
@@ -198,18 +198,18 @@ func parseConsistency(cfgCons string) (lowCons gocql.Consistency, midCons gocql.
 
 	switch cons := strings.Split(cfgCons, ","); len(cons) {
 	case 3:
-		lowCons = gocql.ParseConsistency(strings.TrimSpace(cons[2]))
+		lowCons, _ = gocql.ParseConsistency(strings.TrimSpace(cons[2]))
 		fallthrough
 
 	case 2:
-		midCons = gocql.ParseConsistency(strings.TrimSpace(cons[1]))
+		midCons, _ = gocql.ParseConsistency(strings.TrimSpace(cons[1]))
 		if len(cons) == 2 {
 			lowCons = midCons
 		}
 		fallthrough
 
 	case 1:
-		highCons = gocql.ParseConsistency(strings.TrimSpace(cons[0]))
+		highCons, _ = gocql.ParseConsistency(strings.TrimSpace(cons[0]))
 	}
 
 	return

--- a/clients/metadata/metadata_cassandra.go
+++ b/clients/metadata/metadata_cassandra.go
@@ -1211,7 +1211,7 @@ const (
 		columnDestinationUUID + `, ` +
 		columnIsMultiZone + `, ` +
 		columnConsumerGroup +
-		`) VALUES (?, ?,` + sqlCGValue + `)`
+		`) VALUES (?, ?, ?, ` + sqlCGValue + `)`
 
 	sqlInsertCGByName = `INSERT INTO ` + tableConsumerGroupsByName +
 		`(` +

--- a/clients/metadata/metadata_cassandra_test.go
+++ b/clients/metadata/metadata_cassandra_test.go
@@ -2121,11 +2121,6 @@ func (s *CassandraSuite) TestListConsumerGroups() {
 	}).Equals(cgSet), "ListConsumerGroups did not return all CGs")
 
 	assert.True(listCGs(&shared.ListConsumerGroupRequest{
-		DestinationPath: common.StringPtr(dstPath),
-		Limit:           common.Int64Ptr(testPageSize),
-	}).Equals(cgSet), "ListConsumerGroups did not return all CGs")
-
-	assert.True(listCGs(&shared.ListConsumerGroupRequest{
 		DestinationUUID: common.StringPtr(dstUUID),
 		Limit:           common.Int64Ptr(testPageSize),
 	}).Equals(cgSet), "ListConsumerGroups did not return all CGs")
@@ -2141,7 +2136,7 @@ func (s *CassandraSuite) TestListConsumerGroups() {
 	for i, cg := range cgSet.Keys() {
 
 		switch {
-		case i < 3: // delete it completely
+		case i < 3: // mark these CGs 'deleting'
 			err = s.client.DeleteConsumerGroup(nil, &shared.DeleteConsumerGroupRequest{
 				DestinationPath:   common.StringPtr(dstPath),
 				ConsumerGroupName: common.StringPtr(cg),
@@ -2155,7 +2150,7 @@ func (s *CassandraSuite) TestListConsumerGroups() {
 			assert.Nil(err, "Failed to delete consumer group")
 			fmt.Printf("DeleteConsumerGroupUUID: %v [%v]\n", cg, cgMap[cg])
 
-		case i < 7: // move CG to 'deleting' state
+		case i < 7: // mark these CGs 'deleted'
 			err = s.client.DeleteConsumerGroup(nil, &shared.DeleteConsumerGroupRequest{
 				DestinationPath:   common.StringPtr(dstPath),
 				ConsumerGroupName: common.StringPtr(cg),

--- a/clients/metadata/schema/metadata.cql
+++ b/clients/metadata/schema/metadata.cql
@@ -226,9 +226,12 @@ CREATE TYPE consumer_group (
 
 CREATE TABLE consumer_groups (
   uuid uuid PRIMARY KEY,
+  destination_uuid uuid,
   is_multi_zone boolean,
   consumer_group frozen<consumer_group>,
 );
+
+CREATE INDEX ON consumer_groups (destination_uuid);
 CREATE INDEX ON consumer_groups (is_multi_zone);
 
 CREATE TABLE consumer_groups_by_name (

--- a/clients/metadata/schema/v17/201708090000_destination_uuid_for_consumer_groups.cql
+++ b/clients/metadata/schema/v17/201708090000_destination_uuid_for_consumer_groups.cql
@@ -1,0 +1,2 @@
+ALTER TABLE consumer_groups ADD destination_uuid uuid;
+CREATE INDEX ON consumer_groups (destination_uuid);

--- a/clients/metadata/schema/v17/manifest.json
+++ b/clients/metadata/schema/v17/manifest.json
@@ -1,0 +1,8 @@
+{
+	"CurrVersion": 17,
+	"MinCompatibleVersion": 8,
+	"Description": "Add destination_uuid to consumer_groups",
+	"SchemaUpdateCqlFiles": [
+		"201708090000_destination_uuid_for_consumer_groups.cql"
+	]
+}

--- a/common/metadata/metaMetrics.go
+++ b/common/metadata/metaMetrics.go
@@ -106,6 +106,21 @@ func (m *metadataMetricsMgr) ListConsumerGroups(ctx thrift.Context, request *sha
 	return result, err
 }
 
+func (m *metadataMetricsMgr) ListConsumerGroupsUUID(ctx thrift.Context, request *shared.ListConsumerGroupsUUIDRequest) (result *shared.ListConsumerGroupsUUIDResult_, err error) {
+
+	m.m3.IncCounter(metrics.MetadataListConsumerGroupsUUIDScope, metrics.MetadataRequests)
+	sw := m.m3.StartTimer(metrics.MetadataListConsumerGroupsUUIDScope, metrics.MetadataLatency)
+	defer sw.Stop()
+
+	result, err = m.meta.ListConsumerGroupsUUID(ctx, request)
+
+	if err != nil {
+		m.m3.IncCounter(metrics.MetadataListConsumerGroupsUUIDScope, metrics.MetadataFailures)
+	}
+
+	return result, err
+}
+
 func (m *metadataMetricsMgr) ListDestinations(ctx thrift.Context, request *shared.ListDestinationsRequest) (result *shared.ListDestinationsResult_, err error) {
 
 	m.m3.IncCounter(metrics.MetadataListDestinationsScope, metrics.MetadataRequests)

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -129,6 +129,8 @@ const (
 	MetadataListAllConsumerGroupsScope
 	// MetadataListConsumerGroupsScope defines scope for an operation on metadata
 	MetadataListConsumerGroupsScope
+	// MetadataListConsumerGroupsUUIDScope defines scope for an operation on metadata
+	MetadataListConsumerGroupsUUIDScope
 	// MetadataListDestinationsScope defines scope for an operation on metadata
 	MetadataListDestinationsScope
 	// MetadataListDestinationsByUUIDScope defines scope for an operation on metadata
@@ -478,6 +480,7 @@ var scopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		MetadataHostAddrToUUIDScope:                    {operation: "MetadataHostAddrToUUID"},
 		MetadataListAllConsumerGroupsScope:             {operation: "MetadataListAllConsumerGroups"},
 		MetadataListConsumerGroupsScope:                {operation: "MetadataListConsumerGroups"},
+		MetadataListConsumerGroupsUUIDScope:            {operation: "MetadataListConsumerGroupsUUID"},
 		MetadataListDestinationsScope:                  {operation: "MetadataListDestinations"},
 		MetadataListDestinationsByUUIDScope:            {operation: "MetadataListDestinationsByUUID"},
 		MetadataListDestinationExtentsScope:            {operation: "MetadataListDestinationExtents"},

--- a/glide.lock
+++ b/glide.lock
@@ -134,7 +134,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: f3388f3727e988b990a63bc5d90fa41488e15092
+  version:  f3388f3727e988b990a63bc5d90fa41488e15092
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 07840224a45c283fa0896bf4a06c4da77803b9c89f11bdbedb1468c00ebd96dc
-updated: 2017-10-10T11:37:41.115964499-07:00
+hash: 53807892d07a54645b2869158c500bc4755c4c003d33bcf79ed8501d72f56c9b
+updated: 2017-10-10T12:12:14.744148612-07:00
 imports:
 - name: github.com/apache/thrift
   version: b2a4d4ae21c789b689dd162deb819665567f481c
@@ -134,7 +134,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version:  f3388f3727e988b990a63bc5d90fa41488e15092
+  version: ae427f7974d32a42a96f29f0f627e4d343fad8b2
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b4ac6cca4953caf65596799ec1216e88cc1f27efe83097737844d2da31d9429a
-updated: 2017-10-06T14:22:19.357459794-07:00
+hash: 07840224a45c283fa0896bf4a06c4da77803b9c89f11bdbedb1468c00ebd96dc
+updated: 2017-10-10T11:37:41.115964499-07:00
 imports:
 - name: github.com/apache/thrift
   version: b2a4d4ae21c789b689dd162deb819665567f481c
@@ -54,7 +54,7 @@ imports:
 - name: github.com/codegangsta/cli
   version: cf33a9befefdd6c6ea1a236ab6d546e797a62cbf
 - name: github.com/davecgh/go-spew
-  version: ecdeabc65495df2dec95d7c4a4c3e021903035e5
+  version: a476722483882dd40b8111f0eb64e1d7f43f56e4
   subpackages:
   - spew
 - name: github.com/dgryski/go-farm
@@ -134,7 +134,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: 45b0a9da65195b298b3967360a1a069907d5266a
+  version: f3388f3727e988b990a63bc5d90fa41488e15092
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami
@@ -176,7 +176,7 @@ imports:
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
-  version: a04bdaca5b32abe1c069418fb7088ae607de5bd0
+  version: 0a9397675ba34b2845f758fe3cd68828369c6517
   subpackages:
   - bpf
   - context

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
-hash: 53807892d07a54645b2869158c500bc4755c4c003d33bcf79ed8501d72f56c9b
-updated: 2017-10-10T12:12:14.744148612-07:00
+hash: df533b509cb758b1ac9fb478f628e40f1476a6569fb8073d87f830fee26a0dfc
+updated: 2017-10-20T10:20:43.667131555-07:00
 imports:
 - name: github.com/apache/thrift
   version: b2a4d4ae21c789b689dd162deb819665567f481c
   subpackages:
   - lib/go/thrift
 - name: github.com/aws/aws-sdk-go
-  version: 8a972b4459c2f2582b06f3e2d74448987cc6e19f
+  version: 011ff14652ceaed8ce090cef3f1d94ec9668bd83
   subpackages:
   - aws
   - aws/awserr
@@ -38,7 +38,7 @@ imports:
 - name: github.com/benbjohnson/clock
   version: 7dc76406b6d3c05b5f71a86293cbcf3c4ea03b19
 - name: github.com/bsm/sarama-cluster
-  version: 5efe630369ab4ed5cc4cedeadd61b4d1b2523169
+  version: c4d3d28d22e7bdea71656725bf5cd1d988454b41
 - name: github.com/cactus/go-statsd-client
   version: ce77ca9ecdee1c3ffd097e32f9bb832825ccb203
   subpackages:
@@ -52,9 +52,9 @@ imports:
 - name: github.com/cockroachdb/c-snappy
   version: c0cd3c9ce92f195001595e1fbbe66f045daad34f
 - name: github.com/codegangsta/cli
-  version: cf33a9befefdd6c6ea1a236ab6d546e797a62cbf
+  version: 0bdeddeeb0f650497d603c4ad7b20cfe685682f6
 - name: github.com/davecgh/go-spew
-  version: a476722483882dd40b8111f0eb64e1d7f43f56e4
+  version: ecdeabc65495df2dec95d7c4a4c3e021903035e5
   subpackages:
   - spew
 - name: github.com/dgryski/go-farm
@@ -68,9 +68,9 @@ imports:
 - name: github.com/eapache/queue
   version: 44cc805cf13205b55f69e14bcb69867d1ae92f98
 - name: github.com/go-ini/ini
-  version: d3de07a94d22b4a0972deb4b96d790c2c0ce8333
+  version: 5b3e00af70a9484542169a976dcab8d03e601a17
 - name: github.com/gocql/gocql
-  version: 3e8b36f5e9e52cdeb265f385808c504a53db55fc
+  version: 843f6b1d2288839f5d00f92be11cbbebd600ba51
   subpackages:
   - internal/lru
   - internal/murmur
@@ -91,11 +91,11 @@ imports:
   - ext
   - log
 - name: github.com/pborman/uuid
-  version: e790cca94e6cc75c7064b1332e63811d4aae1a53
+  version: a97ce2ca70fa5a848076093f05e639a89ca34d06
 - name: github.com/pierrec/lz4
-  version: 5a3d2245f97fc249850e7802e3c01fad02a1c316
+  version: 08c27939df1bd95e881e2c2367a749964ad1fceb
 - name: github.com/pierrec/xxHash
-  version: 5a004441f897722c627870a981d02b29924215fa
+  version: a0006b13c722f7f12368c00a3d3c2ae8a999a0c6
   subpackages:
   - xxHash32
 - name: github.com/pmezard/go-difflib
@@ -108,11 +108,11 @@ imports:
   version: bbdbe644099b7fdc8327d5cc69c030945188b2e9
   repo: http://github.com/Shopify/sarama
 - name: github.com/sirupsen/logrus
-  version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
+  version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: github.com/stretchr/objx
   version: 1a9d0bb9f541897e62256577b352fdbc1fb4fd94
 - name: github.com/stretchr/testify
-  version: 890a5c3458b43e6104ff5da8dfa139d013d77544
+  version: 2aa2c176b9dab406a6970f6a55f513e8a8c8b18f
   subpackages:
   - assert
   - mock
@@ -123,7 +123,7 @@ imports:
 - name: github.com/uber-common/bark
   version: 02d883c81a4e7b76904d97efb176efdf4be791bd
 - name: github.com/uber-go/atomic
-  version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
+  version: 54f72d32435d760d5604f17a82e2435b28dc4ba5
 - name: github.com/uber/cherami-client-go
   version: 05b8db6966cc3413c1105a809977febef05ca5a1
   subpackages:
@@ -171,12 +171,8 @@ imports:
   - tos
   - trand
   - typed
-- name: golang.org/x/crypto
-  version: 850760c427c516be930bc91280636328f1a62286
-  subpackages:
-  - ssh/terminal
 - name: golang.org/x/net
-  version: 0a9397675ba34b2845f758fe3cd68828369c6517
+  version: aabf50738bcdd9b207582cbe796b59ed65d56680
   subpackages:
   - bpf
   - context
@@ -185,13 +181,13 @@ imports:
   - ipv4
   - ipv6
 - name: golang.org/x/sys
-  version: 0b25a408a50076fbbcae6b7ac0ea5fbb0b085e79
+  version: 8dbc5d05d6edcc104950cc299a1ce6641235bc86
   subpackages:
   - unix
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/validator.v2
-  version: 07ffaad256c8e957050ad83d6472eb97d785013d
+  version: 460c83432a98c35224a6fe352acf8b23e067ad06
 - name: gopkg.in/yaml.v2
   version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -40,6 +40,7 @@ import:
   - common/websocket
   - stream
 - package: github.com/uber/cherami-thrift
+  version: f3388f3727e988b990a63bc5d90fa41488e15092
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/glide.yaml
+++ b/glide.yaml
@@ -40,7 +40,7 @@ import:
   - common/websocket
   - stream
 - package: github.com/uber/cherami-thrift
-  version: f3388f3727e988b990a63bc5d90fa41488e15092
+  version: ae427f7974d32a42a96f29f0f627e4d343fad8b2
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/services/retentionmgr/metadataDep.go
+++ b/services/retentionmgr/metadataDep.go
@@ -222,7 +222,7 @@ func (t *metadataDepImpl) GetExtentInfo(destID destinationID, extID extentID) (e
 
 func (t *metadataDepImpl) GetConsumerGroups(destID destinationID) (consumerGroups []*consumerGroupInfo) {
 
-	req := shared.NewListConsumerGroupRequest()
+	req := shared.NewListConsumerGroupsUUIDRequest()
 	req.DestinationUUID = common.StringPtr(string(destID))
 	req.Limit = common.Int64Ptr(defaultPageSize)
 	ctx, _ := thrift.NewContext(time.Second)
@@ -233,11 +233,11 @@ func (t *metadataDepImpl) GetConsumerGroups(destID destinationID) (consumerGroup
 	log := t.logger.WithField(common.TagDst, string(destID))
 
 	for {
-		log.Info("GetConsumerGroups: ListConsumerGroups on metadata")
+		log.Info("GetConsumerGroups: ListConsumerGroupsUUID on metadata")
 
-		res, err := t.metadata.ListConsumerGroups(ctx, req)
+		res, err := t.metadata.ListConsumerGroupsUUID(ctx, req)
 		if err != nil {
-			log.WithField(common.TagErr, err).Error("GetConsumerGroups: ListConsumerGroups failed")
+			log.WithField(common.TagErr, err).Error("GetConsumerGroups: ListConsumerGroupsUUID failed")
 			break
 		}
 
@@ -254,7 +254,7 @@ func (t *metadataDepImpl) GetConsumerGroups(destID destinationID) (consumerGroup
 			log.WithFields(bark.Fields{
 				common.TagCnsm: string(cg.id),
 				`status`:       cg.status,
-			}).Info(`GetConsumerGroups: ListConsumerGroups output`)
+			}).Info(`GetConsumerGroups: ListConsumerGroupsUUID output`)
 		}
 
 		if len(res.GetNextPageToken()) == 0 {
@@ -263,7 +263,7 @@ func (t *metadataDepImpl) GetConsumerGroups(destID destinationID) (consumerGroup
 
 		req.PageToken = res.GetNextPageToken()
 
-		log.Info("GetConsumerGroups: fetching next page of ListConsumerGroups")
+		log.Info("GetConsumerGroups: fetching next page of ListConsumerGroupsUUID")
 	}
 
 	log.WithField(`numConsumerGroups`, len(consumerGroups)).Info("GetConsumerGroups done")

--- a/services/retentionmgr/metadataDep.go
+++ b/services/retentionmgr/metadataDep.go
@@ -60,7 +60,7 @@ func (t *metadataDepImpl) GetDestinations() (destinations []*destinationInfo) {
 	i := 0
 	for {
 
-		log.Info("GetDestinations: ListDestinationsByUUID on metadata")
+		log.Debug("GetDestinations: ListDestinationsByUUID on metadata")
 
 		resp, err := t.metadata.ListDestinationsByUUID(ctx, req)
 		if err != nil {
@@ -97,7 +97,7 @@ func (t *metadataDepImpl) GetDestinations() (destinations []*destinationInfo) {
 
 		req.PageToken = resp.GetNextPageToken()
 
-		log.Info("GetDestinations: fetching next page of ListDestinationsByUUID")
+		log.Debug("GetDestinations: fetching next page of ListDestinationsByUUID")
 	}
 
 	log.WithField(`numDestinations`, len(destinations)).Info("GetDestinations done")
@@ -220,7 +220,7 @@ func (t *metadataDepImpl) GetExtentInfo(destID destinationID, extID extentID) (e
 	return
 }
 
-func (t *metadataDepImpl) GetConsumerGroups(destID destinationID) (consumerGroups []*consumerGroupInfo) {
+func (t *metadataDepImpl) GetConsumerGroups(destID destinationID) (consumerGroups []*consumerGroupInfo, err error) {
 
 	req := shared.NewListConsumerGroupsUUIDRequest()
 	req.DestinationUUID = common.StringPtr(string(destID))
@@ -266,7 +266,10 @@ func (t *metadataDepImpl) GetConsumerGroups(destID destinationID) (consumerGroup
 		log.Info("GetConsumerGroups: fetching next page of ListConsumerGroupsUUID")
 	}
 
-	log.WithField(`numConsumerGroups`, len(consumerGroups)).Info("GetConsumerGroups done")
+	log.WithFields(bark.Fields{
+		`numConsumerGroups`: len(consumerGroups),
+		common.TagErr:       err,
+	}).Info("GetConsumerGroups done")
 	return
 }
 
@@ -361,7 +364,10 @@ func (t *metadataDepImpl) GetExtentsForConsumerGroup(destID destinationID, cgID 
 		log.Info("GetExtentsForConsumerGroup: fetching next page of consumer-group extents")
 	}
 
-	log.WithField(`numExtents`, len(extIDs)).Info("GetExtentsForConsumerGroup done")
+	log.WithFields(bark.Fields{
+		`numExtents`:  len(extIDs),
+		common.TagErr: err,
+	}).Info("GetExtentsForConsumerGroup done")
 	return
 }
 
@@ -397,7 +403,7 @@ func (t *metadataDepImpl) DeleteConsumerGroupExtent(destID destinationID, cgID c
 func (t *metadataDepImpl) DeleteConsumerGroup(destID destinationID, cgID consumerGroupID) error {
 
 	req := metadata.NewDeleteConsumerGroupUUIDRequest()
-	req.UUID = common.StringPtr(string(destID))
+	req.UUID = common.StringPtr(string(cgID))
 
 	ctx, cancel := thrift.NewContext(2 * time.Second)
 	defer cancel()

--- a/services/retentionmgr/metadataDep.go
+++ b/services/retentionmgr/metadataDep.go
@@ -51,7 +51,7 @@ func newMetadataDep(metadata metadata.TChanMetadataService, log bark.Logger) *me
 }
 
 // -- the following are various helper routines, that talk to metadata, storehosts, etc -- //
-func (t *metadataDepImpl) GetDestinations() (destinations []*destinationInfo) {
+func (t *metadataDepImpl) GetDestinations() (destinations []*destinationInfo, err error) {
 
 	req := shared.NewListDestinationsByUUIDRequest()
 	req.Limit = common.Int64Ptr(defaultPageSize)
@@ -66,10 +66,10 @@ func (t *metadataDepImpl) GetDestinations() (destinations []*destinationInfo) {
 
 		log.Debug("GetDestinations: ListDestinationsByUUID on metadata")
 
-		resp, err := t.metadata.ListDestinationsByUUID(ctx, req)
-		if err != nil {
-			log.WithField(common.TagErr, err).Error(`GetDestinations: ListDestinationsByUUID failed`)
-			return
+		resp, err0 := t.metadata.ListDestinationsByUUID(ctx, req)
+		if err0 != nil {
+			log.WithField(common.TagErr, err0).Error(`GetDestinations: ListDestinationsByUUID failed`)
+			break
 		}
 
 		for _, destDesc := range resp.GetDestinations() {
@@ -104,7 +104,10 @@ func (t *metadataDepImpl) GetDestinations() (destinations []*destinationInfo) {
 		log.Debug("GetDestinations: fetching next page of ListDestinationsByUUID")
 	}
 
-	log.WithField(`numDestinations`, len(destinations)).Info("GetDestinations done")
+	log.WithFields(bark.Fields{
+		`numDestinations`: len(destinations),
+		common.TagErr:     err,
+	}).Info("GetDestinations done")
 	return
 }
 
@@ -352,9 +355,9 @@ func (t *metadataDepImpl) GetExtentsForConsumerGroup(destID destinationID, cgID 
 	for {
 		log.Info("GetExtentsForConsumerGroup: ReadConsumerGroupExtentsLite on metadata")
 
-		res, e := t.metadata.ReadConsumerGroupExtentsLite(ctx, req)
-		if e != nil {
-			err = e
+		res, err0 := t.metadata.ReadConsumerGroupExtentsLite(ctx, req)
+		if err0 != nil {
+			err = err0
 			log.WithField(common.TagErr, err).Error("GetExtentsForConsumerGroup: ReadConsumerGroupExtentsLite failed")
 			break
 		}

--- a/services/retentionmgr/metadataDep.go
+++ b/services/retentionmgr/metadataDep.go
@@ -60,7 +60,7 @@ func (t *metadataDepImpl) GetDestinations() (destinations []*destinationInfo) {
 	i := 0
 	for {
 
-		log.Debug("GetDestinations: ListDestinationsByUUID on metadata")
+		log.Info("GetDestinations: ListDestinationsByUUID on metadata")
 
 		resp, err := t.metadata.ListDestinationsByUUID(ctx, req)
 		if err != nil {
@@ -88,7 +88,7 @@ func (t *metadataDepImpl) GetDestinations() (destinations []*destinationInfo) {
 				`status`:        dest.status,
 				`hardRetention`: dest.hardRetention,
 				`softRetention`: dest.softRetention,
-			}).Debug("GetDestinations: ListDestinationsByUUID output")
+			}).Info("GetDestinations: ListDestinationsByUUID output")
 		}
 
 		if len(resp.GetNextPageToken()) == 0 {
@@ -97,10 +97,10 @@ func (t *metadataDepImpl) GetDestinations() (destinations []*destinationInfo) {
 
 		req.PageToken = resp.GetNextPageToken()
 
-		log.Debug("GetDestinations: fetching next page of ListDestinationsByUUID")
+		log.Info("GetDestinations: fetching next page of ListDestinationsByUUID")
 	}
 
-	log.WithField(`numDestinations`, len(destinations)).Debug("GetDestinations done")
+	log.WithField(`numDestinations`, len(destinations)).Info("GetDestinations done")
 	return
 }
 
@@ -119,7 +119,7 @@ func (t *metadataDepImpl) GetExtents(destID destinationID) (extents []*extentInf
 	i := 0
 
 	for {
-		log.Debug("GetExtents: ListExtentStats on metadata")
+		log.Info("GetExtents: ListExtentStats on metadata")
 
 		resp, err := t.metadata.ListExtentsStats(ctx, req)
 		if err != nil {
@@ -155,7 +155,7 @@ func (t *metadataDepImpl) GetExtents(destID destinationID) (extents []*extentInf
 				common.TagExt: string(extInfo.id),
 				`status`:      extInfo.status,
 				`replicas`:    extInfo.storehosts,
-			}).Debug(`GetExtents: ListExtentStats output`)
+			}).Info(`GetExtents: ListExtentStats output`)
 		}
 
 		if len(resp.GetNextPageToken()) == 0 {
@@ -164,10 +164,10 @@ func (t *metadataDepImpl) GetExtents(destID destinationID) (extents []*extentInf
 
 		req.PageToken = resp.GetNextPageToken()
 
-		log.Debug("GetExtents: fetching next page of ListExtentStats")
+		log.Info("GetExtents: fetching next page of ListExtentStats")
 	}
 
-	log.WithField(`numExtents`, len(extents)).Debug("GetExtents done")
+	log.WithField(`numExtents`, len(extents)).Info("GetExtents done")
 	return
 }
 
@@ -185,7 +185,7 @@ func (t *metadataDepImpl) GetExtentInfo(destID destinationID, extID extentID) (e
 		common.TagExt: string(extID),
 	})
 
-	log.Debug("GetExtentInfo: ReadExtentStats on metadata")
+	log.Info("GetExtentInfo: ReadExtentStats on metadata")
 
 	resp, err := t.metadata.ReadExtentStats(ctx, req)
 	if err != nil {
@@ -215,7 +215,7 @@ func (t *metadataDepImpl) GetExtentInfo(destID destinationID, extID extentID) (e
 		`extInfo.status`:            extInfo.status,
 		`extInfo.statusUpdatedTime`: extInfo.statusUpdatedTime,
 		`extInfo.storehosts`:        extInfo.storehosts,
-	}).Debug(`GetExtentInfo done`)
+	}).Info(`GetExtentInfo done`)
 
 	return
 }
@@ -233,7 +233,7 @@ func (t *metadataDepImpl) GetConsumerGroups(destID destinationID) (consumerGroup
 	log := t.logger.WithField(common.TagDst, string(destID))
 
 	for {
-		log.Debug("GetConsumerGroups: ListConsumerGroups on metadata")
+		log.Info("GetConsumerGroups: ListConsumerGroups on metadata")
 
 		res, err := t.metadata.ListConsumerGroups(ctx, req)
 		if err != nil {
@@ -254,7 +254,7 @@ func (t *metadataDepImpl) GetConsumerGroups(destID destinationID) (consumerGroup
 			log.WithFields(bark.Fields{
 				common.TagCnsm: string(cg.id),
 				`status`:       cg.status,
-			}).Debug(`GetConsumerGroups: ListConsumerGroups output`)
+			}).Info(`GetConsumerGroups: ListConsumerGroups output`)
 		}
 
 		if len(res.GetNextPageToken()) == 0 {
@@ -263,10 +263,10 @@ func (t *metadataDepImpl) GetConsumerGroups(destID destinationID) (consumerGroup
 
 		req.PageToken = res.GetNextPageToken()
 
-		log.Debug("GetConsumerGroups: fetching next page of ListConsumerGroups")
+		log.Info("GetConsumerGroups: fetching next page of ListConsumerGroups")
 	}
 
-	log.WithField(`numConsumerGroups`, len(consumerGroups)).Debug("GetConsumerGroups done")
+	log.WithField(`numConsumerGroups`, len(consumerGroups)).Info("GetConsumerGroups done")
 	return
 }
 
@@ -285,7 +285,7 @@ func (t *metadataDepImpl) DeleteExtent(destID destinationID, extID extentID) (er
 		common.TagExt: string(extID),
 	})
 
-	log.Debug("DeleteExtent: UpdateExtentStats on metadata")
+	log.Info("DeleteExtent: UpdateExtentStats on metadata")
 
 	resp, err := t.metadata.UpdateExtentStats(ctx, req)
 	if err != nil {
@@ -293,7 +293,7 @@ func (t *metadataDepImpl) DeleteExtent(destID destinationID, extID extentID) (er
 		return
 	}
 
-	log.WithField(`resp.status`, resp.GetExtentStats().GetStatus()).Debug(`DeleteExtent done`)
+	log.WithField(`resp.status`, resp.GetExtentStats().GetStatus()).Info(`DeleteExtent done`)
 	return
 }
 
@@ -312,7 +312,7 @@ func (t *metadataDepImpl) MarkExtentConsumed(destID destinationID, extID extentI
 		common.TagExt: string(extID),
 	})
 
-	log.Debug("MarkExtentConsumed: UpdateExtentStats on metadata")
+	log.Info("MarkExtentConsumed: UpdateExtentStats on metadata")
 
 	resp, err := t.metadata.UpdateExtentStats(ctx, req)
 	if err != nil {
@@ -320,7 +320,7 @@ func (t *metadataDepImpl) MarkExtentConsumed(destID destinationID, extID extentI
 		return
 	}
 
-	log.WithField(`resp.status`, resp.GetExtentStats().GetStatus()).Debug(`MarkExtentConsumed done`)
+	log.WithField(`resp.status`, resp.GetExtentStats().GetStatus()).Info(`MarkExtentConsumed done`)
 	return
 }
 
@@ -339,7 +339,7 @@ func (t *metadataDepImpl) GetExtentsForConsumerGroup(destID destinationID, cgID 
 	})
 
 	for {
-		log.Debug("GetExtentsForConsumerGroup: ReadConsumerGroupExtentsLite on metadata")
+		log.Info("GetExtentsForConsumerGroup: ReadConsumerGroupExtentsLite on metadata")
 
 		res, e := t.metadata.ReadConsumerGroupExtentsLite(ctx, req)
 		if e != nil {
@@ -358,10 +358,10 @@ func (t *metadataDepImpl) GetExtentsForConsumerGroup(destID destinationID, cgID 
 
 		req.PageToken = res.GetNextPageToken()
 
-		log.Debug("GetExtentsForConsumerGroup: fetching next page of consumer-group extents")
+		log.Info("GetExtentsForConsumerGroup: fetching next page of consumer-group extents")
 	}
 
-	log.WithField(`numExtents`, len(extIDs)).Debug("GetExtentsForConsumerGroup done")
+	log.WithField(`numExtents`, len(extIDs)).Info("GetExtentsForConsumerGroup done")
 	return
 }
 
@@ -381,7 +381,7 @@ func (t *metadataDepImpl) DeleteConsumerGroupExtent(destID destinationID, cgID c
 		common.TagExt:    string(extID),
 	})
 
-	log.Debug("DeleteConsumerGroupExtent: UpdateConsumerGroupExtentStatus on metadata")
+	log.Info("DeleteConsumerGroupExtent: UpdateConsumerGroupExtentStatus on metadata")
 
 	err := t.metadata.UpdateConsumerGroupExtentStatus(ctx, req)
 
@@ -390,7 +390,7 @@ func (t *metadataDepImpl) DeleteConsumerGroupExtent(destID destinationID, cgID c
 		return err
 	}
 
-	log.Debug("DeleteConsumerGroupExtent done")
+	log.Info("DeleteConsumerGroupExtent done")
 	return nil
 }
 
@@ -407,7 +407,7 @@ func (t *metadataDepImpl) DeleteConsumerGroup(destID destinationID, cgID consume
 		common.TagCnsmID: string(cgID),
 	})
 
-	log.Debug("DeleteConsumerGroup: DeleteConsumerGroupUUID on metadata")
+	log.Info("DeleteConsumerGroup: DeleteConsumerGroupUUID on metadata")
 
 	err := t.metadata.DeleteConsumerGroupUUID(ctx, req)
 
@@ -416,7 +416,7 @@ func (t *metadataDepImpl) DeleteConsumerGroup(destID destinationID, cgID consume
 		return err
 	}
 
-	log.Debug("DeleteConsumerGroup done")
+	log.Info("DeleteConsumerGroup done")
 	return nil
 }
 
@@ -430,7 +430,7 @@ func (t *metadataDepImpl) DeleteDestination(destID destinationID) error {
 
 	log := t.logger.WithField(common.TagDst, string(destID))
 
-	log.Debug("DeleteDestination: DeleteDestinationUUID on metadata")
+	log.Info("DeleteDestination: DeleteDestinationUUID on metadata")
 
 	err := t.metadata.DeleteDestinationUUID(ctx, req)
 
@@ -439,7 +439,7 @@ func (t *metadataDepImpl) DeleteDestination(destID destinationID) error {
 		return err
 	}
 
-	log.Debug("DeleteDestination done")
+	log.Info("DeleteDestination done")
 	return nil
 }
 
@@ -459,7 +459,7 @@ func (t *metadataDepImpl) GetAckLevel(destID destinationID, extID extentID, cgID
 		common.TagCnsmID: string(cgID),
 	})
 
-	log.Debug("GetAckLevel: ReadConsumerGroupExtent on metadata")
+	log.Info("GetAckLevel: ReadConsumerGroupExtent on metadata")
 
 	resp, err := t.metadata.ReadConsumerGroupExtent(ctx, req)
 	if err != nil {
@@ -490,6 +490,6 @@ func (t *metadataDepImpl) GetAckLevel(destID destinationID, extID extentID, cgID
 			Error("GetAckLevel: Unknown ConsumerGroupExtentStatus")
 	}
 
-	log.WithField(`ackLevel`, ackLevel).Debug("GetAckLevel done")
+	log.WithField(`ackLevel`, ackLevel).Info("GetAckLevel done")
 	return ackLevel, nil
 }

--- a/services/retentionmgr/mocks_test.go
+++ b/services/retentionmgr/mocks_test.go
@@ -115,7 +115,7 @@ func (_m *mockMetadataDep) MarkExtentConsumed(destID destinationID, extID extent
 	return r0
 }
 
-func (_m *mockMetadataDep) DeleteConsumerGroup(destID destinationID, cgID consumerGroupID) error {
+func (_m *mockMetadataDep) DeleteConsumerGroupUUID(destID destinationID, cgID consumerGroupID) error {
 	ret := _m.Called(destID, cgID)
 
 	var r0 error

--- a/services/retentionmgr/mocks_test.go
+++ b/services/retentionmgr/mocks_test.go
@@ -56,6 +56,26 @@ func (_m *mockMetadataDep) GetExtents(destID destinationID) []*extentInfo {
 
 	return r0
 }
+
+func (_m *mockMetadataDep) GetExtentsForConsumerGroup(destID destinationID, cgID consumerGroupID) (extIDs []extentID, err error) {
+	ret := _m.Called(destID, cgID)
+
+	var r0 []extentID
+	if rf, ok := ret.Get(0).(func(destinationID, consumerGroupID) []extentID); ok {
+		r0 = rf(destID, cgID)
+	} else {
+		r0 = ret.Get(0).([]extentID)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(destinationID, consumerGroupID) error); ok {
+		r1 = rf(destID, cgID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
 func (_m *mockMetadataDep) GetConsumerGroups(destID destinationID) []*consumerGroupInfo {
 	ret := _m.Called(destID)
 
@@ -94,6 +114,20 @@ func (_m *mockMetadataDep) MarkExtentConsumed(destID destinationID, extID extent
 
 	return r0
 }
+
+func (_m *mockMetadataDep) DeleteConsumerGroup(destID destinationID, cgID consumerGroupID) error {
+	ret := _m.Called(destID, cgID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(destinationID, consumerGroupID) error); ok {
+		r0 = rf(destID, cgID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 func (_m *mockMetadataDep) DeleteDestination(destID destinationID) error {
 	ret := _m.Called(destID)
 
@@ -107,12 +141,12 @@ func (_m *mockMetadataDep) DeleteDestination(destID destinationID) error {
 	return r0
 }
 
-func (_m *mockMetadataDep) DeleteConsumerGroupExtent(cgID consumerGroupID, extID extentID) error {
-	ret := _m.Called(cgID, extID)
+func (_m *mockMetadataDep) DeleteConsumerGroupExtent(destID destinationID, cgID consumerGroupID, extID extentID) error {
+	ret := _m.Called(destID, cgID, extID)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(consumerGroupID, extentID) error); ok {
-		r0 = rf(cgID, extID)
+	if rf, ok := ret.Get(0).(func(destinationID, consumerGroupID, extentID) error); ok {
+		r0 = rf(destID, cgID, extID)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/services/retentionmgr/mocks_test.go
+++ b/services/retentionmgr/mocks_test.go
@@ -28,7 +28,7 @@ type mockMetadataDep struct {
 	mock.Mock
 }
 
-func (_m *mockMetadataDep) GetDestinations() []*destinationInfo {
+func (_m *mockMetadataDep) GetDestinations() ([]*destinationInfo, error) {
 	ret := _m.Called()
 
 	var r0 []*destinationInfo
@@ -40,9 +40,16 @@ func (_m *mockMetadataDep) GetDestinations() []*destinationInfo {
 		}
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
-func (_m *mockMetadataDep) GetExtents(destID destinationID) []*extentInfo {
+func (_m *mockMetadataDep) GetExtents(destID destinationID) ([]*extentInfo, error) {
 	ret := _m.Called(destID)
 
 	var r0 []*extentInfo
@@ -54,10 +61,17 @@ func (_m *mockMetadataDep) GetExtents(destID destinationID) []*extentInfo {
 		}
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(destinationID) error); ok {
+		r1 = rf(destID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
-func (_m *mockMetadataDep) GetExtentsForConsumerGroup(destID destinationID, cgID consumerGroupID) (extIDs []extentID, err error) {
+func (_m *mockMetadataDep) GetExtentsForConsumerGroup(destID destinationID, cgID consumerGroupID) ([]extentID, error) {
 	ret := _m.Called(destID, cgID)
 
 	var r0 []extentID
@@ -76,7 +90,7 @@ func (_m *mockMetadataDep) GetExtentsForConsumerGroup(destID destinationID, cgID
 
 	return r0, r1
 }
-func (_m *mockMetadataDep) GetConsumerGroups(destID destinationID) []*consumerGroupInfo {
+func (_m *mockMetadataDep) GetConsumerGroups(destID destinationID) ([]*consumerGroupInfo, error) {
 	ret := _m.Called(destID)
 
 	var r0 []*consumerGroupInfo
@@ -88,7 +102,14 @@ func (_m *mockMetadataDep) GetConsumerGroups(destID destinationID) []*consumerGr
 		}
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(destinationID) error); ok {
+		r1 = rf(destID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 func (_m *mockMetadataDep) DeleteExtent(destID destinationID, extID extentID) error {
 	ret := _m.Called(destID, extID)

--- a/services/retentionmgr/retention.go
+++ b/services/retentionmgr/retention.go
@@ -86,7 +86,7 @@ type (
 		DeleteExtent(destID destinationID, extID extentID) (err error)
 		GetExtentsForConsumerGroup(dstID destinationID, cgID consumerGroupID) (extIDs []extentID, err error)
 		MarkExtentConsumed(destID destinationID, extID extentID) (err error)
-		DeleteConsumerGroup(destID destinationID, cgID consumerGroupID) error
+		DeleteConsumerGroupUUID(destID destinationID, cgID consumerGroupID) error
 		DeleteDestination(destID destinationID) (err error)
 		DeleteConsumerGroupExtent(destID destinationID, cgID consumerGroupID, extID extentID) error
 		GetAckLevel(destID destinationID, extID extentID, cgID consumerGroupID) (ackLevel int64, err error)
@@ -397,7 +397,7 @@ func (t *RetentionManager) runRetention(jobsC chan<- *retentionJob) bool {
 					common.TagCnsm: cg.id,
 				}).Info("deleting consumer-group (all cg-extents deleted)")
 
-				if e := t.metadata.DeleteConsumerGroup(dest.id, cg.id); e != nil {
+				if e := t.metadata.DeleteConsumerGroupUUID(dest.id, cg.id); e != nil {
 
 					log.WithFields(bark.Fields{
 						common.TagCnsm: cg.id,

--- a/services/retentionmgr/retention.go
+++ b/services/retentionmgr/retention.go
@@ -321,7 +321,7 @@ func (t *RetentionManager) runRetention(jobsC chan<- *retentionJob) bool {
 		// query consumer groups for the destination
 		cgs := t.metadata.GetConsumerGroups(dest.id)
 
-		t.logger.WithFields(bark.Fields{
+		log.WithFields(bark.Fields{
 			`numCGs`: len(cgs),
 		}).Info("GetConsumerGroups")
 
@@ -331,7 +331,7 @@ func (t *RetentionManager) runRetention(jobsC chan<- *retentionJob) bool {
 			log.WithFields(bark.Fields{
 				common.TagCnsm: cg.id,
 				`status`:       cg.status,
-			}).Info("GetConsumerGroups")
+			}).Info("processing cg")
 
 			if cg.status == shared.ConsumerGroupStatus_DELETED {
 				continue // ignore deleted CGs

--- a/services/retentionmgr/retention_test.go
+++ b/services/retentionmgr/retention_test.go
@@ -327,12 +327,12 @@ func (s *RetentionMgrSuite) TestRetentionManager() {
 	}
 
 	for _, cg := range consumerGroups {
-		s.metadata.On("DeleteConsumerGroupExtent", consumerGroupID(cg.id), extentID("EXT5")).Return(nil).Once()
-		s.metadata.On("DeleteConsumerGroupExtent", consumerGroupID(cg.id), extentID("EXT61")).Return(nil).Once()
-		s.metadata.On("DeleteConsumerGroupExtent", consumerGroupID(cg.id), extentID("EXT9")).Return(shared.NewEntityNotExistsError()).Once()
-		s.metadata.On("DeleteConsumerGroupExtent", consumerGroupID(cg.id), extentID("EXTA")).Return(shared.NewEntityNotExistsError()).Once()
-		s.metadata.On("DeleteConsumerGroupExtent", consumerGroupID(cg.id), extentID("EXTB")).Return(shared.NewBadRequestError()).Once()
-		s.metadata.On("DeleteConsumerGroupExtent", consumerGroupID(cg.id), extentID("EXTD")).Return(nil).Once()
+		s.metadata.On("DeleteConsumerGroupExtent", destinationID("DEST1"), consumerGroupID(cg.id), extentID("EXT5")).Return(nil).Once()
+		s.metadata.On("DeleteConsumerGroupExtent", destinationID("DEST1"), consumerGroupID(cg.id), extentID("EXT61")).Return(nil).Once()
+		s.metadata.On("DeleteConsumerGroupExtent", destinationID("DEST1"), consumerGroupID(cg.id), extentID("EXT9")).Return(shared.NewEntityNotExistsError()).Once()
+		s.metadata.On("DeleteConsumerGroupExtent", destinationID("DEST1"), consumerGroupID(cg.id), extentID("EXTA")).Return(shared.NewEntityNotExistsError()).Once()
+		s.metadata.On("DeleteConsumerGroupExtent", destinationID("DEST1"), consumerGroupID(cg.id), extentID("EXTB")).Return(shared.NewBadRequestError()).Once()
+		s.metadata.On("DeleteConsumerGroupExtent", destinationID("DEST1"), consumerGroupID(cg.id), extentID("EXTD")).Return(nil).Once()
 	}
 
 	// // DeleteConsumerGroupExtent on EXTA got an EntityNotExistsError, but it should still be deleted; while EXTB shouldn't
@@ -434,16 +434,16 @@ func (s *RetentionMgrSuite) TestRetentionManagerOnDeletedDestinations() {
 	}
 
 	for _, cg := range consumerGroupsDEST1 {
-		s.metadata.On("DeleteConsumerGroupExtent", consumerGroupID(cg.id), extentID("EXT1")).Return(nil).Once()
-		s.metadata.On("DeleteConsumerGroupExtent", consumerGroupID(cg.id), extentID("EXT2")).Return(nil).Once()
-		s.metadata.On("DeleteConsumerGroupExtent", consumerGroupID(cg.id), extentID("EXT3")).Return(nil).Once()
-		s.metadata.On("DeleteConsumerGroupExtent", consumerGroupID(cg.id), extentID("EXT4")).Return(nil).Once()
+		s.metadata.On("DeleteConsumerGroupExtent", destinationID("DEST1"), consumerGroupID(cg.id), extentID("EXT1")).Return(nil).Once()
+		s.metadata.On("DeleteConsumerGroupExtent", destinationID("DEST1"), consumerGroupID(cg.id), extentID("EXT2")).Return(nil).Once()
+		s.metadata.On("DeleteConsumerGroupExtent", destinationID("DEST1"), consumerGroupID(cg.id), extentID("EXT3")).Return(nil).Once()
+		s.metadata.On("DeleteConsumerGroupExtent", destinationID("DEST1"), consumerGroupID(cg.id), extentID("EXT4")).Return(nil).Once()
 	}
 
 	for _, cg := range consumerGroupsDEST2 {
-		s.metadata.On("DeleteConsumerGroupExtent", consumerGroupID(cg.id), extentID("EXT5")).Return(nil).Once()
-		s.metadata.On("DeleteConsumerGroupExtent", consumerGroupID(cg.id), extentID("EXT6")).Return(nil).Once()
-		s.metadata.On("DeleteConsumerGroupExtent", consumerGroupID(cg.id), extentID("EXT7")).Return(nil).Once()
+		s.metadata.On("DeleteConsumerGroupExtent", destinationID("DEST2"), consumerGroupID(cg.id), extentID("EXT5")).Return(nil).Once()
+		s.metadata.On("DeleteConsumerGroupExtent", destinationID("DEST2"), consumerGroupID(cg.id), extentID("EXT6")).Return(nil).Once()
+		s.metadata.On("DeleteConsumerGroupExtent", destinationID("DEST2"), consumerGroupID(cg.id), extentID("EXT7")).Return(nil).Once()
 	}
 
 	// s.metadata.On("DeleteExtent", destinationID("DEST1"), extentID("EXT1")).Return(nil).Once()

--- a/services/retentionmgr/retention_test.go
+++ b/services/retentionmgr/retention_test.go
@@ -160,8 +160,8 @@ func (s *RetentionMgrSuite) TestRetentionManager() {
 		s.metadata.On("GetExtentInfo", destinationID("DEST1"), ext).Return(&extInfo, nil).Once()
 	}
 
-	s.metadata.On("GetDestinations").Return(destinations).Once()
-	s.metadata.On("GetExtents", destinationID("DEST1")).Return(extents).Once()
+	s.metadata.On("GetDestinations").Return(destinations, nil).Once()
+	s.metadata.On("GetExtents", destinationID("DEST1")).Return(extents, nil).Once()
 
 	consumerGroups := []*consumerGroupInfo{
 		{id: "CG1", status: shared.ConsumerGroupStatus_ENABLED},
@@ -170,7 +170,7 @@ func (s *RetentionMgrSuite) TestRetentionManager() {
 		{id: "CGm", status: shared.ConsumerGroupStatus_ENABLED}, // Single CG Visible consumer group
 	}
 
-	s.metadata.On("GetConsumerGroups", destinationID("DEST1")).Return(consumerGroups)
+	s.metadata.On("GetConsumerGroups", destinationID("DEST1")).Return(consumerGroups, nil)
 
 	type gaftRet struct {
 		addr   int64
@@ -409,12 +409,12 @@ func (s *RetentionMgrSuite) TestRetentionManagerOnDeletedDestinations() {
 		}
 	}
 
-	s.metadata.On("GetDestinations").Return(destinations).Once()
-	s.metadata.On("GetExtents", destinationID("DEST1")).Return(extentsDEST1).Once()
-	s.metadata.On("GetConsumerGroups", destinationID("DEST1")).Return(consumerGroupsDEST1)
+	s.metadata.On("GetDestinations").Return(destinations, nil).Once()
+	s.metadata.On("GetExtents", destinationID("DEST1")).Return(extentsDEST1, nil).Once()
+	s.metadata.On("GetConsumerGroups", destinationID("DEST1")).Return(consumerGroupsDEST1, nil)
 
-	s.metadata.On("GetExtents", destinationID("DEST2")).Return(extentsDEST2).Once()
-	s.metadata.On("GetConsumerGroups", destinationID("DEST2")).Return(consumerGroupsDEST2)
+	s.metadata.On("GetExtents", destinationID("DEST2")).Return(extentsDEST2, nil).Once()
+	s.metadata.On("GetConsumerGroups", destinationID("DEST2")).Return(consumerGroupsDEST2, nil)
 
 	s.storehost.On("GetAddressFromTimestamp", storehostID(common.KafkaPhantomExtentStorehost), mock.AnythingOfType("extentID"), mock.AnythingOfType("int64")).Return(int64(store.ADDR_BEGIN), false, nil)
 	s.storehost.On("PurgeMessages", storehostID(common.KafkaPhantomExtentStorehost), mock.AnythingOfType("extentID"), mock.AnythingOfType("int64")).Return(int64(store.ADDR_BEGIN), nil)

--- a/test/mocks/metadata/TChanMetadataService.go
+++ b/test/mocks/metadata/TChanMetadataService.go
@@ -672,6 +672,29 @@ func (_m *TChanMetadataService) ListConsumerGroups(ctx thrift.Context, listReque
 	return r0, r1
 }
 
+// ListConsumerGroupsUUID returns all ConsumerGroups matching the given destination-uuid.
+func (_m *TChanMetadataService) ListConsumerGroupsUUID(ctx thrift.Context, listRequest *shared.ListConsumerGroupsUUIDRequest) (*shared.ListConsumerGroupsUUIDResult_, error) {
+	ret := _m.Called(ctx, listRequest)
+
+	var r0 *shared.ListConsumerGroupsUUIDResult_
+	if rf, ok := ret.Get(0).(func(thrift.Context, *shared.ListConsumerGroupsUUIDRequest) *shared.ListConsumerGroupsUUIDResult_); ok {
+		r0 = rf(ctx, listRequest)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*shared.ListConsumerGroupsUUIDResult_)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, *shared.ListConsumerGroupsUUIDRequest) error); ok {
+		r1 = rf(ctx, listRequest)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ListDestinations provides a mock function with given fields: ctx, listRequest
 func (_m *TChanMetadataService) ListDestinations(ctx thrift.Context, listRequest *shared.ListDestinationsRequest) (*shared.ListDestinationsResult_, error) {
 	ret := _m.Called(ctx, listRequest)

--- a/tools/cassandra/cqlclient.go
+++ b/tools/cassandra/cqlclient.go
@@ -76,7 +76,7 @@ func newCQLClient(config *SchemaUpdaterConfig) (CQLClient, error) {
 	clusterCfg.Keyspace = config.Keyspace
 	clusterCfg.Timeout = defaultTimeout
 	clusterCfg.ProtoVersion = config.ProtoVersion
-	clusterCfg.Consistency = gocql.ParseConsistency(defaultConsistency)
+	clusterCfg.Consistency, _ = gocql.ParseConsistency(defaultConsistency)
 
 	if config.Username != "" && config.Password != "" {
 		clusterCfg.Authenticator = gocql.PasswordAuthenticator{


### PR DESCRIPTION
This diff also adds a new API to list consumer-groups for a given destination-uuid -- the difference between this and the existing ListConsumerGroups API is that this one would look at the 'consumer_groups' table (instead of 'consumer_groups_by_name', that ListConsumerGroups look at).

Retention-manager uses this new API to query consumer-groups in 'deleting' state and takes appropriate action to 'delete' them.