### PR TITLE
Fix retryableEventHandler logic

### DIFF
--- a/services/controllerhost/event_pipeline.go
+++ b/services/controllerhost/event_pipeline.go
@@ -276,13 +276,9 @@ func (executor *retryableEventExecutor) execute(event Event) {
 		context.m3Client.IncCounter(metrics.EventPipelineScope, metrics.ControllerRetries)
 
 		err = event.Handle(executor.context)
-		if err == nil {
+		if err != errRetryable || !executor.sleep(computeRetryInterval()) {
+			// break if non retryable event, or retryable, but cannot sleep due to shut down
 			break
-		}
-		if err == errRetryable {
-			if !executor.sleep(computeRetryInterval()) {
-				break
-			}
 		}
 	}
 


### PR DESCRIPTION
If event.Handle() returns non-retryable error, the original logic will immediately retry because the case is not handled.