### PR TITLE
Plug hole that allowed concurrent replication streams

### DIFF
--- a/services/storehost/extMgr.go
+++ b/services/storehost/extMgr.go
@@ -378,8 +378,7 @@ func (xMgr *ExtentManager) closeExtent(ext *extentContext, intent OpenIntent, op
 		xMgr.hostMetrics.Decrement(load.HostMetricNumReadConns)
 
 	case OpenIntentReplicateExtent:
-
-		if openError != nil {
+		if openError == nil {
 			// mark as not open for replication
 			atomic.StoreInt32(&ext.openedForReplication, 0)
 		}

--- a/services/storehost/extMgr.go
+++ b/services/storehost/extMgr.go
@@ -320,8 +320,11 @@ retryOpen:
 		if !exists {
 			numExtents := atomic.AddInt64(&xMgr.numExtents, 1)
 			xMgr.m3Client.UpdateGauge(metrics.ExtentManagerScope, metrics.StorageOpenExtents, numExtents) // metrics
-			xMgr.logger.WithField("context", fmt.Sprintf("ext=%v numExtents=%d", id, numExtents)).
-				Info("ExtMgr: extent opened")
+			xMgr.logger.WithFields(bark.Fields{
+				common.TagExt: id,
+				`intent`:      intent,
+				`numExtents`:  numExtents,
+			}).Info("ExtMgr: extent opened")
 		}
 
 		// no errors -> move on

--- a/services/storehost/replicate.go
+++ b/services/storehost/replicate.go
@@ -208,7 +208,7 @@ func (t *ReplicationJob) Start() error {
 
 	var beginKey storage.Key // key to start replicating from
 
-	if t.ext.getLastSeqNum() != SeqNumInvalid {
+	if t.ext.getLastSeqNum() != SeqnumInvalid {
 
 		// if we already have the extent, it's likely because we failed during
 		// replication. in order to resume replication, find the address of the
@@ -306,7 +306,7 @@ func (t *ReplicationJob) replicationPump() {
 	lastCreditUpdate := time.Now()
 
 	var done bool
-	var firstMsg = (t.ext.getLastSeqNum() == SeqNumInvalid)
+	var firstMsg = (t.ext.getLastSeqNum() == SeqnumInvalid)
 
 pump:
 	for {
@@ -377,10 +377,8 @@ pump:
 			x.setSealSeqNum(sealSeqNum) // save sealSeqNum
 
 			log.WithFields(bark.Fields{
-				`reason`:      `extent sealed`,
 				`seal-seqnum`: sealSeqNum,
-				`replMsgs`:    replMsgs,
-			}).Info(`replicationPump done`)
+			}).Info(`replicationPump: extent sealed`)
 
 			// now try to mark the replication status as 'done' so that the job won't be scheduled again
 			t.updateReplicationStatus(t.extentID.String(), shared.ExtentReplicaReplicationStatus_DONE)
@@ -402,11 +400,10 @@ pump:
 		default:
 			t.err = fmt.Errorf("unknown ReadMessageContentType: %v", readMsg.GetType())
 			log.WithFields(bark.Fields{
-				`reason`:       `unknown ReadMessageContentType`,
 				common.TagErr:  t.err,
 				`readmsg-type`: readMsg.GetType(),
 				`replMsgs`:     replMsgs,
-			}).Error(`replicationPump done`)
+			}).Error(`unknown ReadMessageContentType`)
 			done = true
 			continue pump
 		}


### PR DESCRIPTION
- fix for concurrent replication streams
- update the 'first seqnum' in replication code-path (this was missing)
- added more logs around open/close extent