### PR TITLE
Fix cg-id tag in consConn

### DIFF
--- a/services/outputhost/consconnection.go
+++ b/services/outputhost/consconnection.go
@@ -95,11 +95,8 @@ func newConsConnection(id int, cgCache *consumerGroupCache, stream serverStream.
 		cacheTimeout:             timeout,
 		closeChannel:             make(chan struct{}),
 		expiration:               time.Now().Add(timeout),
-		logger: logger.WithFields(bark.Fields{
-			common.TagCnsmID: common.FmtCnsmID(id),
-			common.TagModule: `consConn`,
-		}),
-		cgCache: cgCache,
+		logger:                   logger.WithField(common.TagModule, `consConn`),
+		cgCache:                  cgCache,
 	}
 
 	return conn

--- a/services/outputhost/replicaconnection.go
+++ b/services/outputhost/replicaconnection.go
@@ -95,7 +95,7 @@ func newReplicaConnection(stream storeStream.BStoreOpenReadStreamOutCall, extCac
 		name:                replicaConnectionName,
 		creditNotifyCh:      extCache.creditNotifyCh,
 		localCreditCh:       make(chan int32, 5),
-		logger:              logger.WithFields(bark.Fields{common.TagModule: `replConn`}),
+		logger:              logger.WithField(common.TagModule, `replConn`),
 		startingSequence:    startingSequence,
 		consumerM3Client:    extCache.consumerM3Client,
 	}


### PR DESCRIPTION
In consConn, we incorrectly/inadvertently overwrite the consumer-group uuid tag (that is already setup on the logger) with the "cgCache ID" .. causing logs to contain spurious numbers instead of the actual cg-uuid.