### PR TITLE
Fix some logging

### DIFF
--- a/services/outputhost/messagecache.go
+++ b/services/outputhost/messagecache.go
@@ -751,6 +751,7 @@ func (msgCache *cgMsgCache) manageMessageDeliveryCache() {
 
 		if fullCount > 3 && common.Now()-lastPumpHealthLog > common.UnixNanoTime(time.Minute) {
 			msgCache.logMessageCacheHealth()
+			lastPumpHealthLog = common.Now()
 		}
 
 		numOutstandingMsgs := msgCache.getOutstandingMsgs()

--- a/services/outputhost/outputhost.go
+++ b/services/outputhost/outputhost.go
@@ -242,12 +242,7 @@ func (h *OutputHost) OpenConsumerStreamHandler(w http.ResponseWriter, r *http.Re
 	})
 
 	// create thrift stream call wrapper and deligate to streaming call
-	if err = h.OpenConsumerStream(ctx, wsStream); err != nil {
-		h.logger.WithField(common.TagDstPth, common.FmtDstPth(path)).
-			WithField(common.TagCnsPth, common.FmtCnsPth(cgName)).
-			WithField(common.TagErr, err).Error("unable to open consume stream")
-		/* Metrics will be logged in OpenConsumerStream*/
-	}
+	h.OpenConsumerStream(ctx, wsStream)
 }
 
 // OpenConsumerStream is the implementation of the thrift handler for the Out service


### PR DESCRIPTION
1. messagecache.go: the code intended to rate limit logging to be once per minute, but it forgets to save the last logging timestamp.
2. outputhost.go: OpenConsumerStreamHandler() need not re-log whatever error in OpenConsumerStream() that is already logged.