### PR TITLE
cmq: lots of various fixes

### DIFF
--- a/cmd/tools/cmq/ansi.go
+++ b/cmd/tools/cmq/ansi.go
@@ -4,49 +4,73 @@ import (
 	"fmt"
 )
 
+// SaveScreen saves the screen
 func SaveScreen() {
 	print(`\x1b[?47h`)
 }
 
+// RestoreScreen restores saved screen
 func RestoreScreen() {
 	print(`\x1b[?47l`)
 }
+
+// ClearScreen clears screen
 func ClearScreen() {
 	print("\x1b[H;2J\x1b[2J") // clear screen and move cursor to (0,0)
 }
 
+// MoveCursor moves cursor to specified row/col
 func MoveCursor(row, col int) {
 	fmt.Printf("\x1b[%d;%dH", row, col)
 }
 
 const (
+	// Black color
 	Black = iota
+	// Red color
 	Red
+	// Green color
 	Green
+	// Yellow color
 	Yellow
+	// Blue color
 	Blue
+	// Magenta color
 	Magenta
+	// Cyan color
 	Cyan
+	// White color
 	White
+	// BrightBlack color
 	BrightBlack
+	// BrightRed color
 	BrightRed
+	// BrightGreen color
 	BrightGreen
+	// BrightYellow color
 	BrightYellow
+	// BrightBlue color
 	BrightBlue
+	// BrightMagenta color
 	BrightMagenta
+	// BrightCyan color
 	BrightCyan
+	// BrightWhite color
 	BrightWhite
 )
 
+// AnsiCtrlSeq holds an ansi control sequence
 type AnsiCtrlSeq struct {
 	text string
 	ansi []int
 }
 
+// Text takes a string to use with ansi control sequence
 func Text(text string) *AnsiCtrlSeq {
 	return &AnsiCtrlSeq{text: text}
 }
 
