### PR TITLE
Stop controller from placing extents on readonly stores

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b4ac6cca4953caf65596799ec1216e88cc1f27efe83097737844d2da31d9429a
-updated: 2017-10-24T15:20:10.812837238-07:00
+hash: d0c29905b07aed1278050c3471afb0f75bcaa2288b9e1394fa9eee1d52a55fa3
+updated: 2017-11-16T11:59:10.262960188-08:00
 imports:
 - name: github.com/apache/thrift
   version: b2a4d4ae21c789b689dd162deb819665567f481c
@@ -105,7 +105,7 @@ imports:
 - name: github.com/rcrowley/go-metrics
   version: 1f30fe9094a513ce4c700b9a54458bbb0c96996c
 - name: github.com/Shopify/sarama
-  version: bbdbe644099b7fdc8327d5cc69c030945188b2e9
+  version: 240fd146ce68bcafb034cc5dc977229ffbafa8ea
   repo: http://github.com/Shopify/sarama
 - name: github.com/sirupsen/logrus
   version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
@@ -134,7 +134,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: ae427f7974d32a42a96f29f0f627e4d343fad8b2
+  version: ce2fc989809bb711289c2420c8979ef37bcf5b61
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami
@@ -174,7 +174,7 @@ imports:
 - name: github.com/urfave/cli
   version: 7bc6a0acffa589f415f88aca16cc1de5ffd66f9c
 - name: golang.org/x/net
-  version: aabf50738bcdd9b207582cbe796b59ed65d56680
+  version: a337091b0525af65de94df2eb7e98bd9962dcbe2
   subpackages:
   - bpf
   - context

--- a/glide.yaml
+++ b/glide.yaml
@@ -40,6 +40,7 @@ import:
   - common/websocket
   - stream
 - package: github.com/uber/cherami-thrift
+  version: ce2fc989809bb711289c2420c8979ef37bcf5b61
   subpackages:
   - .generated/go/admin
   - .generated/go/cherami