+// String returns the string to output with the appropriate ansi control sequences
 func (t *AnsiCtrlSeq) String() string {
 
 	const (
@@ -79,11 +103,13 @@ func (t *AnsiCtrlSeq) String() string {
 	}
 }
 
+// Width truncates to specified width
 func (t *AnsiCtrlSeq) Width(w int) *AnsiCtrlSeq {
 	t.text = fmt.Sprintf("%*s", w, t.text)
 	return t
 }
 
+// Color adds specified foreground color to text
 func (t *AnsiCtrlSeq) Color(color int) *AnsiCtrlSeq {
 
 	if color <= White {
@@ -94,6 +120,7 @@ func (t *AnsiCtrlSeq) Color(color int) *AnsiCtrlSeq {
 	return t.Color(30 + color - BrightBlack).Bold()
 }
 
+// Background adds specified background color to text
 func (t *AnsiCtrlSeq) Background(color int) *AnsiCtrlSeq {
 
 	if color <= White {
@@ -105,44 +132,23 @@ func (t *AnsiCtrlSeq) Background(color int) *AnsiCtrlSeq {
 	return t.Background(40 + color - White)
 }
 
+// Underline underlines text
 func (t *AnsiCtrlSeq) Underline() *AnsiCtrlSeq {
 
 	t.ansi = append(t.ansi, 4)
 	return t
 }
 
+// Bold emboldens the text
 func (t *AnsiCtrlSeq) Bold() *AnsiCtrlSeq {
 
 	t.ansi = append(t.ansi, 1)
 	return t
 }
 
+// Blink makes text blink
 func (t *AnsiCtrlSeq) Blink() *AnsiCtrlSeq {
 
 	t.ansi = append(t.ansi, 5)
-	return t
-}
-
-func (t *AnsiCtrlSeq) FastBlink() *AnsiCtrlSeq {
-
-	t.ansi = append(t.ansi, 6)
-	return t
-}
-
-func (t *AnsiCtrlSeq) Reverse() *AnsiCtrlSeq {
-
-	t.ansi = append(t.ansi, 7)
-	return t
-}
-
-func (t *AnsiCtrlSeq) AltFont() *AnsiCtrlSeq {
-
-	t.ansi = append(t.ansi, 12)
-	return t
-}
-
-func (t *AnsiCtrlSeq) Overlined() *AnsiCtrlSeq {
-
-	t.ansi = append(t.ansi, 53)
 	return t
 }

--- a/cmd/tools/cmq/ansi.go
+++ b/cmd/tools/cmq/ansi.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"fmt"
+)
+
+func SaveScreen() {
+	print(`\x1b[?47h`)
+}
+
+func RestoreScreen() {
+	print(`\x1b[?47l`)
+}
+func ClearScreen() {
+	print("\x1b[H;2J\x1b[2J") // clear screen and move cursor to (0,0)
+}
+
+func MoveCursor(row, col int) {
+	fmt.Printf("\x1b[%d;%dH", row, col)
+}
+
+const (
+	Black = iota
+	Red
+	Green
+	Yellow
+	Blue
+	Magenta
+	Cyan
+	White
+	BrightBlack
+	BrightRed
+	BrightGreen
+	BrightYellow
+	BrightBlue
+	BrightMagenta
+	BrightCyan
+	BrightWhite
+)
+
+type AnsiCtrlSeq struct {
+	text string
+	ansi []int
+}
+
+func Text(text string) *AnsiCtrlSeq {
+	return &AnsiCtrlSeq{text: text}
+}
+
+func (t *AnsiCtrlSeq) String() string {
+
+	const (
+		start = "\x1b["
+		end   = "m"
+		reset = start + end
+	)
+
+	switch len(t.ansi) {
+	case 0:
+		return t.text
+
+	case 1:
+		return start + fmt.Sprintf("%d", t.ansi[0]) + end + t.text + reset
+
+	default:
+
+		var str = start
+
+		for i, c := range t.ansi {
+
+			if i > 0 {
+				str += ";"
+			}
+
+			str += fmt.Sprintf("%d", c)
+		}
+
+		return str + end + t.text + reset
+	}
+}
+
+func (t *AnsiCtrlSeq) Width(w int) *AnsiCtrlSeq {
+	t.text = fmt.Sprintf("%*s", w, t.text)
+	return t
+}
+
+func (t *AnsiCtrlSeq) Color(color int) *AnsiCtrlSeq {
+
+	if color <= White {
+		t.ansi = append(t.ansi, 30+color)
+		return t
+	}
+
+	return t.Color(30 + color - BrightBlack).Bold()
+}
+
+func (t *AnsiCtrlSeq) Background(color int) *AnsiCtrlSeq {
+
+	if color <= White {
+		t.ansi = append(t.ansi, 40+color)
+		return t
+	}
+
+	// can't do "bright" background; so just use plain
+	return t.Background(40 + color - White)
+}
+
+func (t *AnsiCtrlSeq) Underline() *AnsiCtrlSeq {
+
+	t.ansi = append(t.ansi, 4)
+	return t
+}
+
+func (t *AnsiCtrlSeq) Bold() *AnsiCtrlSeq {
+
+	t.ansi = append(t.ansi, 1)
+	return t
+}
+
+func (t *AnsiCtrlSeq) Blink() *AnsiCtrlSeq {
+
+	t.ansi = append(t.ansi, 5)
+	return t
+}
+
+func (t *AnsiCtrlSeq) FastBlink() *AnsiCtrlSeq {
+
+	t.ansi = append(t.ansi, 6)
+	return t
+}
+
+func (t *AnsiCtrlSeq) Reverse() *AnsiCtrlSeq {
+
+	t.ansi = append(t.ansi, 7)
+	return t
+}
+
+func (t *AnsiCtrlSeq) AltFont() *AnsiCtrlSeq {
+
+	t.ansi = append(t.ansi, 12)
+	return t
+}
+
+func (t *AnsiCtrlSeq) Overlined() *AnsiCtrlSeq {
+
+	t.ansi = append(t.ansi, 53)
+	return t
+}

--- a/cmd/tools/cmq/commands.go
+++ b/cmd/tools/cmq/commands.go
@@ -63,7 +63,6 @@ var cmqOptions = []cli.Flag{
 	cli.StringSliceFlag{
 		Name:   "output, out, o",
 		Usage:  "cmq output format: short, json, cql, undo, none [default: json]",
-		Value:  &cli.StringSlice{"json"},
 		EnvVar: "CMQ_OUTPUT",
 	},
 }

--- a/cmd/tools/cmq/commands.go
+++ b/cmd/tools/cmq/commands.go
@@ -42,7 +42,7 @@ var cmqOptions = []cli.Flag{
 	},
 	cli.StringFlag{
 		Name:   "keyspace, env, k",
-		Usage:  "Cassandra keyspace suffix (ex: 'cherami_staging_dca1a')",
+		Usage:  "Cassandra keyspace",
 		EnvVar: "CHERAMI_KEYSPACE",
 	},
 	cli.DurationFlag{
@@ -499,17 +499,109 @@ var cmqCommands = []cli.Command{
 	cli.Command{
 		Name:    "destination",
 		Aliases: []string{"d"},
-		Action:  showDestination,
+		Flags: []cli.Flag{
+			cli.StringSliceFlag{
+				Name:  "destination, dest, dst, d",
+				Usage: "destination uuid(s)",
+			},
+			cli.StringSliceFlag{
+				Name:  "path, p, n",
+				Usage: "destination path(s)",
+			},
+			cli.StringSliceFlag{
+				Name:  "status, s",
+				Usage: "destination status (enabled, disabled, sendonly, receiveonly, deleting, deleted) ",
+			},
+			cli.StringSliceFlag{
+				Name:  "type, t",
+				Usage: "destination type (plain, timer, log)",
+			},
+			cli.BoolFlag{
+				Name:  "multizone, mz",
+				Usage: "multizone",
+			},
+		},
+		Action: listDestinations,
 	},
 	cli.Command{
 		Name:    "consumergroup",
 		Aliases: []string{"cg"},
-		Action:  showConsumerGroup,
+		Flags: []cli.Flag{
+			cli.StringSliceFlag{
+				Name:  "consumergroup, cg",
+				Usage: "consumer-group uuid(s)",
+			},
+			cli.StringSliceFlag{
+				Name:  "name, n, p",
+				Usage: "consumer-group name(s)",
+			},
+			cli.StringSliceFlag{
+				Name:  "destination, dest, dst, d",
+				Usage: "destination uuid(s)",
+			},
+			cli.StringSliceFlag{
+				Name:  "status, s",
+				Usage: "status",
+			},
+		},
+		Action: listConsumerGroups,
 	},
 	cli.Command{
 		Name:    "extent",
 		Aliases: []string{"x"},
-		Action:  showExtent,
+		Flags: []cli.Flag{
+			cli.StringSliceFlag{
+				Name:  "destination, dest, dst, d",
+				Usage: "destination uuid(s)",
+			},
+			cli.StringSliceFlag{
+				Name:  "extent, e, x",
+				Usage: "extent uuid(s)",
+			},
+			cli.StringSliceFlag{
+				Name:  "status, s",
+				Usage: "status",
+			},
+		},
+		Action: listDestinationExtents,
+	},
+	cli.Command{
+		Name:    "cgextents",
+		Aliases: []string{"cgx"},
+		Flags: []cli.Flag{
+			cli.StringSliceFlag{
+				Name:  "consumergroup, cg",
+				Usage: "consumer-group uuid(s)",
+			},
+			cli.StringSliceFlag{
+				Name:  "extent, e, x",
+				Usage: "extent uuid(s)",
+			},
+			cli.StringSliceFlag{
+				Name:  "status, s",
+				Usage: "status",
+			},
+		},
+		Action: listConsumerGroupExtents,
+	},
+	cli.Command{
+		Name:    "storeextents",
+		Aliases: []string{"sx"},
+		Flags: []cli.Flag{
+			cli.StringSliceFlag{
+				Name:  "store",
+				Usage: "store uuid(s)",
+			},
+			cli.StringSliceFlag{
+				Name:  "extent, e, x",
+				Usage: "extent uuid(s)",
+			},
+			cli.StringSliceFlag{
+				Name:  "status, s",
+				Usage: "status",
+			},
+		},
+		Action: listStoreExtents,
 	},
 	cli.Command{
 		Name:   "stats",

--- a/cmd/tools/cmq/commands.go
+++ b/cmd/tools/cmq/commands.go
@@ -62,7 +62,7 @@ var cmqOptions = []cli.Flag{
 	},
 	cli.StringSliceFlag{
 		Name:   "output, out, o",
-		Usage:  "cmq output format: short, json, cql, undo, none [default: json]",
+		Usage:  "cmq output format: short, json, cql, delete, undo, none [default: json]",
 		EnvVar: "CMQ_OUTPUT",
 	},
 }

--- a/cmd/tools/cmq/gc.go
+++ b/cmd/tools/cmq/gc.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/gocql/gocql"
+	"github.com/uber/cherami-server/common/set"
 	"github.com/uber/cherami-thrift/.generated/go/shared"
 	"github.com/urfave/cli"
 )
@@ -63,6 +64,21 @@ func gc(c *cli.Context) error {
 	defer mc.Close()
 
 	// lookup tables
+
+	type (
+		cgExtentRow struct {
+			cgUUID, extUUID string
+		}
+
+		inputExtentRow struct {
+			destUUID, inputUUID string
+		}
+
+		storeExtentRow struct {
+			storeUUID, extUUID string
+		}
+	)
+
 	var (
 		destPaths   = make(map[string]string)   // dest-uuid to path
 		cgPaths     = make(map[string]string)   // cg-uuid to path
@@ -71,24 +87,22 @@ func gc(c *cli.Context) error {
 		destCGs     = make(map[string][]string) // dest-uuid to list of CGs
 		destDLQs    = make(map[string][]string) // dest-uuid to list of DLQs (for its CGs)
 		destExtents = make(map[string][]string) // destination to extents
-		destNoTTL   = make(map[string]string)
-	)
 
-	type inputExtentRow struct {
-		destUUID  string
-		inputUUID string
-	}
+		destNoTTL         = set.New(0)
+		cgNoTTL           = set.New(0)
+		extNoTTL          = set.New(0)
+		cgExtentsNoTTL    = set.New(0)
+		inputExtentsNoTTL = set.New(0)
+		storeExtentsNoTTL = set.New(0)
 
-	var (
-		storeExtents = make(map[string]string)         // store_extents: extent-uuid to store-uuid (for active extents in store_extents)
-		inputExtents = make(map[string]inputExtentRow) // input_host_extents: extent-uuid to {dest-uuid,input-uuid} (for active extents in input_host_extents)
+		storeExtentsActive = set.New(0) // store_extents: extent-uuid to store-uuid (for active extents in store_extents)
+		inputExtentsActive = set.New(0) // input_host_extents: extent-uuid to {dest-uuid,input-uuid} (for active extents in input_host_extents)
 
-		cgxExtents = make(map[string][]string) // consumer_group_extents: extents to consumer-groups
-		cgxCGs     = make(map[string][]string) // consumer_group_extents: consumer-groups to extents
+		cgExtentsActive = set.New(0) // consumer_group_extents: extents to consumer-groups
 
-		extActive  = make(map[string]string) // destination_extents
-		cgActive   = make(map[string]string) // consumer_groups
-		cgDeleting = make(map[string]string) // consumer_groups in 'deleting' state
+		extActive  = set.New(0) // destination_extents
+		cgActive   = set.New(0) // consumer_groups
+		cgDeleting = set.New(0) // consumer_groups in 'deleting' state
 
 		destActive   = make(map[string]string) // destinations active
 		destDeleting = make(map[string]string) // destinations in 'deleting' state
@@ -110,76 +124,78 @@ func gc(c *cli.Context) error {
 
 	// 'store_extents' table:
 	if gcStoreExtents {
+
 		fmt.Printf("store_extents: ")
+
 		cql := `SELECT extent_uuid, store_uuid, status, TTL(status) FROM store_extents`
 		iter, close := getIterator(cql)
 
 		var extUUID, storeUUID string
 		var status, ttl int
 		var nRows int
-		var nDeletedNoTTL int
 		for iter.Scan(&extUUID, &storeUUID, &status, &ttl) {
 
 			if status != int(shared.ExtentStatus_DELETED) { // FIXME: BUG in metadata-client (should use ExtentReplicaStatus)
 
-				storeExtents[extUUID] = storeUUID
+				storeExtentsActive.Insert(storeUUID + `:` + extUUID)
 
 			} else if ttl == 0 {
 
-				nDeletedNoTTL++
+				storeExtentsNoTTL.Insert(storeUUID + `:` + extUUID)
 			}
 
 			nRows++
 			//fmt.Printf("\rstore_extents: %d rows", nRows)
 		}
 
-		fmt.Printf("\rstore_extents: %d rows: %d active\n", nRows, len(storeExtents))
+		fmt.Printf("\rstore_extents: %d rows: %d active\n", nRows, storeExtentsActive.Count())
 		if close() != nil {
 			return nil
 		}
 
-		if nDeletedNoTTL > 0 {
-			fmt.Printf("\tWARNING: %d deleted store_extents have no TTL!\n", nDeletedNoTTL)
+		if !storeExtentsNoTTL.Empty() {
+			fmt.Printf("\tWARNING: %d deleted store_extents have no TTL!\n", storeExtentsNoTTL.Count())
 		}
 	}
 
 	// 'input_host_extents' table:
 	if gcInputExtents {
+
 		fmt.Printf("input_host_extents: ")
+
 		cql := `SELECT input_host_uuid, destination_uuid, extent_uuid, status, TTL(status) FROM input_host_extents`
 		iter, close := getIterator(cql)
 
 		var inputUUID, destUUID, extUUID string
 		var status, ttl int
 		var nRows int
-		var nDeletedNoTTL int
 		for iter.Scan(&inputUUID, &destUUID, &extUUID, &status, &ttl) {
 
 			if status != int(shared.ExtentStatus_DELETED) {
 
-				inputExtents[extUUID] = inputExtentRow{destUUID: destUUID, inputUUID: inputUUID}
+				inputExtentsActive.Insert(inputUUID + `:` + extUUID)
 
 			} else if ttl == 0 {
 
-				nDeletedNoTTL++
+				inputExtentsNoTTL.Insert(inputUUID + `:` + extUUID)
 			}
 
 			nRows++
 			//fmt.Printf("\rinput_host_extents: %d rows", nRows)
 		}
 
-		fmt.Printf("\rinput_host_extents: %d rows: %d active\n", nRows, len(inputExtents))
+		fmt.Printf("\rinput_host_extents: %d rows: %d active\n", nRows, inputExtentsActive.Count())
+
 		if close() != nil {
 			return nil
 		}
 
-		if nDeletedNoTTL > 0 {
-			fmt.Printf("\tWARNING: %d deleted input_host_extents have no TTL!\n", nDeletedNoTTL)
+		if !inputExtentsNoTTL.Empty() {
+			fmt.Printf("\tWARNING: %d deleted input_host_extents have no TTL!\n", inputExtentsNoTTL.Count())
 		}
 	}
 
 	// 'consumer_group_extents' table:
-	var nCGExtents int
 	if gcCGExtents {
 
 		fmt.Printf("consumer_group_extents: ")
@@ -190,36 +206,39 @@ func gc(c *cli.Context) error {
 		var extUUID, cgUUID string
 		var status, ttl int
 		var nRows int
-		var nDeletedNoTTL int
+		var cgxExtents = set.New(0) // consumer_group_extents: extents to consumer-groups
+		var cgxCGs = set.New(0)     // consumer_group_extents: consumer-groups to extents
 		for iter.Scan(&extUUID, &cgUUID, &status, &ttl) {
 
 			if status != int(shared.ConsumerGroupExtentStatus_DELETED) {
 
-				cgxExtents[extUUID] = append(cgxExtents[extUUID], cgUUID)
-				cgxCGs[cgUUID] = append(cgxCGs[cgUUID], extUUID)
-				nCGExtents++
+				cgExtentsActive.Insert(cgUUID + `:` + extUUID)
+
+				cgxExtents.Insert(extUUID)
+				cgxCGs.Insert(cgUUID)
 
 			} else if ttl == 0 {
 
-				nDeletedNoTTL++
+				cgExtentsNoTTL.Insert(cgUUID + `:` + extUUID)
 			}
 
 			nRows++
 			//fmt.Printf("\rconsumer_group_extents: %d rows", nRows)
 		}
 
-		fmt.Printf("\rconsumer_group_extents: %d rows: %d active (for %d extents, %d cgs)\n", nRows, nCGExtents, len(cgxExtents), len(cgxCGs))
+		fmt.Printf("\rconsumer_group_extents: %d rows: %d active (for %d extents, %d cgs)\n", nRows, cgExtentsActive.Count(), cgxExtents.Count(), cgxCGs.Count())
 		if close() != nil {
 			return nil
 		}
 
-		if nDeletedNoTTL > 0 {
-			fmt.Printf("\tWARNING: %d deleted consumer-group extents have no TTL!\n", nDeletedNoTTL)
+		if !cgExtentsNoTTL.Empty() {
+			fmt.Printf("\tWARNING: %d deleted consumer-group extents have no TTL!\n", cgExtentsNoTTL.Count())
 		}
 	}
 
 	// 'destination_extents' table:
 	if gcDestExtents || gcStoreExtents || gcInputExtents || gcCGExtents {
+
 		fmt.Printf("destination_extents: ")
 
 		cql := `SELECT extent_uuid, extent.status, TTL(extent), destination_uuid FROM destination_extents`
@@ -228,32 +247,32 @@ func gc(c *cli.Context) error {
 		var extUUID, destUUID string
 		var status, ttl int
 		var nRows int
-		var nDeletedNoTTL int
 		for iter.Scan(&extUUID, &status, &ttl, &destUUID) {
 
 			extDest[extUUID] = destUUID
 
 			if status != int(shared.ExtentStatus_DELETED) {
 
-				extActive[extUUID] = destUUID
+				extActive.Insert(extUUID)
 				destExtents[destUUID] = append(destExtents[destUUID], extUUID)
 
 			} else if ttl == 0 {
 
-				nDeletedNoTTL++
+				extNoTTL.Insert(extUUID)
+				destExtents[destUUID] = append(destExtents[destUUID], extUUID)
 			}
 
 			nRows++
 			//fmt.Printf("\rdestination_extents: %d rows", nRows)
 		}
 
-		fmt.Printf("\rdestination_extents: %d rows: %d active (for %d destinations)\n", nRows, len(extActive), len(destExtents))
+		fmt.Printf("\rdestination_extents: %d rows: %d active (for %d destinations)\n", nRows, extActive.Count(), len(destExtents))
 		if close() != nil {
 			return nil
 		}
 
-		if nDeletedNoTTL > 0 {
-			fmt.Printf("\tWARNING: %d deleted extents have no TTL!\n", nDeletedNoTTL)
+		if !extNoTTL.Empty() {
+			fmt.Printf("\tWARNING: %d deleted extents have no TTL!\n", extNoTTL.Count())
 		}
 	}
 
@@ -267,7 +286,6 @@ func gc(c *cli.Context) error {
 		var cgUUID, destUUID, cgName, dlqDestUUID string
 		var status, ttl int
 		var nRows, nDLQ, nCGDeleted int
-		var nDeletedNoTTL int
 		for iter.Scan(&cgUUID, &cgName, &status, &ttl, &destUUID, &dlqDestUUID) {
 
 			cgPaths[cgUUID] = cgName
@@ -276,9 +294,9 @@ func gc(c *cli.Context) error {
 			if status != int(shared.ConsumerGroupStatus_DELETED) {
 
 				if status == int(shared.ConsumerGroupStatus_DELETING) {
-					cgDeleting[cgUUID] = destUUID
+					cgDeleting.Insert(cgUUID)
 				} else {
-					cgActive[cgUUID] = destUUID
+					cgActive.Insert(cgUUID)
 				}
 
 				destCGs[destUUID] = append(destCGs[destUUID], cgUUID)
@@ -293,8 +311,7 @@ func gc(c *cli.Context) error {
 				nCGDeleted++
 
 				if ttl == 0 {
-
-					nDeletedNoTTL++
+					cgNoTTL.Insert(cgUUID)
 				}
 			}
 
@@ -303,26 +320,26 @@ func gc(c *cli.Context) error {
 		}
 
 		fmt.Printf("\rconsumer_groups: %d rows: %d active, %d deleting, %d deleted (found %d DLQs for %d destinations)\n",
-			nRows, len(cgActive), len(cgDeleting), nCGDeleted, nDLQ, len(destDLQs))
+			nRows, cgActive.Count(), cgDeleting.Count(), nCGDeleted, nDLQ, len(destDLQs))
 
 		if close() != nil {
 			return nil
 		}
 
-		if nDeletedNoTTL > 0 {
-			fmt.Printf("\tWARNING: %d deleted consumer-groups have no TTL!\n", nDeletedNoTTL)
+		if !cgNoTTL.Empty() {
+			fmt.Printf("\tWARNING: %d deleted consumer-groups have no TTL!\n", cgNoTTL.Count())
 		}
 	}
 
 	// 'destinations' table: find all destinations
 	{
 		fmt.Printf("destinations: ")
+
 		cql := `SELECT uuid, destination.path, destination.status, TTL(destination) FROM destinations`
 		iter, close := getIterator(cql)
 		var destUUID, destPath string
 		var status, ttl int
 		var nRows, nDestDeleted int
-		var nDeletedNoTTL int
 		for iter.Scan(&destUUID, &destPath, &status, &ttl) {
 
 			destPaths[destUUID] = destPath
@@ -340,7 +357,7 @@ func gc(c *cli.Context) error {
 				nDestDeleted++
 
 				if ttl == 0 {
-					nDeletedNoTTL++
+					destNoTTL.Insert(destUUID)
 				}
 			}
 
@@ -353,8 +370,8 @@ func gc(c *cli.Context) error {
 			return nil
 		}
 
-		if nDeletedNoTTL > 0 {
-			fmt.Printf("\tWARNING: %d deleted destinations have no TTL!\n", nDeletedNoTTL)
+		if !destNoTTL.Empty() {
+			fmt.Printf("\tWARNING: %d deleted destinations have no TTL!\n", destNoTTL.Count())
 		}
 	}
 
@@ -382,15 +399,15 @@ func gc(c *cli.Context) error {
 
 	// -- compute set of valid destination, cg and extent UUIDs -- //
 
-	var destUUIDs = make(map[string]string) // set of valid destination-uuids
-	var cgUUIDs = make(map[string]string)   // set of valid consumergroup-uuids
-	var extUUIDs = make(map[string]string)  // set of valid extent-uuids
+	var destValid = set.New(0) // set of valid destination-uuids
+	var cgValid = set.New(0)   // set of valid consumergroup-uuids
+	var extValid = set.New(0)  // set of valid extent-uuids
 
 	// include all entries from destinations_by_path table
 	var nDestNoUUID, nDestPathMismatch int
 	for d, p := range destByPathActive {
 
-		destUUIDs[d] = p
+		destValid.Insert(d)
 
 		// check if exists in the 'destinations' table
 		if dp, ok := destActive[d]; !ok {
@@ -413,7 +430,7 @@ func gc(c *cli.Context) error {
 
 	// include all 'deleting' destinations
 	for d := range destDeleting {
-		destUUIDs[d] = destDeleting[d]
+		destValid.Insert(d)
 	}
 
 	// find valid DLQ destinations and include them
@@ -423,7 +440,7 @@ func gc(c *cli.Context) error {
 		if _, ok := destByPathActive[d]; ok {
 
 			for _, dlq := range dlqs {
-				destUUIDs[dlq] = destActive[dlq] // get path from 'destinations' table entry
+				destValid.Insert(dlq) // get path from 'destinations' table entry
 			}
 		}
 	}
@@ -433,9 +450,9 @@ func gc(c *cli.Context) error {
 		for d, cgs := range destCGs {
 
 			// only include CGs for destinations that are valid
-			if _, ok := destUUIDs[d]; ok {
+			if destValid.Contains(d) {
 				for _, cg := range cgs {
-					cgUUIDs[cg] = d
+					cgValid.Insert(cg)
 				}
 			}
 		}
@@ -445,10 +462,10 @@ func gc(c *cli.Context) error {
 	if gcDestExtents || gcStoreExtents || gcInputExtents || gcCGExtents {
 		for d, extents := range destExtents {
 
-			// only include CGs for destinations that are valid
-			if _, ok := destUUIDs[d]; ok {
+			// only include extents for destinations that are valid
+			if destValid.Contains(d) {
 				for _, x := range extents {
-					extUUIDs[x] = d
+					extValid.Insert(x)
 				}
 			}
 		}
@@ -478,17 +495,22 @@ func gc(c *cli.Context) error {
 
 			if _, ok := destActive[d]; ok {
 
-				if _, ok = destUUIDs[d]; !ok {
-					// destInvalid = append(destInvalid, d)
+				if !destValid.Contains(d) {
+
 					nInvalidRows++
-					out.Destination(row, fmt.Sprintf("%s, %s", d, destPaths[d]))
+					out.Destination(row, destPaths[d])
 				}
+
+			} else if destNoTTL.Contains(d) {
+
+				nInvalidRows++
+				out.Destination(row, destPaths[d])
 			}
 
 			row = make(map[string]interface{})
 		}
 
-		fmt.Printf("%d (of %d) to be deleted\n", nInvalidRows, len(destActive))
+		fmt.Printf("%d (of %d) to be deleted\n", nInvalidRows, len(destActive)+destNoTTL.Count())
 	}
 
 	// * consumer_groups:
@@ -506,19 +528,24 @@ func gc(c *cli.Context) error {
 
 			cg := row["uuid"].(gocql.UUID).String()
 
-			if _, ok := cgActive[cg]; ok {
+			if cgActive.Contains(cg) {
 
-				if _, ok = cgUUIDs[cg]; !ok {
-					// cgInvalid = append(cgInvalid, cg)
+				if !cgValid.Contains(cg) {
+
 					nInvalidRows++
 					out.ConsumerGroup(row, cgPaths[cg])
 				}
+
+			} else if cgNoTTL.Contains(cg) {
+
+				nInvalidRows++
+				out.ConsumerGroup(row, cgPaths[cg])
 			}
 
 			row = make(map[string]interface{})
 		}
 
-		fmt.Printf("%d (of %d) to be deleted\n", nInvalidRows, len(cgActive))
+		fmt.Printf("%d (of %d) to be deleted\n", nInvalidRows, cgActive.Count()+cgNoTTL.Count())
 	}
 
 	// * destination_extents:
@@ -536,20 +563,26 @@ func gc(c *cli.Context) error {
 
 			x := row["extent_uuid"].(gocql.UUID).String()
 
-			if _, ok := extActive[x]; ok {
+			if extActive.Contains(x) {
 
-				if _, ok = extUUIDs[x]; !ok {
-					// extInvalid = append(extInvalid, x)
+				if !extValid.Contains(x) {
+
 					nInvalidRows++
 					destUUID := row["destination_uuid"].(gocql.UUID).String()
 					out.Extent(row, destPaths[destUUID])
 				}
+
+			} else if extNoTTL.Contains(x) {
+
+				nInvalidRows++
+				destUUID := row["destination_uuid"].(gocql.UUID).String()
+				out.Extent(row, destPaths[destUUID])
 			}
 
 			row = make(map[string]interface{})
 		}
 
-		fmt.Printf("%d (of %d) to be deleted\n", nInvalidRows, len(extActive))
+		fmt.Printf("%d (of %d) to be deleted\n", nInvalidRows, extActive.Count()+extNoTTL.Count())
 	}
 
 	// * consumer_group_extents:
@@ -567,37 +600,30 @@ func gc(c *cli.Context) error {
 
 			extUUID := row["extent_uuid"].(gocql.UUID).String()
 			cgUUID := row["consumer_group_uuid"].(gocql.UUID).String()
-
-			cgs, ok := cgxExtents[extUUID]
+			key := cgUUID + `:` + extUUID
 
 			// -- validate that row was in our first query --
-			if !ok {
+			if !cgExtentsActive.Contains(key) {
+
 				row = make(map[string]interface{})
 				continue
-			}
 
-			ok = false
-			for _, cg := range cgs {
-				if cgUUID == cg {
-					ok = true
-					break
-				}
-			}
+			} else if cgExtentsNoTTL.Contains(key) { // check if no-ttl case
 
-			if !ok {
-				row = make(map[string]interface{})
-				continue
-			}
-			// -- //
-
-			if _, ok := extUUIDs[extUUID]; !ok { // valid extent?
 				nInvalidRows++
 				out.ConsumerGroupExtent(row, fmt.Sprintf("%s, %s", destPaths[extDest[extUUID]], cgPaths[cgUUID]))
 				row = make(map[string]interface{})
 				continue
 			}
 
-			if _, ok := cgUUIDs[cgUUID]; !ok { // valid CG?
+			if !extValid.Contains(extUUID) { // valid extent?
+				nInvalidRows++
+				out.ConsumerGroupExtent(row, fmt.Sprintf("%s, %s", destPaths[extDest[extUUID]], cgPaths[cgUUID]))
+				row = make(map[string]interface{})
+				continue
+			}
+
+			if !cgValid.Contains(cgUUID) { // valid CG?
 				nInvalidRows++
 				out.ConsumerGroupExtent(row, fmt.Sprintf("%s, %s", destPaths[extDest[extUUID]], cgPaths[cgUUID]))
 				row = make(map[string]interface{})
@@ -608,22 +634,22 @@ func gc(c *cli.Context) error {
 		}
 
 		/* // logic for additional validation //
-		for x, cgs := range cgxExtents {
-			if _, ok := extUUIDs[x]; !ok { // check if valid extent
+		for x, cgs := range cgExtents {
+			if !extValid.Contains(x) { // check if valid extent
 				for _, cg := range cgs {
 					fmt.Printf("DELETE FROM consumer_group_extents WHERE consumer_group_uuid=%v AND extent_uuid=%v;\n", cg, x)
 				}
 				continue
 			}
 			for _, cg := range cgs { // check if valid CG
-				if _, ok := cgUUIDs[cg]; !ok {
+				if _, ok := cgValid[cg]; !ok {
 					fmt.Printf("DELETE FROM consumer_group_extents WHERE consumer_group_uuid=%v AND extent_uuid=%v;\n", cg, x)
 				}
 			}
 		}
 		*/
 
-		fmt.Printf("%d (of %d) to be deleted\n", nInvalidRows, nCGExtents)
+		fmt.Printf("%d (of %d) to be deleted\n", nInvalidRows, cgExtentsActive.Count()+cgExtentsNoTTL.Count())
 	}
 
 	// * input_host_extents:
@@ -639,20 +665,27 @@ func gc(c *cli.Context) error {
 
 		for iter.MapScan(row) {
 
+			input := row["input_host_uuid"].(gocql.UUID).String()
 			x := row["extent_uuid"].(gocql.UUID).String()
+			key := input + `:` + x
 
-			if _, ok := inputExtents[x]; ok {
+			if inputExtentsActive.Contains(key) {
 
-				if _, ok = extUUIDs[x]; !ok {
+				if !extValid.Contains(x) {
 					nInvalidRows++
-					out.InputExtent(row, destPaths[x])
+					out.InputExtent(row, "") // FIXME: look for dest info?
 				}
+
+			} else if inputExtentsNoTTL.Contains(key) {
+
+				nInvalidRows++
+				out.InputExtent(row, "") // FIXME: look for dest info?
 			}
 
 			row = make(map[string]interface{})
 		}
 
-		fmt.Printf("%d (of %d) to be deleted\n", nInvalidRows, len(inputExtents))
+		fmt.Printf("%d (of %d) to be deleted\n", nInvalidRows, inputExtentsActive.Count()+inputExtentsNoTTL.Count())
 	}
 
 	// * store_extents:
@@ -670,19 +703,25 @@ func gc(c *cli.Context) error {
 
 			x := row["extent_uuid"].(gocql.UUID).String()
 			s := row["store_uuid"].(gocql.UUID).String()
+			key := s + `:` + x
 
-			if store, ok := storeExtents[x]; ok && s == store {
+			if storeExtentsActive.Contains(key) {
 
-				if _, ok := extUUIDs[x]; !ok {
+				if !extValid.Contains(x) {
 					nInvalidRows++
-					out.StoreExtent(row, destPaths[x])
+					out.StoreExtent(row, "") // TOOD: annotate with dest-info?
 				}
+
+			} else if storeExtentsNoTTL.Contains(key) {
+
+				nInvalidRows++
+				out.StoreExtent(row, "") // TODO: annotate with dest-info?
 			}
 
 			row = make(map[string]interface{})
 		}
 
-		fmt.Printf("%d (of %d) to be deleted\n", nInvalidRows, len(storeExtents))
+		fmt.Printf("%d (of %d) to be deleted\n", nInvalidRows, storeExtentsActive.Count()+storeExtentsNoTTL.Count())
 	}
 
 	return nil

--- a/cmd/tools/cmq/gc.go
+++ b/cmd/tools/cmq/gc.go
@@ -313,6 +313,7 @@ func gc(c *cli.Context) error {
 
 	// 'destinations' table: find all destinations
 	var destActive = make(map[string]string)
+	var destDeleting = make(map[string]string)
 	{
 		fmt.Printf("destinations: ")
 		cql := `SELECT uuid, destination.path, destination.status, TTL(destination) FROM destinations`

--- a/cmd/tools/cmq/gc.go
+++ b/cmd/tools/cmq/gc.go
@@ -112,7 +112,7 @@ func gc(c *cli.Context) error {
 	var consistency = gocql.All // use 'all' consistency
 
 	if cliContext.IsSet("consistency") { // override consistency, if specified
-		consistency, _ = gocql.ParseConsistency(cliContext.String("consistency"))
+		consistency = gocql.ParseConsistency(cliContext.String("consistency"))
 	}
 
 	// get query iterator

--- a/cmd/tools/cmq/gc.go
+++ b/cmd/tools/cmq/gc.go
@@ -53,7 +53,7 @@ func gc(c *cli.Context) error {
 		return nil
 	}
 
-	mc, err := newMetadataClient(getOpts(cliContext))
+	mc, err := newMetadataClient()
 
 	if err != nil {
 		fmt.Errorf("newMetadataClient error: %v", err)

--- a/cmd/tools/cmq/gc.go
+++ b/cmd/tools/cmq/gc.go
@@ -109,10 +109,16 @@ func gc(c *cli.Context) error {
 		destDeleting = make(map[string]string) // destinations in 'deleting' state
 	)
 
+	var consistency = gocql.All // use 'all' consistency
+
+	if cliContext.IsSet("consistency") { // override consistency, if specified
+		consistency, _ = gocql.ParseConsistency(cliContext.String("consistency"))
+	}
+
 	// get query iterator
 	getIterator := func(cql string) (iter *gocql.Iter, close func() error) {
 
-		iter = mc.session.Query(cql).Consistency(gocql.All).RetryPolicy(&gocql.SimpleRetryPolicy{NumRetries: mc.retries}).Iter()
+		iter = mc.session.Query(cql).Consistency(consistency).RetryPolicy(&gocql.SimpleRetryPolicy{NumRetries: mc.retries}).Iter()
 		close = func() (err error) {
 			if err = iter.Close(); err != nil {
 				fmt.Printf("ERROR from query '%v': %v\n", cql, err)

--- a/cmd/tools/cmq/list.go
+++ b/cmd/tools/cmq/list.go
@@ -10,7 +10,7 @@ import (
 
 func listDestinations(c *cli.Context) error {
 
-	mc, err := newMetadataClient(getOpts(cliContext))
+	mc, err := newMetadataClient()
 
 	if err != nil {
 		fmt.Errorf("newMetadataClient error: %v", err)
@@ -19,7 +19,7 @@ func listDestinations(c *cli.Context) error {
 
 	defer mc.Close()
 
-	out := cmqOutputWriter(cliContext.StringSlice("output"))
+	out := cmqOutputWriter(cliContext.StringSlice(`output`))
 	defer out.close()
 
 	cql := "SELECT * FROM destinations"
@@ -107,7 +107,7 @@ func listDestinationsByPath(c *cli.Context) error {
 
 func listConsumerGroups(c *cli.Context) error {
 
-	mc, err := newMetadataClient(getOpts(cliContext))
+	mc, err := newMetadataClient()
 
 	if err != nil {
 		fmt.Errorf("newMetadataClient error: %v", err)
@@ -116,7 +116,7 @@ func listConsumerGroups(c *cli.Context) error {
 
 	defer mc.Close()
 
-	out := cmqOutputWriter(cliContext.StringSlice("output"))
+	out := cmqOutputWriter(cliContext.StringSlice(`output`))
 	defer out.close()
 
 	cql := "SELECT * FROM consumer_groups"
@@ -200,7 +200,7 @@ func listConsumerGroups(c *cli.Context) error {
 
 func listDestinationExtents(c *cli.Context) error {
 
-	mc, err := newMetadataClient(getOpts(cliContext))
+	mc, err := newMetadataClient()
 
 	if err != nil {
 		fmt.Errorf("newMetadataClient error: %v", err)
@@ -209,7 +209,7 @@ func listDestinationExtents(c *cli.Context) error {
 
 	defer mc.Close()
 
-	out := cmqOutputWriter(cliContext.StringSlice("output"))
+	out := cmqOutputWriter(cliContext.StringSlice(`output`))
 	defer out.close()
 
 	cql := "SELECT * FROM destination_extents"
@@ -273,7 +273,7 @@ func listDestinationExtents(c *cli.Context) error {
 
 func listConsumerGroupExtents(c *cli.Context) error {
 
-	mc, err := newMetadataClient(getOpts(cliContext))
+	mc, err := newMetadataClient()
 
 	if err != nil {
 		fmt.Errorf("newMetadataClient error: %v", err)
@@ -282,7 +282,7 @@ func listConsumerGroupExtents(c *cli.Context) error {
 
 	defer mc.Close()
 
-	out := cmqOutputWriter(cliContext.StringSlice("output"))
+	out := cmqOutputWriter(cliContext.StringSlice(`output`))
 	defer out.close()
 
 	cql := "SELECT * FROM consumer_group_extents"
@@ -347,7 +347,7 @@ func listConsumerGroupExtents(c *cli.Context) error {
 
 func listStoreExtents(c *cli.Context) error {
 
-	mc, err := newMetadataClient(getOpts(cliContext))
+	mc, err := newMetadataClient()
 
 	if err != nil {
 		fmt.Errorf("newMetadataClient error: %v", err)
@@ -356,7 +356,7 @@ func listStoreExtents(c *cli.Context) error {
 
 	defer mc.Close()
 
-	out := cmqOutputWriter(cliContext.StringSlice("output"))
+	out := cmqOutputWriter(cliContext.StringSlice(`output`))
 	defer out.close()
 
 	cql := "SELECT * FROM store_extents"
@@ -421,7 +421,7 @@ func listOperations(c *cli.Context) error {
 		return fmt.Errorf("specify UUIDs to search for")
 	}
 
-	mc, err := newMetadataClient(getOpts(cliContext))
+	mc, err := newMetadataClient()
 
 	if err != nil {
 		fmt.Errorf("newMetadataClient error: %v", err)
@@ -430,7 +430,7 @@ func listOperations(c *cli.Context) error {
 
 	defer mc.Close()
 
-	out := cmqOutputWriter(cliContext.StringSlice("output"))
+	out := cmqOutputWriter(cliContext.StringSlice(`output`))
 	defer out.close()
 
 	cql := "SELECT * FROM user_operations_by_entity_uuid"

--- a/cmd/tools/cmq/list.go
+++ b/cmd/tools/cmq/list.go
@@ -76,11 +76,11 @@ func listDestinations(c *cli.Context) error {
 				continue
 			}
 
-			if len(typeFilters) > 0 && !matchIntFilters(dest["type"].(int), typeFilters) {
+			if !matchIntFilters(dest["type"].(int), typeFilters) {
 				continue
 			}
 
-			if len(statusFilters) > 0 && !matchIntFilters(dest["status"].(int), statusFilters) {
+			if !matchIntFilters(dest["status"].(int), statusFilters) {
 				continue
 			}
 
@@ -180,11 +180,11 @@ func listConsumerGroups(c *cli.Context) error {
 				continue
 			}
 
-			if len(statusFilters) > 0 && !matchIntFilters(cg["status"].(int), statusFilters) {
+			if !matchIntFilters(cg["status"].(int), statusFilters) {
 				continue
 			}
 
-			if len(nameFilters) > 0 && !matchRegexpFilters(cg["name"].(string), nameFilters) {
+			if !matchRegexpFilters(cg["name"].(string), nameFilters) {
 				continue
 			}
 		}
@@ -398,7 +398,7 @@ func listStoreExtents(c *cli.Context) error {
 		// storeUUID := row["store_uuid"]
 		// extUUID := row["extent_uuid"]
 
-		if len(statusFilters) > 0 && !matchIntFilters(row["status"].(int), statusFilters) {
+		if matchIntFilters(row["status"].(int), statusFilters) {
 			continue
 		}
 
@@ -470,7 +470,7 @@ func listInputHostExtents(c *cli.Context) error {
 		// storeUUID := row["store_uuid"]
 		// extUUID := row["extent_uuid"]
 
-		if len(statusFilters) > 0 && !matchIntFilters(row["status"].(int), statusFilters) {
+		if !matchIntFilters(row["status"].(int), statusFilters) {
 			continue
 		}
 

--- a/cmd/tools/cmq/main.go
+++ b/cmd/tools/cmq/main.go
@@ -23,7 +23,6 @@ func main() {
 	}
 
 	app.After = func(c *cli.Context) error {
-		print("\n")
 		return nil
 	}
 

--- a/cmd/tools/cmq/main.go
+++ b/cmd/tools/cmq/main.go
@@ -1,12 +1,9 @@
 package main
 
 import (
-	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/urfave/cli"
-	"gopkg.in/yaml.v2"
 )
 
 var cliContext *cli.Context // global cli context
@@ -34,90 +31,4 @@ func main() {
 	app.Commands = cmqCommands
 
 	app.Run(os.Args)
-}
-
-// ZoneConfig has config for cassandra for each zone
-type ZoneConfig struct {
-	Hosts    string `yaml:"hosts"` // TODO: add support for multiple hosts
-	Port     int    `yaml:"port"`
-	Keyspace string `yaml:"keyspace"`
-	Username string `yaml:"username"`
-	Password string `yaml:"password"`
-}
-
-func getOpts(c *cli.Context) *opts {
-
-	var opts = &opts{
-		Port:        9042,
-		Consistency: "One",
-		Keyspace:    "cherami",
-	}
-
-	if c.IsSet("zone") {
-
-		if configYaml, err := ioutil.ReadFile(c.String("config")); err == nil {
-
-			config := make(map[string]ZoneConfig)
-
-			if err = yaml.Unmarshal(configYaml, &config); err != nil {
-
-				fmt.Printf("error parsing yaml (%s): %v\n", c.String("config"), err)
-
-			} else {
-
-				if cfg, ok := config[c.String("zone")]; !ok {
-
-					fmt.Printf("config not found for zone '%v'\n", c.String("zone"))
-
-				} else {
-
-					opts.Hosts = cfg.Hosts
-					if cfg.Port != 0 {
-						opts.Port = cfg.Port
-					}
-					opts.Keyspace = cfg.Keyspace
-					opts.Username = cfg.Username
-					opts.Password = cfg.Password
-				}
-			}
-		}
-	}
-
-	if c.IsSet("hosts") {
-		opts.Hosts = c.String("hosts")
-	}
-
-	if c.IsSet("port") {
-		opts.Port = c.Int("port")
-	}
-
-	if c.IsSet("keyspace") {
-		opts.Keyspace = c.String("keyspace")
-	}
-
-	if c.IsSet("consistency") {
-		opts.Consistency = c.String("consistency")
-	}
-
-	if c.IsSet("username") {
-		opts.Username = c.String("username")
-	}
-
-	if c.IsSet("password") {
-		opts.Password = c.String("password")
-	}
-
-	if c.IsSet("timeout") {
-		opts.Timeout = c.Duration("timeout")
-	}
-
-	if c.IsSet("retries") {
-		opts.Retries = c.Int("retries")
-	}
-
-	if c.IsSet("pagesize") {
-		opts.PageSize = c.Int("pagesize")
-	}
-
-	return opts
 }

--- a/cmd/tools/cmq/meta.go
+++ b/cmd/tools/cmq/meta.go
@@ -2,8 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/gocql/gocql"
+	"io/ioutil"
 	"time"
+
+	"github.com/gocql/gocql"
+	"github.com/urfave/cli"
+	"gopkg.in/yaml.v2"
 )
 
 type opts struct {
@@ -30,7 +34,9 @@ const (
 	numConns        = 1
 )
 
-func newMetadataClient(opts *opts) (*metadataClient, error) {
+func newMetadataClient() (*metadataClient, error) {
+
+	opts := getOpts(cliContext)
 
 	cluster := gocql.NewCluster(opts.Hosts) // TODO: add support for multiple hosts
 
@@ -148,4 +154,90 @@ func (m *metadataClient) Query(table string, f filter) (row map[string]interface
 	*/
 
 	return
+}
+
+// ZoneConfig has config for cassandra for each zone
+type ZoneConfig struct {
+	Hosts    string `yaml:"hosts"` // TODO: add support for multiple hosts
+	Port     int    `yaml:"port"`
+	Keyspace string `yaml:"keyspace"`
+	Username string `yaml:"username"`
+	Password string `yaml:"password"`
+}
+
+func getOpts(c *cli.Context) *opts {
+
+	var opts = &opts{
+		Port:        9042,
+		Consistency: "One",
+		Keyspace:    "cherami",
+	}
+
+	if c.IsSet("zone") {
+
+		if configYaml, err := ioutil.ReadFile(c.String("config")); err == nil {
+
+			config := make(map[string]ZoneConfig)
+
+			if err = yaml.Unmarshal(configYaml, &config); err != nil {
+
+				fmt.Printf("error parsing yaml (%s): %v\n", c.String("config"), err)
+
+			} else {
+
+				if cfg, ok := config[c.String("zone")]; !ok {
+
+					fmt.Printf("config not found for zone '%v'\n", c.String("zone"))
+
+				} else {
+
+					opts.Hosts = cfg.Hosts
+					if cfg.Port != 0 {
+						opts.Port = cfg.Port
+					}
+					opts.Keyspace = cfg.Keyspace
+					opts.Username = cfg.Username
+					opts.Password = cfg.Password
+				}
+			}
+		}
+	}
+
+	if c.IsSet("hosts") {
+		opts.Hosts = c.String("hosts")
+	}
+
+	if c.IsSet("port") {
+		opts.Port = c.Int("port")
+	}
+
+	if c.IsSet("keyspace") {
+		opts.Keyspace = c.String("keyspace")
+	}
+
+	if c.IsSet("consistency") {
+		opts.Consistency = c.String("consistency")
+	}
+
+	if c.IsSet("username") {
+		opts.Username = c.String("username")
+	}
+
+	if c.IsSet("password") {
+		opts.Password = c.String("password")
+	}
+
+	if c.IsSet("timeout") {
+		opts.Timeout = c.Duration("timeout")
+	}
+
+	if c.IsSet("retries") {
+		opts.Retries = c.Int("retries")
+	}
+
+	if c.IsSet("pagesize") {
+		opts.PageSize = c.Int("pagesize")
+	}
+
+	return opts
 }

--- a/cmd/tools/cmq/out.go
+++ b/cmd/tools/cmq/out.go
@@ -270,7 +270,7 @@ func (t *cmqWriterShort) ConsumerGroup(row map[string]interface{}, annot string)
 	cgUUID := row["uuid"]
 	cgPath := row["consumer_group"].(map[string]interface{})["name"]
 	destUUID := row["consumer_group"].(map[string]interface{})["destination_uuid"]
-	fmt.Printf("dest=%v cg=%v ('%v')\n", destUUID, cgUUID, cgPath)
+	fmt.Printf("dest=%v cg=%v ('%v') %s\n", destUUID, cgUUID, cgPath, annot)
 }
 
 func (t *cmqWriterShort) Extent(row map[string]interface{}, annot string) {

--- a/cmd/tools/cmq/out.go
+++ b/cmd/tools/cmq/out.go
@@ -39,6 +39,11 @@ type outContext struct {
 
 func cmqOutputWriter(outTypes []string) (writer cmqWriter) {
 
+	// override 'output' format, if specified
+	if len(outTypes) == 0 {
+		outTypes = []string{`json`}
+	}
+
 	var writers []cmqWriter
 
 	for _, ot := range outTypes {

--- a/cmd/tools/cmq/out.go
+++ b/cmd/tools/cmq/out.go
@@ -173,26 +173,26 @@ func newCmqWriterShort() *cmqWriterShort {
 func (t *cmqWriterShort) Destination(row map[string]interface{}, annot string) {
 	destUUID := row["uuid"]
 	destPath := row["destination"].(map[string]interface{})["path"]
-	fmt.Printf("destination: %v [%v]\n", destPath, destUUID)
+	fmt.Printf("dest=%v ('%v')\n", destUUID, destPath)
 }
 
 func (t *cmqWriterShort) ConsumerGroup(row map[string]interface{}, annot string) {
 	cgUUID := row["uuid"]
 	cgPath := row["consumer_group"].(map[string]interface{})["name"]
 	destUUID := row["destination_uuid"]
-	fmt.Printf("consumer_group: dest=%v, cg='%v' [%v]\n", destUUID, cgPath, cgUUID)
+	fmt.Printf("dest=%v cg=%v ('%v')\n", destUUID, cgUUID, cgPath)
 }
 
 func (t *cmqWriterShort) Extent(row map[string]interface{}, annot string) {
 	destUUID := row["destination_uuid"]
 	extUUID := row["extent_uuid"]
-	fmt.Printf("extent: dest=%v, ext=%v\n", destUUID, extUUID)
+	fmt.Printf("dest=%v ext=%v\n", destUUID, extUUID)
 }
 
 func (t *cmqWriterShort) ConsumerGroupExtent(row map[string]interface{}, annot string) {
 	cgUUID := row["consumer_group_uuid"]
 	extUUID := row["extent_uuid"]
-	fmt.Printf("consumer_group_extent: cg=%v ext=%v\n", cgUUID, extUUID)
+	fmt.Printf("cg=%v ext=%v\n", cgUUID, extUUID)
 }
 
 func (t *cmqWriterShort) InputExtent(row map[string]interface{}, annot string) {

--- a/cmd/tools/cmq/out.go
+++ b/cmd/tools/cmq/out.go
@@ -269,7 +269,7 @@ func (t *cmqWriterShort) Destination(row map[string]interface{}, annot string) {
 func (t *cmqWriterShort) ConsumerGroup(row map[string]interface{}, annot string) {
 	cgUUID := row["uuid"]
 	cgPath := row["consumer_group"].(map[string]interface{})["name"]
-	destUUID := row["destination_uuid"]
+	destUUID := row["consumer_group"].(map[string]interface{})["destination_uuid"]
 	fmt.Printf("dest=%v cg=%v ('%v')\n", destUUID, cgUUID, cgPath)
 }
 

--- a/cmd/tools/cmq/show.go
+++ b/cmd/tools/cmq/show.go
@@ -17,6 +17,7 @@ func printRow(prefix string, row map[string]interface{}) {
 	sort.Strings(keys)
 
 	for _, k := range keys {
+
 		fmt.Printf("%s%v:", prefix, k)
 		switch row[k].(type) {
 		case map[string]interface{}:
@@ -47,18 +48,20 @@ func showDestinationByPath(c *cli.Context) error {
 	out := cmqOutputWriter(cliContext.StringSlice(`output`))
 	defer out.close()
 
-	path := c.Args()[0]
-	cql := fmt.Sprintf("SELECT * FROM destinations_by_path WHERE path='%v' ALLOW FILTERING", path)
+	for _, path := range c.Args() {
 
-	row, err := mc.QueryRow(cql)
+		cql := fmt.Sprintf("SELECT * FROM destinations_by_path WHERE path='%v' ALLOW FILTERING", path)
 
-	if err != nil {
-		fmt.Printf("showDestinationByPath: '%v': %v\n", cql, err)
-		return nil
+		row, err := mc.QueryRow(cql)
+
+		if err != nil {
+			fmt.Printf("showDestinationByPath: '%v': %v\n", cql, err)
+			return nil
+		}
+
+		fmt.Printf("destinations_by_path[%v]:\n", path)
+		printRow("\t", row)
 	}
-
-	fmt.Printf("destinations_by_path[%v]:\n", path)
-	printRow("\t", row)
 
 	return nil
 }
@@ -79,19 +82,21 @@ func showDestination(c *cli.Context) error {
 	out := cmqOutputWriter(cliContext.StringSlice(`output`))
 	defer out.close()
 
-	uuid := c.Args()[0]
-	cql := fmt.Sprintf("SELECT * FROM destinations WHERE uuid=%v", uuid)
+	for _, uuid := range c.Args() {
 
-	row, err := mc.QueryRow(cql)
+		cql := fmt.Sprintf("SELECT * FROM destinations WHERE uuid=%v", uuid)
 
-	if err != nil {
-		fmt.Printf("showDestination: '%v': %v\n", cql, err)
-		return nil
+		row, err := mc.QueryRow(cql)
+
+		if err != nil {
+			fmt.Printf("showDestination: '%v': %v\n", cql, err)
+			return nil
+		}
+
+		// fmt.Printf("destinations[%v]:\n", uuid)
+		// printRow("\t", row)
+		out.Destination(row, "")
 	}
-
-	// fmt.Printf("destinations[%v]:\n", uuid)
-	// printRow("\t", row)
-	out.Destination(row, "")
 
 	return nil
 }
@@ -112,19 +117,21 @@ func showConsumerGroup(c *cli.Context) error {
 	out := cmqOutputWriter(cliContext.StringSlice(`output`))
 	defer out.close()
 
-	uuid := c.Args()[0]
-	cql := fmt.Sprintf("SELECT * FROM consumer_groups WHERE uuid=%v", uuid)
+	for _, uuid := range c.Args() {
 
-	row, err := mc.QueryRow(cql)
+		cql := fmt.Sprintf("SELECT * FROM consumer_groups WHERE uuid=%v", uuid)
 
-	if err != nil {
-		fmt.Printf("showConsumerGroup: '%v': %v\n", cql, err)
-		return nil
+		row, err := mc.QueryRow(cql)
+
+		if err != nil {
+			fmt.Printf("showConsumerGroup: '%v': %v\n", cql, err)
+			return nil
+		}
+
+		// fmt.Printf("consumergroups[%v]:\n", uuid)
+		// printRow("\t", row)
+		out.ConsumerGroup(row, "")
 	}
-
-	// fmt.Printf("consumergroups[%v]:\n", uuid)
-	// printRow("\t", row)
-	out.ConsumerGroup(row, "")
 
 	return nil
 }
@@ -145,19 +152,21 @@ func showExtent(c *cli.Context) error {
 	out := cmqOutputWriter(cliContext.StringSlice(`output`))
 	defer out.close()
 
-	uuid := c.Args()[0]
-	cql := fmt.Sprintf("SELECT * FROM destination_extents WHERE extent_uuid=%v ALLOW FILTERING", uuid)
+	for _, uuid := range c.Args() {
 
-	row, err := mc.QueryRow(cql)
+		cql := fmt.Sprintf("SELECT * FROM destination_extents WHERE extent_uuid=%v ALLOW FILTERING", uuid)
 
-	if err != nil {
-		fmt.Printf("showExtent: '%v': %v\n", cql, err)
-		return nil
+		row, err := mc.QueryRow(cql)
+
+		if err != nil {
+			fmt.Printf("showExtent: '%v': %v\n", cql, err)
+			return nil
+		}
+
+		// fmt.Printf("destination_extents[%v]:\n", uuid)
+		// printRow("\t", row)
+		out.Extent(row, "")
 	}
-
-	// fmt.Printf("destination_extents[%v]:\n", uuid)
-	// printRow("\t", row)
-	out.Extent(row, "")
 
 	return nil
 }

--- a/cmd/tools/cmq/show.go
+++ b/cmd/tools/cmq/show.go
@@ -37,14 +37,14 @@ func showDestinationByPath(c *cli.Context) error {
 		return fmt.Errorf("destination path not specified")
 	}
 
-	mc, err := newMetadataClient(getOpts(cliContext))
+	mc, err := newMetadataClient()
 
 	if err != nil {
 		fmt.Errorf("newMetadataClient error: %v", err)
 		return nil
 	}
 
-	out := cmqOutputWriter(cliContext.StringSlice("output"))
+	out := cmqOutputWriter(cliContext.StringSlice(`output`))
 	defer out.close()
 
 	path := c.Args()[0]
@@ -69,14 +69,14 @@ func showDestination(c *cli.Context) error {
 		return fmt.Errorf("destination uuid not specified")
 	}
 
-	mc, err := newMetadataClient(getOpts(cliContext))
+	mc, err := newMetadataClient()
 
 	if err != nil {
 		fmt.Errorf("newMetadataClient error: %v", err)
 		return nil
 	}
 
-	out := cmqOutputWriter(cliContext.StringSlice("output"))
+	out := cmqOutputWriter(cliContext.StringSlice(`output`))
 	defer out.close()
 
 	uuid := c.Args()[0]
@@ -102,14 +102,14 @@ func showConsumerGroup(c *cli.Context) error {
 		return fmt.Errorf("consumer-group uuid not specified")
 	}
 
-	mc, err := newMetadataClient(getOpts(cliContext))
+	mc, err := newMetadataClient()
 
 	if err != nil {
 		fmt.Errorf("newMetadataClient error: %v", err)
 		return nil
 	}
 
-	out := cmqOutputWriter(cliContext.StringSlice("output"))
+	out := cmqOutputWriter(cliContext.StringSlice(`output`))
 	defer out.close()
 
 	uuid := c.Args()[0]
@@ -135,14 +135,14 @@ func showExtent(c *cli.Context) error {
 		return fmt.Errorf("extent uuid not specified")
 	}
 
-	mc, err := newMetadataClient(getOpts(cliContext))
+	mc, err := newMetadataClient()
 
 	if err != nil {
 		fmt.Errorf("newMetadataClient error: %v", err)
 		return nil
 	}
 
-	out := cmqOutputWriter(cliContext.StringSlice("output"))
+	out := cmqOutputWriter(cliContext.StringSlice(`output`))
 	defer out.close()
 
 	uuid := c.Args()[0]
@@ -167,14 +167,14 @@ func showCGExtent(c *cli.Context) error {
 	if c.NArg() < 2 {
 		return fmt.Errorf("cg/extent uuid not specified")
 	}
-	mc, err := newMetadataClient(getOpts(cliContext))
+	mc, err := newMetadataClient()
 
 	if err != nil {
 		fmt.Errorf("newMetadataClient error: %v", err)
 		return nil
 	}
 
-	out := cmqOutputWriter(cliContext.StringSlice("output"))
+	out := cmqOutputWriter(cliContext.StringSlice(`output`))
 	defer out.close()
 
 	cgUUID := c.Args()[0]

--- a/cmd/tools/cmq/util.go
+++ b/cmd/tools/cmq/util.go
@@ -91,7 +91,7 @@ func multiMatchWhereClause(column string, filters []string) (clause string) {
 	default: // > 1
 		for i, d := range filters {
 			if i == 0 {
-				clause = fmt.Sprintf("%s in ( ", column)
+				clause = fmt.Sprintf("%s IN ( ", column)
 			} else {
 				clause += ", "
 			}

--- a/cmd/tools/cmq/util.go
+++ b/cmd/tools/cmq/util.go
@@ -175,6 +175,10 @@ func getCGStatus(status string) int {
 		fallthrough
 	case "deleted":
 		return int(shared.ConsumerGroupStatus_DELETED)
+	case "3":
+		fallthrough
+	case "deleting":
+		return int(shared.ConsumerGroupStatus_DELETING)
 	default:
 		return -1
 	}

--- a/cmd/tools/cmq/watch.go
+++ b/cmd/tools/cmq/watch.go
@@ -60,6 +60,7 @@ func watch(c *cli.Context) error {
 		fmt.Printf(" replicate: %.1f msgs/sec [%d msgs]   \n", cgMon.rateReplicate, cgMon.deltaPublish)
 		fmt.Printf(" consume: %.1f msgs/sec [%d msgs]    \n", cgMon.rateConsume, cgMon.deltaConsume)
 		fmt.Printf(" backlog: %d    \n", cgMon.totalBacklog)
+		fmt.Printf("\n %v  \n", time.Now())
 
 		<-ticker.C // don't query more than once every two-seconds
 	}

--- a/cmd/tools/cmq/watch.go
+++ b/cmd/tools/cmq/watch.go
@@ -48,12 +48,10 @@ func watch(c *cli.Context) error {
 	ctrlc := make(chan os.Signal, 1)
 	signal.Notify(ctrlc, os.Interrupt, syscall.SIGTERM)
 
-	fmt.Printf("SaveScreen\n")
 	SaveScreen()
 
 	go func() {
 		<-ctrlc
-		fmt.Printf("RestoreScreen\n")
 		RestoreScreen()
 		os.Exit(1)
 	}()

--- a/cmd/tools/cmq/watch.go
+++ b/cmd/tools/cmq/watch.go
@@ -27,7 +27,7 @@ func watch(c *cli.Context) error {
 		return nil
 	}
 
-	mc, err := newMetadataClient(getOpts(cliContext))
+	mc, err := newMetadataClient()
 
 	if err != nil {
 		fmt.Errorf("newMetadataClient error: %v", err)


### PR DESCRIPTION
- added new top-level shortcut commands to list extents (x), list destinations (d), cg-extents (cgx), etc
- a new "cmq fix fixdestuuid" command that updates the (newly added) 'destination_uuid' column for each row of 'consumer_groups' table, with the 'consumer_group.destination_uuid' value.
- various minor fixes in 'cmq gc'
  - use "set" package instead of 'map[string]string'
  - removed redundant variables, maps, etc.
- enhanced the 'cmqWriter' interface to make it easier to do "json" output, etc
- implemented 'listStoreExtents' and 'listInputHostExtents' commands
- moved top-level metadata args handling to 'meta.go'
- the delete and undo writers (used by 'cmq gc') creates only one "_delete.cql" and "_undo.cql" each, instead of one per table
- added support to recognize 'status' by numeric values (0 -> open, etc)
- support routines for ANSI control sequences