--- a/services/controllerhost/controllerhost.go
+++ b/services/controllerhost/controllerhost.go
@@ -555,7 +555,7 @@ func (mcp *Mcp) ReportNodeMetric(ctx thrift.Context, request *c.ReportNodeMetric
 	if metrics.IsSetOutgoingBytesCounter() {
 		loadMetrics.Put(hostID, load.EmptyTag, load.BytesOutPerSec, metrics.GetOutgoingBytesCounter(), timestamp)
 	}
-	if metrics.IsSetNodeState() && (metrics.GetNodeState()&c.NODE_STATE_READONLY) != 0 {
+	if metrics.IsSetNodeState() && metrics.GetNodeState()&c.NODE_STATE_READONLY != 0 {
 		loadMetrics.Put(hostID, load.EmptyTag, load.ReadOnly, 1, timestamp)
 	}
 	if metrics.IsSetNodeStatus() && request.IsSetRole() && metrics.GetNodeStatus() == c.NodeStatus_GOING_DOWN {

--- a/services/controllerhost/controllerhost.go
+++ b/services/controllerhost/controllerhost.go
@@ -537,6 +537,9 @@ func (mcp *Mcp) ReportNodeMetric(ctx thrift.Context, request *c.ReportNodeMetric
 	if metrics.IsSetRemainingDiskSpace() {
 		loadMetrics.Put(hostID, load.EmptyTag, load.RemDiskSpaceBytes, metrics.GetRemainingDiskSpace(), timestamp)
 	}
+	if metrics.IsSetRemainingDiskSpace() {
+		loadMetrics.Put(hostID, load.EmptyTag, load.RemDiskSpaceBytes, metrics.GetRemainingDiskSpace(), timestamp)
+	}
 	if metrics.IsSetNumberOfActiveExtents() {
 		loadMetrics.Put(hostID, load.EmptyTag, load.NumExtentsActive, metrics.GetNumberOfActiveExtents(), timestamp)
 	}
@@ -554,6 +557,9 @@ func (mcp *Mcp) ReportNodeMetric(ctx thrift.Context, request *c.ReportNodeMetric
 	}
 	if metrics.IsSetOutgoingBytesCounter() {
 		loadMetrics.Put(hostID, load.EmptyTag, load.BytesOutPerSec, metrics.GetOutgoingBytesCounter(), timestamp)
+	}
+	if metrics.IsSetNodeState() && (metrics.GetNodeState()&c.NODE_STATE_READONLY) != 0 {
+		loadMetrics.Put(hostID, load.EmptyTag, load.ReadOnly, 1, timestamp)
 	}
 	if metrics.IsSetNodeStatus() && request.IsSetRole() && metrics.GetNodeStatus() == c.NodeStatus_GOING_DOWN {
 		switch request.GetRole() {

--- a/services/controllerhost/controllerhost.go
+++ b/services/controllerhost/controllerhost.go
@@ -537,9 +537,6 @@ func (mcp *Mcp) ReportNodeMetric(ctx thrift.Context, request *c.ReportNodeMetric
 	if metrics.IsSetRemainingDiskSpace() {
 		loadMetrics.Put(hostID, load.EmptyTag, load.RemDiskSpaceBytes, metrics.GetRemainingDiskSpace(), timestamp)
 	}
-	if metrics.IsSetRemainingDiskSpace() {
-		loadMetrics.Put(hostID, load.EmptyTag, load.RemDiskSpaceBytes, metrics.GetRemainingDiskSpace(), timestamp)
-	}
 	if metrics.IsSetNumberOfActiveExtents() {
 		loadMetrics.Put(hostID, load.EmptyTag, load.NumExtentsActive, metrics.GetNumberOfActiveExtents(), timestamp)
 	}

--- a/services/controllerhost/load/types.go
+++ b/services/controllerhost/load/types.go
@@ -82,12 +82,14 @@ const (
 )
 
 const (
-	// NumConns is a guage that refers to number of connections
+	// NumConns is a gauge that refers to number of connections
 	NumConns MetricName = "numConns"
-	// NumExtentsActive is a guage that refers to number of active extents
+	// NumExtentsActive is a gauge that refers to number of active extents
 	NumExtentsActive = "numExtentsActive"
-	// RemDiskSpaceBytes is a guage that refers to remaining disk space
+	// RemDiskSpaceBytes is a gauge that refers to remaining disk space
 	RemDiskSpaceBytes = "remDiskSpaceBytes"
+	// ReadOnly is a (boolean) gauge that specifies if the store is read-only
+	ReadOnly = "readOnly"
 
 	// MsgsInPerSec refers to incoming messages per sec counter
 	MsgsInPerSec MetricName = "msgsInPerSec"

--- a/services/storehost/storehost.go
+++ b/services/storehost/storehost.go
@@ -1338,6 +1338,12 @@ func (t *StoreHost) reportHostMetric(reporter common.LoadReporter, diffSecs int6
 		OutgoingBytesCounter:    common.Int64Ptr(bytesOutPerSec),
 		NumberOfConnections:     common.Int64Ptr(numConns),
 		NodeStatus:              common.NodeStatusPtr(t.GetNodeStatus()),
+		NodeState:               common.Int64Ptr(0),
+	}
+
+	// check and notify read-only state
+	if t.storageMonitor.GetStorageMode() == SMReadOnly {
+		hostMetrics.NodeState = common.Int64Ptr(controller.NODE_STATE_READONLY)
 	}
 
 	remDiskSpaceBytes := t.hostMetrics.Get(load.HostMetricFreeDiskSpaceBytes)


### PR DESCRIPTION
- storehosts that are 'read-only' (due to low-space), would emit a (new) node-metric to controller
- controller would stop placing extents on stores that are read-only

This change relies on a thrift change, tracked by this PR:
https://github.com/uber/cherami-thrift/pull/29

